### PR TITLE
Removing flex layout from body

### DIFF
--- a/revolv/static/css/screen.css
+++ b/revolv/static/css/screen.css
@@ -95,16 +95,6 @@ html {
 /* common style */
 body {
 	background: #fff;
-	display: -webkit-box;
-	display: -webkit-flex;
-	display: -ms-flexbox;
-	display: flex;
-	min-height: 100vh;
-	-webkit-box-orient: vertical;
-	-webkit-box-direction: normal;
-	-webkit-flex-direction: column;
-	    -ms-flex-direction: column;
-	        flex-direction: column;
 }
 input,
 button {


### PR DESCRIPTION
Indiscriminately using `display: flex` on the `body` element was causing layout issues in non-content pages.

This leaves the flexbox layout in `cms-page.scss` but removes it from `body` elsewhere. The result is a footer that doesn't stick to the bottom of the page, but also an elimination of those pesky layout errors.
