### PR TITLE
Reimplementing h1 header on Create Project page

### DIFF
--- a/revolv/static/css/screen.css
+++ b/revolv/static/css/screen.css
@@ -1269,11 +1269,21 @@ a:focus {
 
 
 /* .contents */
+header.edit-project-header {
+	text-align: center;
+}
+	header.edit-project-header > .container > h1 {
+		display: inline-block;
+		color: #11ADE5;
+		font-size: 2rem;
+		text-align: center;
+		line-height: 75px;
+	}
 .edit-project .header-container {
     height: 0;
 }
 .edit-project .form-section {
-    margin-top: 40px;
+    margin-top: 20px;
 }
 .contents {
 	min-height: 450px;

--- a/revolv/templates/base/partials/nav.html
+++ b/revolv/templates/base/partials/nav.html
@@ -5,11 +5,12 @@
 {% endcomment %}
 {% load staticfiles revolv_cms_tags %}
 
-<header class="header after-scroll-header">
+<header class="header after-scroll-header {% block "header-classes" %}{% endblock "header-classes" %}">
   <div class="container">
     <div class="lefts pull-left">
       <a href="/" class="logo"></a>
     </div>
+    {% block "extra-header" %}{% endblock %}
     <!-- end .logo -->
     <div class="rights pull-right">
       <div class="txt pull-left">

--- a/revolv/templates/base/partials/project-nav.html
+++ b/revolv/templates/base/partials/project-nav.html
@@ -1,0 +1,11 @@
+{% extends "base/partials/nav.html" %}
+
+{% block "header-classes" %}edit-project-header{% endblock "header-classes" %}
+
+{% block "extra-header" %}
+  {% if project.id %}
+    <h1>Edit Project</h1>
+  {% else %}
+    <h1>Create Project</h1>
+  {% endif %}
+{% endblock %}

--- a/revolv/templates/project/edit_project.html
+++ b/revolv/templates/project/edit_project.html
@@ -14,110 +14,103 @@
 
 {% endblock %}
 
-{% block title %}Edit Project | {% endblock %}
+{% block title %}{% if project.id %}Edit{% else %}Create{% endif %} Project | {% endblock %}
+
+{% block nav %}
+  {% include "base/partials/project-nav.html" %}
+{% endblock %}
 
 {% block body %}
-<div class="contents top100 edit-project"> 
-  <div class="container"> 
+<div class="contents top100 edit-project">
+  <div class="container">
+    <div class="row form-section">
+        <div class="large-12 columns">
+            <form method="POST" enctype="multipart/form-data" id="project_form">
+                  {% csrf_token %}
+                  {{ form.media }}
+                  {% for error in form.non_field_errors %}
+                <div data-alert class="alert-box alert">
+                    {{ error }}
+                    <a href="#" class="close">&times;</a>
+                  </div>
+                {% endfor %}
 
-<div class='row header-container'>
-    <div class='medium-4 columns'>
-        {% if project.id %}
-        <h1 class="header">Edit Project</h1>
-        {% else %}
-        <h1 class="header">Create Project</h1>
-        {% endif %}
-    </div>
-</div>
-<div class="row form-section">
-    <div class="large-12 columns">
-        <form method="POST" enctype="multipart/form-data" id="project_form">
-              {% csrf_token %}
-              {{ form.media }}
-              {% for error in form.non_field_errors %}
-            <div data-alert class="alert-box alert">
-                {{ error }}
-                <a href="#" class="close">&times;</a>
-              </div>
-            {% endfor %}
+                <div class="row project-overview section">
+                    <p class="section-title">Project Overview</p>
+                    <div class="medium-6 small-12 columns">
+                        {% include "base/partials/tooltip_formfield.html" with field=form.title %}
+                        {% include "base/partials/tooltip_formfield.html" with field=form.tagline %}
+                        <span>Categories</span>
+                        {{ form.categories_select|add_class:"chosen-select" }}
+                        {% for error in form.categories_select.errors %}
+                            <small class="error">{{ error }}</small>
+                        {% endfor %}
+                    </div>
 
-            <div class="row project-overview section">
-                <p class="section-title">Project Overview</p>
-                <div class="medium-6 small-12 columns">
-                    {% include "base/partials/tooltip_formfield.html" with field=form.title %}
-                    {% include "base/partials/tooltip_formfield.html" with field=form.tagline %}
-                    <span>Categories</span>
-                    {{ form.categories_select|add_class:"chosen-select" }}
-                    {% for error in form.categories_select.errors %}
-                        <small class="error">{{ error }}</small>
+                    <div class="medium-6 small-12 columns">
+                        {% include "base/partials/tooltip_formfield.html" with field=form.funding_goal %}
+                        {% include "base/partials/tooltip_formfield.html" with field=form.impact_power %}
+                        {% include "base/partials/tooltip_formfield.html" with field=form.end_date %}
+                    </div>
+
+                    <div class="medium-12 small-12 columns">
+                        {% include "base/partials/tooltip_formfield.html" with field=form.video_url %}
+                        {% include "base/partials/tooltip_formfield.html" with field=form.cover_photo %}
+                        {% include "base/partials/tooltip_formfield.html" with field=form.description %}
+                    </div>
+                </div>
+
+                <div class="row donation-levels section">
+                    <p class="section-title donation-level-container">Donation Levels</p>
+                    {{ donation_level_formset.management_form }}
+                    <script type="text/javascript">
+                        window.DONATION_LEVEL_COUNT = {{ donation_level_formset|length }};
+                        window.EXTRA = 1;
+                    </script>
+                    {% for donation_level_form in donation_level_formset %}
+                        <div class="donation-level-box donation-level-{{ forloop.counter0 }}">
+                            <div class="small-4 columns">
+                                {% include "base/partials/tooltip_formfield.html" with field=donation_level_form.amount %}
+                                {% include "base/partials/tooltip_formfield.html" with field=donation_level_form.DELETE %}
+                            </div>
+                            <div class="small-8 columns">
+                                {% include "base/partials/tooltip_formfield.html" with field=donation_level_form.description %}
+                            </div>
+                            {% for hidden in donation_level_form.hidden_fields %}
+                                {{ hidden }}
+                            {% endfor %}
+                        </div>
                     {% endfor %}
                 </div>
 
-                <div class="medium-6 small-12 columns">
-                    {% include "base/partials/tooltip_formfield.html" with field=form.funding_goal %}
-                    {% include "base/partials/tooltip_formfield.html" with field=form.impact_power %}
-                    {% include "base/partials/tooltip_formfield.html" with field=form.end_date %}
-                </div>
-                
-                <div class="medium-12 small-12 columns">
-                    {% include "base/partials/tooltip_formfield.html" with field=form.video_url %}
-                    {% include "base/partials/tooltip_formfield.html" with field=form.cover_photo %}
-                    {% include "base/partials/tooltip_formfield.html" with field=form.description %}
-                </div>
-            </div>
+                <!-- THIS DOES NOT EXIST -->
+                <!-- <div class="row add-button">Add a new donation level</div> -->
 
-            <div class="row donation-levels section">
-                <p class="section-title donation-level-container">Donation Levels</p>
-                {{ donation_level_formset.management_form }}
-                <script type="text/javascript">
-                    window.DONATION_LEVEL_COUNT = {{ donation_level_formset|length }};
-                    window.EXTRA = 1;
-                </script>
-                {% for donation_level_form in donation_level_formset %}
-                    <div class="donation-level-box donation-level-{{ forloop.counter0 }}">
-                        <div class="small-4 columns">
-                            {% include "base/partials/tooltip_formfield.html" with field=donation_level_form.amount %}
-                            {% include "base/partials/tooltip_formfield.html" with field=donation_level_form.DELETE %}
-                        </div>
-                        <div class="small-8 columns">
-                            {% include "base/partials/tooltip_formfield.html" with field=donation_level_form.description %}
-                        </div>
-                        {% for hidden in donation_level_form.hidden_fields %}
-                            {{ hidden }}
-                        {% endfor %}
+                <div class="row organization-overview section">
+                    <p class="section-title">Organization Overview</p>
+                    <div class="medium-12 small-12 columns">
+                        {% include "base/partials/tooltip_formfield.html" with field=form.org_name %}
                     </div>
-                {% endfor %}
-            </div>
-
-            <!-- THIS DOES NOT EXIST -->
-            <!-- <div class="row add-button">Add a new donation level</div> -->
-
-            <div class="row organization-overview section">
-                <p class="section-title">Organization Overview</p>
-                <div class="medium-12 small-12 columns">
-                    {% include "base/partials/tooltip_formfield.html" with field=form.org_name %}
+                    <div class="medium-6 small-12 columns">
+                        {% include "base/partials/tooltip_formfield.html" with field=form.org_start_date %}
+                    </div>
+                    <div class="medium-6 small-12 columns">
+                        {% include "base/partials/tooltip_formfield.html" with field=form.people_affected %}                </div>
+                    <div class="medium-12 small-12 columns">
+                        {% include "base/partials/tooltip_formfield.html" with field=form.location %}
+                        <div id="map-canvas"></div>
+                        {% include "base/partials/tooltip_formfield.html" with field=form.org_about %}
+                    </div>
                 </div>
-                <div class="medium-6 small-12 columns">
-                    {% include "base/partials/tooltip_formfield.html" with field=form.org_start_date %}
+                <div class="hide">
+                    {% include "base/partials/tooltip_formfield.html" with field=form.location_latitude %}
+                    {% include "base/partials/tooltip_formfield.html" with field=form.location_longitude %}
+                    {% include "base/partials/tooltip_formfield.html" with field=form.extra %}
                 </div>
-                <div class="medium-6 small-12 columns">
-                    {% include "base/partials/tooltip_formfield.html" with field=form.people_affected %}                </div>
-                <div class="medium-12 small-12 columns">
-                    {% include "base/partials/tooltip_formfield.html" with field=form.location %}
-                    <div id="map-canvas"></div>
-                    {% include "base/partials/tooltip_formfield.html" with field=form.org_about %}
-                </div>
-            </div>
-            <div class="hide">
-                {% include "base/partials/tooltip_formfield.html" with field=form.location_latitude %}
-                {% include "base/partials/tooltip_formfield.html" with field=form.location_longitude %}
-                {% include "base/partials/tooltip_formfield.html" with field=form.extra %}
-            </div>
-            <button class="large right save-button" id="save_project" type="submit">Save</button>
-        </form>
+                <button class="large right save-button" id="save_project" type="submit">Save</button>
+            </form>
+        </div>
     </div>
-</div>
-
   </div>
 </div>
 


### PR DESCRIPTION
The weird thing where the `h1` element with the page's title was supposed to be floated over the header … let's not do that. Instead this simply places the `h1` inside the header.

This is accomplished by creating a new override block inside the `nav.html` template (or rather, `project-nav.html`, which extends it) that lets you inject stuff into the header as you wish.

The result should be a consistently centered title "Create Project" (or "Edit Project", as appropriate) within the header. It is not responsive, but neither was the original version.

A lot of the changes to `edit-project.html` are garbage, caused by me fixing the incorrect indentation of the file. The real changes consist of removing the `header-container` element and pushing its contents into `project-nav.html`, where the overrides take place.
