### PR TITLE
Task aborted if missing repayment config

### DIFF
--- a/revolv/tasks/reinvestment_allocation.py
+++ b/revolv/tasks/reinvestment_allocation.py
@@ -39,7 +39,7 @@ def calculate_montly_reinvesment_allocation():
             repayment_config = project.projectmontlyrepaymentconfig_set\
                 .get(year=date.today().year, repayment_type=ProjectMontlyRepaymentConfig.SOLAR_SEED_FUND)
         except ProjectMontlyRepaymentConfig.DoesNotExist:
-            logger.error("Project {0} - {%} doesn't have repayment config!".format(project.id, project.title))
+            logger.error("Project %s - %s doesn't have repayment config!", project.id, project.title)
             continue
 
         AdminRepayment.objects.create(amount=repayment_config.amount,

--- a/revolv/tasks/reinvestment_allocation.py
+++ b/revolv/tasks/reinvestment_allocation.py
@@ -40,6 +40,7 @@ def calculate_montly_reinvesment_allocation():
                 .get(year=date.today().year, repayment_type=ProjectMontlyRepaymentConfig.SOLAR_SEED_FUND)
         except ProjectMontlyRepaymentConfig.DoesNotExist:
             logger.error("Project {0} - {%} doesn't have repayment config!".format(project.id, project.title))
+            continue
 
         AdminRepayment.objects.create(amount=repayment_config.amount,
                                       project=project,


### PR DESCRIPTION
Skip over processing of ProjectMontlyRepaymentConfig if not configured for project

Fix KeyError while logging error for project without repayment config, and use smarter log message formatting
