### PR TITLE
Changing gulp-sass version dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-contrib-watch": "~0.5.3",
-    "grunt-sass": "~0.8.0"
+    "grunt-sass": "~1.1.0"
   },
   "dependencies": {
     "bower": "^1.4.1"


### PR DESCRIPTION
With up-to-date versions of `node` and `npm`, the version of `gulp-sass` required by `package.json` causes serious installation problems.

This bumps up the version to the newest one, which fixes the issue (allowing `npm install` and `grunt sass` to go through).
