### PR TITLE
Changing indent and line break style on screen.css

### DIFF
--- a/revolv/static/css/screen.css
+++ b/revolv/static/css/screen.css
@@ -1,11120 +1,10693 @@
 /* Reset HTML5
 */
-html,
-body,
-div,
-span,
-applet,
-object,
-iframe,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-blockquote,
-pre,
-a,
-abbr,
-acronym,
-address,
-big,
-cite,
-code,
-del,
-dfn,
-em,
-img,
-ins,
-kbd,
-q,
-s,
-samp,
-small,
-strike,
-strong,
-sub,
-sup,
-tt,
-var,
-b,
-u,
-i,
-center,
-dl,
-dt,
-dd,
-ol,
-ul,
-li,
-fieldset,
-form,
-label,
-legend,
-table,
-caption,
-tbody,
-tfoot,
-thead,
-tr,
-th,
-td,
-article,
-aside,
-canvas,
-details,
-embed,
-figure,
-figcaption,
-footer,
-header,
-hgroup,
-menu,
-nav,
-output,
-ruby,
-section,
-summary,
-time,
-mark,
-audio,
-video {
-	font-family: 'Source Sans Pro', Arial, Helvetica, sans-serif;
-	margin: 0;
-	padding: 0;
-	list-style: none;
+
+html, body, div, span, applet, object, iframe, h1, h2, h3, h4, h5, h6, p, blockquote, pre, a, abbr, acronym, address, big, cite, code, del, dfn, em, img, ins, kbd, q, s, samp, small, strike, strong, sub, sup, tt, var, b, u, i, center, dl, dt, dd, ol, ul, li, fieldset, form, label, legend, table, caption, tbody, tfoot, thead, tr, th, td, article, aside, canvas, details, embed, figure, figcaption, footer, header, hgroup, menu, nav, output, ruby, section, summary, time, mark, audio, video {
+  font-family: 'Source Sans Pro', Arial, Helvetica, sans-serif;
+  margin: 0;
+  padding: 0;
+  list-style: none;
 }
 html {
-	min-height: 100%;
+  min-height: 100%;
 }
-
-
 
 /* common style */
+
 body {
-	background: #fff;
+  background: #fff;
 }
-input,
-button {
-	border-radius: 0;
+input, button {
+  border-radius: 0;
 }
-a,
-a:focus {
-	text-decoration: none;
-	outline: none;
+a, a:focus {
+  text-decoration: none;
+  outline: none;
 }
-	a:hover {
-		text-decoration: underline;
-	}
+a:hover {
+  text-decoration: underline;
+}
 .icons {
-	background: url(../images/icon-sprites.png) no-repeat;
-	display: inline-block;
+  background: url(../images/icon-sprites.png) no-repeat;
+  display: inline-block;
 }
-
-
 
 /* btn */
-.btn-blue {
-	font-family: 'Source Sans Pro';
-    font-weight: 900;
-	font-size: 14px;
-	color: #fff;
-	height: 53px;
-	line-height: 53px;
-	padding: 0 10px;
-	text-align: center;
-	display: inline-block;
-}
-	.btn-blue:hover,
-	.btn-blue:focus {
-		text-decoration: none;
-		color: #fff;
-	}
-		.btn-blue {
-			background-color: #14b1e7;
-		}
-			.btn-blue:hover,
-			.btn-blue:focus {
-				background-color: #2c3691;
-			}
-.btn-icon-gray {
-	text-align: center;
-	background: rgba(40,40,40,0.15);
-	width: 53px;
-	height: 43px;
-	border: 2px solid #fff;
-	display: inline-block;
-}
-	.btn-icon-gray .icons {
-		width: 24px;
-		height: 24px;
-		margin-top: 7px;
-	}
-		.btn-icon-gray .icon-fb {
-			background-position: -144px -16px;
-		}
-			.btn-icon-gray:hover .icon-fb {
-				background-position: -168px -16px;
-			}
-		.btn-icon-gray .icon-tw {
-			background-position: -192px -16px;
-		}
-			.btn-icon-gray:hover .icon-tw {
-				background-position: -216px -16px;
-			}
-		.btn-icon-gray .icon-gg {
-			background-position: -240px -16px;
-		}
-			.btn-icon-gray:hover .icon-gg {
-				background-position: -264px -16px;
-			}
 
+.btn-blue {
+  font-family: 'Source Sans Pro';
+  font-weight: 900;
+  font-size: 14px;
+  color: #fff;
+  height: 53px;
+  line-height: 53px;
+  padding: 0 10px;
+  text-align: center;
+  display: inline-block;
+}
+.btn-blue:hover, .btn-blue:focus {
+  text-decoration: none;
+  color: #fff;
+}
+.btn-blue {
+  background-color: #14b1e7;
+}
+.btn-blue:hover, .btn-blue:focus {
+  background-color: #2c3691;
+}
+.btn-icon-gray {
+  text-align: center;
+  background: rgba(40, 40, 40, 0.15);
+  width: 53px;
+  height: 43px;
+  border: 2px solid #fff;
+  display: inline-block;
+}
+.btn-icon-gray .icons {
+  width: 24px;
+  height: 24px;
+  margin-top: 7px;
+}
+.btn-icon-gray .icon-fb {
+  background-position: -144px -16px;
+}
+.btn-icon-gray:hover .icon-fb {
+  background-position: -168px -16px;
+}
+.btn-icon-gray .icon-tw {
+  background-position: -192px -16px;
+}
+.btn-icon-gray:hover .icon-tw {
+  background-position: -216px -16px;
+}
+.btn-icon-gray .icon-gg {
+  background-position: -240px -16px;
+}
+.btn-icon-gray:hover .icon-gg {
+  background-position: -264px -16px;
+}
 
 /* title */
-.title-white-border,
-.title-blue-border {
-	font-family: 'Source Sans Pro';
-    font-weight: 700;
-	font-size: 18px;
-	letter-spacing: 8px;
-	height: 43px;
-	line-height: 41px;
-	padding: 0 10px;
-	text-align: center;
-	display: inline-block;
+
+.title-white-border, .title-blue-border {
+  font-family: 'Source Sans Pro';
+  font-weight: 700;
+  font-size: 18px;
+  letter-spacing: 8px;
+  height: 43px;
+  line-height: 41px;
+  padding: 0 10px;
+  text-align: center;
+  display: inline-block;
 }
 .title-white-border {
-	color: #fff;
-	border: 2px solid #fff;
+  color: #fff;
+  border: 2px solid #fff;
 }
 .title-blue-border {
-	color: #14b1e7;
-	border: 2px solid #14b1e7;
+  color: #14b1e7;
+  border: 2px solid #14b1e7;
 }
-
-
 
 /* .dropdown-default */
+
 .dropdown-default {
-	text-transform: uppercase;
+  text-transform: uppercase;
 }
-	.dropdown-default .btn-default {
-		font-size: 12px;
-		font-weight: normal;
-		color: #9d9d9d;
-		text-align: left;
-		background: #f0f0f0;
-		letter-spacing: 6px;
-		text-shadow: none;
-		background-image: none;
-		filter: none;
-		border: 2px solid #fff;
-		box-shadow: none;
-		border-radius: 0;
-		padding: 0 28px 0 23px;
-		height: 36px;
-		line-height: 33px;
-		position: relative;
-	}
-		.dropdown-default .btn-default .icon-arrow-down {
-			background-position: -48px 0;
-			width: 16px;
-			height: 16px;
-			position: absolute;
-			top: 8px;
-			right: 9px;
-			z-index: 9;
-		}
-		.dropdown-default .btn-default.active,
-		.dropdown-default .btn-default:active,
-		.open.dropdown-default>.dropdown-toggle.btn-default {
-			color: #9d9d9d;
-			background-color: #f0f0f0;
-			border: 2px solid #fff;
-		}
-		.dropdown-default .selected-option {
-			overflow:hidden;
-		    text-overflow:ellipsis;
-			white-space:nowrap;
-			display: block;
-		}
-
-		.dropdown-default .dropdown-menu {
-			font-size: 12px;
-			min-width: 60px;
-			padding: 5px 0;
-			margin: 0;
-			width: 100%;
-			background: rgba(240,240,240,0.75);
-			border: 2px solid rgba(255,255,255,0.75);
-			border-radius: 0;
-			-webkit-box-shadow: 0 3px 5px rgba(34,34,33,0.19);
-			box-shadow: 0 3px 5px rgba(34,34,33,0.19);
-		}
-			.dropdown-default .dropdown-menu>li>a {
-				font-weight: normal;
-				color: #4b4b4b;
-				padding: 0 25px;
-				line-height: 24px;
-			}
-			.dropdown-default .dropdown-menu>li>a:hover,
-			.dropdown-default .dropdown-menu>li>a:active,
-			.dropdown-default .dropdown-menu>li>a:focus,
-			.dropdown-default .dropdown-menu>li>a.active {
-				font-family: 'Source Sans Pro';
-                font-weight: 700;
-				background: #f0f0f0;
-				background-image: none;
-				filter: none;
-			}
-
-
-
+.dropdown-default .btn-default {
+  font-size: 12px;
+  font-weight: normal;
+  color: #9d9d9d;
+  text-align: left;
+  background: #f0f0f0;
+  letter-spacing: 6px;
+  text-shadow: none;
+  background-image: none;
+  filter: none;
+  border: 2px solid #fff;
+  box-shadow: none;
+  border-radius: 0;
+  padding: 0 28px 0 23px;
+  height: 36px;
+  line-height: 33px;
+  position: relative;
+}
+.dropdown-default .btn-default .icon-arrow-down {
+  background-position: -48px 0;
+  width: 16px;
+  height: 16px;
+  position: absolute;
+  top: 8px;
+  right: 9px;
+  z-index: 9;
+}
+.dropdown-default .btn-default.active, .dropdown-default .btn-default:active, .open.dropdown-default>.dropdown-toggle.btn-default {
+  color: #9d9d9d;
+  background-color: #f0f0f0;
+  border: 2px solid #fff;
+}
+.dropdown-default .selected-option {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: block;
+}
+.dropdown-default .dropdown-menu {
+  font-size: 12px;
+  min-width: 60px;
+  padding: 5px 0;
+  margin: 0;
+  width: 100%;
+  background: rgba(240, 240, 240, 0.75);
+  border: 2px solid rgba(255, 255, 255, 0.75);
+  border-radius: 0;
+  -webkit-box-shadow: 0 3px 5px rgba(34, 34, 33, 0.19);
+  box-shadow: 0 3px 5px rgba(34, 34, 33, 0.19);
+}
+.dropdown-default .dropdown-menu>li>a {
+  font-weight: normal;
+  color: #4b4b4b;
+  padding: 0 25px;
+  line-height: 24px;
+}
+.dropdown-default .dropdown-menu>li>a:hover, .dropdown-default .dropdown-menu>li>a:active, .dropdown-default .dropdown-menu>li>a:focus, .dropdown-default .dropdown-menu>li>a.active {
+  font-family: 'Source Sans Pro';
+  font-weight: 700;
+  background: #f0f0f0;
+  background-image: none;
+  filter: none;
+}
 
 /* .header */
+
 .header {
-	margin-top: 30px;
-	width: 100%;
-	height: 102px;
-	position: fixed;
-	top: 0;
-	left: 0;
-	z-index: 1019;
+  margin-top: 30px;
+  width: 100%;
+  height: 102px;
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 1019;
 }
-	.header .container {
-		height: 100%;
-		padding: 0;
-	}
-		.header .logo {
-			background: url(../images/logo-white.png);
-			margin: 17px 0 0 85px;
-			width: 171px;
-			height: 68px;
-			display: block;
-		}
-		.header .btn-donate {
-			min-width: 132px;
-		}
-		.header .rights {
-			padding: 24px 84px 0 0;
-		}
-			.header .txt {
-				font-size: 14px;
-				color: #fff;
-				padding: 2px 14px 3px 0;
-				line-height: 26px;
-			}
-				.header .txt .block {
-					text-align: right;
-					display: block;
-				}
-					.header .txt a {
-						color: #fff;
-						text-decoration: underline;
-					}
-					.header .txt a:hover,
-					.header .txt a:focus {
-						color: #14b1e7;
-					}
-	/* .after-scroll-header */
-	.header.after-scroll-header {
-		background: #fff;
-		border-bottom: 1px solid #32221e;
-		margin: 0;
-	}
-		.header.after-scroll-header .logo {
-			background: url(../images/logo.png);
-		}
-			.header.after-scroll-header .txt {
-				color: #4b4b4b;
-			}
-				.header.after-scroll-header .txt a {
-					color: #4b4b4b;
-				}
-				.header.after-scroll-header .txt a:hover,
-				.header.after-scroll-header .txt a:focus {
-					color: #14b1e7;
-				}
-	/* .top-section-header */
-	.header.top-section-header {
-		position: absolute;
-	}
-    .home-page-content .header {
-        margin-top: 5px;
-    }
-    .home-page-content .header.after-scroll-header {
-        margin-top: inherit;
-    }
+.header .container {
+  height: 100%;
+  padding: 0;
+}
+.header .logo {
+  background: url(../images/logo-white.png);
+  margin: 17px 0 0 85px;
+  width: 171px;
+  height: 68px;
+  display: block;
+}
+.header .btn-donate {
+  min-width: 132px;
+}
+.header .rights {
+  padding: 24px 84px 0 0;
+}
+.header .txt {
+  font-size: 14px;
+  color: #fff;
+  padding: 2px 14px 3px 0;
+  line-height: 26px;
+}
+.header .txt .block {
+  text-align: right;
+  display: block;
+}
+.header .txt a {
+  color: #fff;
+  text-decoration: underline;
+}
+.header .txt a:hover, .header .txt a:focus {
+  color: #14b1e7;
+}
 
+/* .after-scroll-header */
 
+.header.after-scroll-header {
+  background: #fff;
+  border-bottom: 1px solid #32221e;
+  margin: 0;
+}
+.header.after-scroll-header .logo {
+  background: url(../images/logo.png);
+}
+.header.after-scroll-header .txt {
+  color: #4b4b4b;
+}
+.header.after-scroll-header .txt a {
+  color: #4b4b4b;
+}
+.header.after-scroll-header .txt a:hover, .header.after-scroll-header .txt a:focus {
+  color: #14b1e7;
+}
+
+/* .top-section-header */
+
+.header.top-section-header {
+  position: absolute;
+}
+.home-page-content .header {
+  margin-top: 5px;
+}
+.home-page-content .header.after-scroll-header {
+  margin-top: inherit;
+}
 
 /* .top-section */
+
 .top-section {
-	background-color: #000;
-	width: 100%;
-	min-height: 150px;
-	position: relative;
+  background-color: #000;
+  width: 100%;
+  min-height: 150px;
+  position: relative;
 }
 .top-section.fixed {
-	position: fixed;
-	top: 0;
-	left: 0;
-	z-index: 1009;
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 1009;
 }
-	.top-section .section-bg,
-	.top-section .sub-section-bg {
-		width: 100%;
-		height: 100%;
-		opacity: 0.65;
-		position: absolute;
-		top: 0;
-		left: 0;
-		z-index: 9;
-	}
-		.top-section .sub-section-bg {
-			background: url(../images/sub-section-bg.jpg) no-repeat center top;
-			background-size: 100% 150px;
-		}
-		.top-section.min-height {
-            overflow: hidden;
-            height: 880px;
-		}
-			.top-section .section-video .video-opacity {
-				background: rgba(0,0,0,0.35);
-				position: absolute;
-				top: 0;
-				left: 0;
-				width: 100%;
-				height: 100%;
-			}
-			.top-section .section-video img {
-				width: 100%;
-				height: 993px;
-			}
-			.top-section .section-video-area iframe,
-			.top-section .section-video-area video,
-			.top-section .section-video-area .mejs-container,
-			.top-section .section-video-area .me-plugin,
-			.top-section .section-video-area embed,
-			.top-section .section-video-area .mejs-overlay-play {
-				width: 100%!important;
-				height: 993px!important;
-				border: none;
-			}
-			.top-section .section-video-area .mejs-container .mejs-controls {
-				display: none !important;
-			}
-			.top-section .section-video-area .mejs-container .mejs-overlay-button {
-				display: none !important;
-			}
-	.top-section.min-height .container {
-		color: #fff;
-		text-align: center;
-		position: absolute;
-		z-index: 999;
-		top: 150px;
-		left: 50%;
-		margin-left: -600px;
-		padding: 0;
-	}
-	/* .top-section .carousel */
-	.top-section .carousel {
-		padding-right: 80px;
-		padding-left: 80px;
-	}
-		/* .top-section .carousel .item */
-		.top-section .carousel .item {
-			padding: 155px 0 0 0;
-			min-height: 788px;
-		}
-			.top-section .carousel .item-info {
-				width: 580px;
-				margin: 0 auto;
-			}
-				.top-section .carousel .item-info .titles {
-					font-family: 'Source Sans Pro';
-                    font-weight: 900;
-					font-size: 48px;
-					text-transform: uppercase;
-					line-height: 58px;
-				}
-					.top-section .carousel .item-info i {
-						display: block;
-					}
-				.top-section .carousel .item-info p {
-					font-size: 20px;
-					line-height: 36px;
-					width: 480px;
-					margin: 0 auto;
-					padding: 5px 0 32px 0;
-				}
-				.top-section .carousel .item-info .btn-donate-now {
-					letter-spacing: 4.5px;
-					min-width: 172px;
-					padding-left: 15px;
-				}
-		/* .top-section .carousel-indicators */
-		.top-section .carousel-indicators li {
-			border-radius: 0;
-			background-color: rgba(255,255,255,0.3);
-			border: none;
-			width: 12px;
-			height: 12px;
-			margin: 0 3px 0 2px;
-		}
-		.top-section .carousel-indicators .active {
-			border-radius: 0;
-			background-color: rgba(255,255,255,1);
-			border: none;
-		}
-			.top-section .icon-arrow-down {
-				background-position: -240px -40px;
-				position: absolute;
-				width: 48px;
-				height: 48px;
-				bottom: -40px;
-				left: 50%;
-				margin: 0 0 0 -24px;
-			}
-			.top-section .carousel-control.left,
-			.top-section .carousel-control.right {
-				background-color: rgba(255,255,255,0.15);
-				text-shadow: none;
-				background-image: none;
-				box-shadow: none;
-				opacity: 1;
-				width: 49px;
-				height: 47px;
-				border: 2px solid #fff;
-				top: 303px;
-			}
-				.top-section .carousel-control.left {
-					left: 16px;
-				}
-				.top-section .carousel-control.right {
-					right: 16px;
-				}
-					.top-section .carousel-control.left .icons,
-					.top-section .carousel-control.right .icons {
-						width: 24px;
-						height: 24px;
-						margin-top: 9px;
-					}
-						.top-section .carousel-control.left .icons {
-							background-position: -312px -16px;
-						}
-							.top-section .carousel-control:hover.left .icons {
-								background-position: -336px -16px;
-							}
-						.top-section .carousel-control.right .icons {
-							background-position: -408px -16px;
-						}
-							.top-section .carousel-control:hover.right .icons {
-								background-position: -385px -16px;
-							}
+.top-section .section-bg, .top-section .sub-section-bg {
+  width: 100%;
+  height: 100%;
+  opacity: 0.65;
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 9;
+}
+.top-section .sub-section-bg {
+  background: url(../images/sub-section-bg.jpg) no-repeat center top;
+  background-size: 100% 150px;
+}
+.top-section.min-height {
+  overflow: hidden;
+  height: 880px;
+}
+.top-section .section-video .video-opacity {
+  background: rgba(0, 0, 0, 0.35);
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+.top-section .section-video img {
+  width: 100%;
+  height: 993px;
+}
+.top-section .section-video-area iframe, .top-section .section-video-area video, .top-section .section-video-area .mejs-container, .top-section .section-video-area .me-plugin, .top-section .section-video-area embed, .top-section .section-video-area .mejs-overlay-play {
+  width: 100%!important;
+  height: 993px!important;
+  border: none;
+}
+.top-section .section-video-area .mejs-container .mejs-controls {
+  display: none !important;
+}
+.top-section .section-video-area .mejs-container .mejs-overlay-button {
+  display: none !important;
+}
+.top-section.min-height .container {
+  color: #fff;
+  text-align: center;
+  position: absolute;
+  z-index: 999;
+  top: 150px;
+  left: 50%;
+  margin-left: -600px;
+  padding: 0;
+}
 
+/* .top-section .carousel */
 
+.top-section .carousel {
+  padding-right: 80px;
+  padding-left: 80px;
+}
+
+/* .top-section .carousel .item */
+
+.top-section .carousel .item {
+  padding: 155px 0 0 0;
+  min-height: 788px;
+}
+.top-section .carousel .item-info {
+  width: 580px;
+  margin: 0 auto;
+}
+.top-section .carousel .item-info .titles {
+  font-family: 'Source Sans Pro';
+  font-weight: 900;
+  font-size: 48px;
+  text-transform: uppercase;
+  line-height: 58px;
+}
+.top-section .carousel .item-info i {
+  display: block;
+}
+.top-section .carousel .item-info p {
+  font-size: 20px;
+  line-height: 36px;
+  width: 480px;
+  margin: 0 auto;
+  padding: 5px 0 32px 0;
+}
+.top-section .carousel .item-info .btn-donate-now {
+  letter-spacing: 4.5px;
+  min-width: 172px;
+  padding-left: 15px;
+}
+
+/* .top-section .carousel-indicators */
+
+.top-section .carousel-indicators li {
+  border-radius: 0;
+  background-color: rgba(255, 255, 255, 0.3);
+  border: none;
+  width: 12px;
+  height: 12px;
+  margin: 0 3px 0 2px;
+}
+.top-section .carousel-indicators .active {
+  border-radius: 0;
+  background-color: rgba(255, 255, 255, 1);
+  border: none;
+}
+.top-section .icon-arrow-down {
+  background-position: -240px -40px;
+  position: absolute;
+  width: 48px;
+  height: 48px;
+  bottom: -40px;
+  left: 50%;
+  margin: 0 0 0 -24px;
+}
+.top-section .carousel-control.left, .top-section .carousel-control.right {
+  background-color: rgba(255, 255, 255, 0.15);
+  text-shadow: none;
+  background-image: none;
+  box-shadow: none;
+  opacity: 1;
+  width: 49px;
+  height: 47px;
+  border: 2px solid #fff;
+  top: 303px;
+}
+.top-section .carousel-control.left {
+  left: 16px;
+}
+.top-section .carousel-control.right {
+  right: 16px;
+}
+.top-section .carousel-control.left .icons, .top-section .carousel-control.right .icons {
+  width: 24px;
+  height: 24px;
+  margin-top: 9px;
+}
+.top-section .carousel-control.left .icons {
+  background-position: -312px -16px;
+}
+.top-section .carousel-control:hover.left .icons {
+  background-position: -336px -16px;
+}
+.top-section .carousel-control.right .icons {
+  background-position: -408px -16px;
+}
+.top-section .carousel-control:hover.right .icons {
+  background-position: -385px -16px;
+}
 
 /* home page */
 
-	/* .active-projects-module */
-	.active-projects-module {
-		text-align: center;
-		background-color: #ededed;
-		padding-bottom: 80px;
-	}
-		.active-projects-module .container {
-			padding: 0;
-		}
-		.active-projects-module .title-active-projects {
-			background: none;
-			width: 370px;
-			margin: 55px auto 67px auto;
-		}
-		.active-projects-module .row {
-			margin: 0 97px;
-		}
-			.active-projects-module .col-md-4 {
-				padding: 0;
-			}
-				/* .active-projects-module .module-box */
-				.active-projects-module .module-box {
-					background-color: #fff;
-					margin: 0 18px;
-				}
-					.active-projects-module .desktop-img {
-						display: block;
-					}
-					.active-projects-module .mobile-img {
-						display: none;
-					}
-					/* .active-projects-module .img-main */
-					.active-projects-module .img-main {
-						position: relative;
-					}
-						.active-projects-module .img-main .img-link {
-							background-color: #000;
-							display: block;
-						}
-						.active-projects-module .img-main .img-link img {
-							opacity: 0.6;
-							width: 100%;
-						}
-							.active-projects-module .img-main .img-link:hover img {
-								opacity: 1;
-							}
-								.active-projects-module .img-main .txt-table {
-									position: absolute;
-									top: 0;
-									left: 0;
-									width: 100%;
-									height: 297px;
-									display: table;
-									z-index: 99;
-								}
-									.active-projects-module .img-main .txt {
-										font-family: 'Source Sans Pro';
-                                        font-weight: 700;
-										font-size: 30px;
-										line-height: 32px;
-										color: #fff;
-										padding: 0 20px 30px 20px;
-										display: table-cell;
-										vertical-align: middle;
-									}
-						.active-projects-module .img-main .funded-round {
-							text-align: center;
-							background-color: #fff;
-							width: 128px;
-							height: 135px;
-							padding: 10px;
-							border-radius: 100%;
-							position: absolute;
-							bottom: -67.5px;
-							margin: 0 0 0 -67.5px;
-							left: 50%;
-							z-index: 99;
-						}
-							.active-projects-module .img-main .funded-round .round-depict {
-								font-family: 'Source Sans Pro';
-                                font-weight: 700;
-								font-size: 14px;
-								color: #039;
-								display: block;
-								position: absolute;
-								top: 50%;
-								left: 50%;
-								width: 110px;
-								margin: 2px 0 0 -55px;
-							}
-							.active-projects-module .img-main .funded-round .status-indicator input {
-								margin-top: 27px !important;
-								font-size: 29px !important;
-							}
-							.active-projects-module .img-main .funded-round .status-indicator input.smaller {
-								font-size: 23px !important;
-								margin-top: 29px !important;
-								-webkit-transition: all 0.25s ease;
-								transition: all 0.25s ease;
-							}
-                            .active-projects-module.embedded .img-main .funded-round .status-indicator input {
-                                margin-top: -85px !important;
-                                margin-left: 26px!important;
-                                box-shadow: none;
-							}
-                            .active-projects-module.embedded .img-main .funded-round .status-indicator input.smaller {
-                                margin-top: -81px !important;
-                                margin-left: 27px!important;
-																font-size: 23px !important;
-                                box-shadow: none;
-																-webkit-transition: font-size 0.25s ease;
-																transition: font-size 0.25s ease;
-							}
 
-						.status-indicator {
-							transform: rotateY(180deg);
-							-webkit-transform: rotateY(180deg);
-						}
-						.status-indicator input {
-							transform: rotateY(180deg);
-							-webkit-transform: rotateY(180deg);
-						}
-						.desktop-circle {
-							display: block;
-						}
-						.small-circle ,
-						.mobile-circle,
-						.tablet-circle {
-							display: none;
-						}
+/* .active-projects-module */
 
-					/* .active-projects-module .info-main */
-					.active-projects-module .info-main {
-						padding: 41px 29px 34px 27px;
-						position: relative;
-						z-index: 199;
-					}
-						.active-projects-module .info-main .blue-bar,
-						.active-projects-module .info-main .dark-blue-bar {
-							font-family: 'Source Sans Pro';
-                            font-weight: 700;
-							font-size: 16px;
-							color: #fff;
-							height: 60px;
-							line-height: 60px;
-							padding: 0 16px 0 24px;
-							overflow: hidden;
-							margin-top: 19px;
-						}
-							.active-projects-module .info-main .blue-bar {
-								background: #14b1e7;
-							}
-							.active-projects-module .info-main .dark-blue-bar {
-								background: #003399;
-							}
-								.active-projects-module .info-main .blue-bar span,
-								.active-projects-module .info-main .dark-blue-bar span {
-									font-family: 'Source Sans Pro';
-                                    font-weight: 700;
-								}
+.active-projects-module {
+  text-align: center;
+  background-color: #ededed;
+  padding-bottom: 80px;
+}
+.active-projects-module .container {
+  padding: 0;
+}
+.active-projects-module .title-active-projects {
+  background: none;
+  width: 370px;
+  margin: 55px auto 67px auto;
+}
+.active-projects-module .row {
+  margin: 0 97px;
+}
+.active-projects-module .col-md-4 {
+  padding: 0;
+}
 
-	/* .our-impacts-module */
-	.our-impacts-module {
-		text-align: center;
-	}
-		.our-impacts-module .title-our-impacts {
-			letter-spacing: 8px;
-			background: none;
-			padding-left: 20px;
-			width: 276px;
-			margin: 72px auto 53px auto;
-		}
-		.our-impacts-module .row {
-			margin: 0 86px 0 113px;
-			padding: 0 0 40px 0;
-			border-bottom: 1px solid #8a8a8a;
-		}
-			.our-impacts-module .row .col-md-3 {
-				padding: 0;
-			}
-				.our-impacts-module .row .col-md-3:nth-child(1) .module-box {
-					float: left;
-					width: 170px;
-					margin-left: -11px;
-				}
-					.our-impacts-module .row .col-md-3:nth-child(2) .module-box .titles {
-						padding-right: 30px;
-					}
-					.our-impacts-module .row .col-md-3:nth-child(3) .module-box .icons {
-						margin-left: 8%;
-					}
-					.our-impacts-module .row .col-md-3:nth-child(3) .module-box .titles {
-						letter-spacing: -1.8px;
-						padding-top: 20px;
-						line-height: 40px;
-					}
-				.our-impacts-module .row .col-md-3:nth-child(4) .module-box {
-					float: right;
-					width: 194px;
-				}
-					.our-impacts-module .row .col-md-3:nth-child(4) .module-box .titles {
-						padding-top: 20px;
-						line-height: 50px;
-					}
-		.our-impacts-module .module-box {
-			text-align: center;
-		}
-			.our-impacts-module .module-box .icons {
-				width: 168px;
-				height: 160px;
-				margin: 0 auto;
-				display: block;
-			}
-				.our-impacts-module .module-box .icon-people {
-					background-position: 0 -184px;
-				}
-				.our-impacts-module .module-box .icon-home-ok {
-					background-position: -168px -184px;
-				}
-				.our-impacts-module .module-box .icon-tree {
-					background-position: -336px -190px;
-				}
-				.our-impacts-module .module-box .icon-user {
-					background-position: -504px -178px;
-				}
-					.our-impacts-module .module-box .titles {
-						font-family: 'Source Sans Pro';
-                        font-weight: 900;
-						color: #282828;
-						line-height: 66px;
-						display: block;
-					}
-						.our-impacts-module .module-box .font20 {
-							font-size: 20px;
-						}
-						.our-impacts-module .module-box .font48 {
-							font-size: 48px;
-						}
-						.our-impacts-module .module-box .font72 {
-							font-size: 72px;
-						}
-							.our-impacts-module .module-box .titles .font20 {
-								font-family: 'Source Sans Pro';
-                                font-weight: 900;
-							}
-					.our-impacts-module .module-box .txt {
-						font-size: 18px;
-						color: #4b4b4b;
-						text-transform: uppercase;
-						line-height: 22px;
-						display: block;
-						position: relative;
-					}
-					.our-impacts-module .module-box .txt .position {
-						position: relative;
-						min-width: 8px;
-						display: inline-block;
-					}
-					.our-impacts-module .module-box .txt .position .font10 {
-						font-size: 10px;
-						position: absolute;
-						top: -7px;
-						left: 3px;
-					}
+/* .active-projects-module .module-box */
 
-	/* .how-it-works-module */
-	.how-it-works-module {
-		text-align: center;
-	}
-		.how-it-works-module .title-how-it-works {
-			letter-spacing: 8px;
-			background: none;
-			padding-left: 20px;
-			width: 276px;
-			margin: 58px auto 0 auto;
-		}
-			/* .how-it-works-module .info-row */
-			.how-it-works-module .info-row {
-				text-align: left;
-				margin: 0;
-				padding: 57px 86px 0 113px;
-			}
-				.how-it-works-module .info-row .video-area .video {
-					background: #000;
-					width: 501px;
-					height: 326px;
-					position: relative;
-				}
-				.how-it-works-module .info-row .video-area .video iframe {
-					width: 501px;
-					height: 326px;
-					border: none;
-				}
-					.how-it-works-module .info-row .video-area .video-opacity {
-						background: rgba(0,0,0,0.5);
-						position: absolute;
-						top: 0;
-						left: 0;
-						width: 100%;
-						height: 100%;
-					}
-					.how-it-works-module .info-row .video-area .btn-play {
-						text-align: center;
-						border: 5px solid #fff;
-						border-radius: 100%;
-						position: absolute;
-						top: 50%;
-						left: 50%;
-						width: 130px;
-						height: 130px;
-						margin: -75px 0 0 -75px;
-					}
-						.how-it-works-module .info-row .video-area .btn-play .icons {
-							background-position: 0 -88px;
-							width: 96px;
-							height: 96px;
-							margin: 13px 0 0 0;
-						}
-							.how-it-works-module .info-row .video-area .btn-play:hover,
-							.how-it-works-module .info-row .video-area .btn-play:focus {
-								border: 5px solid #1cb0e6;
-							}
-							.how-it-works-module .info-row .video-area .btn-play:hover .icons,
-							.how-it-works-module .info-row .video-area .btn-play:focus .icons {
-								background-position: -96px -88px;
-							}
-				.how-it-works-module .info-row .txt-area {
-					margin: 0 530px 0 0;
-				}
-				    .how-it-works-module .info-row .txt-area .txt-table {
-						width: 100%;
-					    display: table;
-					    min-height: 326px;
-					}
-					.how-it-works-module .info-row .txt-area .txt-td {
-						display: table-cell;
-						vertical-align: middle;
-						line-height: 20px;
-					}
-					.how-it-works-module .info-row .txt-area .txt-td p {
-						font-size: 14px;
-						color: #4b4b4b;
-						line-height: 28px;
-						letter-spacing: -0.5px;
-					}
-			/* .how-it-works-module .step-row */
-			.how-it-works-module .step-row {
-				text-align: left;
-				margin: 65px 86px 0 113px;
-				border-bottom: 1px solid #8a8a8a;
-			}
-				.how-it-works-module .step-row .item {
-					float: left;
-					display: block;
-				}
-					.how-it-works-module .step-row .item:nth-child(1),
-					.how-it-works-module .step-row .item:nth-child(2) {
-						width: 35.5%;
-					}
-					.how-it-works-module .step-row .item:nth-child(3) {
-						width: 29%;
-					}
-						.how-it-works-module .step-row .item:nth-child(3) .info-txt {
-							margin-right: 0;
-						}
-						.how-it-works-module .step-row .module-box {
-							position: relative;
-							padding-top: 10px;
-							min-height: 170px;
-						}
-							.how-it-works-module .step-row .icon-blue-round {
-								text-align: center;
-								background: #00a1d9;
-								width: 70px;
-								height: 70px;
-								border-radius: 100%;
-							}
-								.how-it-works-module .step-row .icon-blue-round .icons {
-									width: 48px;
-									height: 48px;
-									margin-top: 12px;
-								}
-									.how-it-works-module .step-row .icon-fundraise .icons {
-										background-position: 0 -40px;
-									}
-									.how-it-works-module .step-row .icon-invest .icons {
-										background-position: -48px -40px;
-									}
-									.how-it-works-module .step-row .icon-pay-it-forward .icons {
-										background-position: -96px -40px;
-									}
-							.how-it-works-module .step-row .icon-arrow-right {
-								background-position: -144px -40px;
-								width: 48px;
-								height: 48px;
-								position: absolute;
-								top: 34px;
-								right: 15px;
-							}
-							.how-it-works-module .step-row .info-txt {
-								margin: 0 55px 0 100px;
-							}
-								.how-it-works-module .step-row .info-txt h4 {
-									font-family: 'Source Sans Pro';
-                                    font-weight: 700;
-									font-size: 18px;
-									line-height: 20px;
-									padding-bottom: 10px;
-									margin-top: -4px;
-								}
-								.how-it-works-module .step-row .info-txt p {
-									font-size: 14px;
-									color: #8a8a8a;
-									line-height: 24px;
-								}
-					.how-it-works-module .row .carousel-control,
-					.how-it-works-module .row .carousel-indicators {
-						display: none;
-					}
+.active-projects-module .module-box {
+  background-color: #fff;
+  margin: 0 18px;
+}
+.active-projects-module .desktop-img {
+  display: block;
+}
+.active-projects-module .mobile-img {
+  display: none;
+}
 
-	/* .how-it-works-module */
-	.testimonial-module {
-		text-align: center;
-		padding-bottom: 65px;
-	}
-		.testimonial-module .title-testimonial {
-			letter-spacing: 8px;
-			background: none;
-			padding-left: 20px;
-			width: 231px;
-			margin: 54px auto 0 auto;
-		}
-			/* .testimonial-module .head-row */
-			.testimonial-module .head-row {
-				margin: 0;
-				padding: 63px 86px 0 85px;
-			}
-				.testimonial-module .head-row ul {
-					display: table;
-					margin: 0 auto;
-				}
-				.testimonial-module .head-row li {
-					display: table-cell;
-				}
-				.testimonial-module .head-row li .head-img {
-					display: block;
-					margin: 25px;
-					position: relative;
-				}
-					.testimonial-module .head-row li .head-img .desktop-head {
-						display: block;
-					}
-					.testimonial-module .head-row li .head-img .mobile-head {
-						display: none;
-					}
-					.testimonial-module .head-row li .head-img .icon-arrow-down {
-						display: none;
-					}
-					.testimonial-module .head-row li.mobile-show {
-						display: none;
-					}
-				/*.testimonial-module .head-row li .head-img:hover,
-				.testimonial-module .head-row li .head-img:focus,*/
-				.testimonial-module .head-row li .head-img.active {
-					background-color: #ebfaff;
-					border: 2px solid #14b1e7;
-					border-radius: 6px;
-					margin: 0;
-					padding: 23px;
-				}
-					/*.testimonial-module .head-row li .head-img:hover .icon-arrow-down,
-					.testimonial-module .head-row li .head-img:focus .icon-arrow-down,*/
-					.testimonial-module .head-row li .head-img.active .icon-arrow-down {
-						background-position: -201px -55px;
-						width: 29px;
-						height: 22px;
-						display: block;
-						position: absolute;
-						bottom: -22px;
-						left: 50%;
-						margin: 0 0 0 -15px;
-					}
-					.testimonial-module .head-row li .head-img img {
-						width: 72px;
-						height: 72px;
-						border-radius: 6px;
-					}
-			/* .testimonial-module .info-area */
-			.testimonial-module .info-area {
-				padding: 47px 0 0 0;
-			}
-				.testimonial-module .info-area p {
-					font-size: 14px;
-					color: #4b4b4b;
-					text-align: justify;
-					line-height: 28px;
-					width: 770px;
-					margin: 0 auto;
-					padding-bottom: 15px;
-				}
-					.testimonial-module .info-area .block {
-						display: block;
-					}
-					    .testimonial-module .user-group {
-							padding-top: 14px;
-						}
-							.testimonial-module .user-group .link-blue {
-								font-family: 'Source Sans Pro';
-                                font-weight: 700;
-								font-size: 18px;
-								color: #00a1d9;
-							}
-							.testimonial-module .user-group .txt {
-								font-family: 'Source Sans Pro';
-                                font-weight: 700;
-								font-size: 14px;
-								color: rgba(121,121,121,0.5);
-								line-height: 25px;
-								padding: 3px 0 40px 0;
-							}
-							.testimonial-module .user-group .btn-blue {
-								height: 43px;
-								line-height: 43px;
-								padding-top: 2px;
-								min-width: 298px;
-								letter-spacing: 4px;
-							}
+/* .active-projects-module .img-main */
 
-	/* .featured-on-module */
-	.featured-on-module {
-		background-color: #ededed;
-		text-align: center;
-		padding-bottom: 45px;
-	}
-		.featured-on-module .title-featured-on {
-			letter-spacing: 8px;
-			background: none;
-			padding-left: 20px;
-			width: 241px;
-			margin: 44px auto 43px auto;
-		}
-		#featured-on-example-generic {
-			display: block;
-		}
-		#mobile-featured-on-example-generic {
-			display: none;
-		}
-			/* .featured-on-module .carousel-main */
-			.featured-on-module .carousel-main {
-				min-height: 171px;
-				margin-right: 70px;
-				margin-left: 70px;
-			}
-			.featured-on-module .carousel-main .logo-ul {
-				display: table;
-				width: 100%;
-			}
-				.featured-on-module .carousel-main .logo-ul li {
-					text-align: center;
-					vertical-align: middle;
-					width: 20%;
-					height: 171px;
-					display: table-cell;
-				}
-				    .featured-on-module .logo {
-						margin-right: auto;
-						margin-left: auto;
-						display: block;
-						overflow: hidden;
-					}
-						.featured-on-module .logo-fast-mpany {
-							background: url(../images/logo-fast-mpany.png) no-repeat;
-							width: 154px;
-							height: 23px;
-						}
-						.featured-on-module .logo-ehe-new-hork-eimes {
-							background: url(../images/logo-ehe-new-hork-eimes.png) no-repeat;
-							width: 137px;
-							height: 113px;
-						}
-						.featured-on-module .logo-shareable {
-							background: url(../images/logo-shareable.png) no-repeat;
-							width: 144px;
-							height: 21px;
-						}
-						.featured-on-module .logo-philanthropy {
-							background: url(../images/logo-philanthropy.png) no-repeat;
-							width: 153px;
-							height: 28px;
-						}
-						.featured-on-module .logo-clean-technica {
-							background: url(../images/logo-clean-technica.png) no-repeat;
-							width: 153px;
-							height: 44px;
-							margin-bottom: 25px;
-						}
-							.featured-on-module .logo-fast-mpany:hover,
-							.featured-on-module .logo-fast-mpany:focus,
-							.featured-on-module .logo-ehe-new-hork-eimes:hover,
-							.featured-on-module .logo-ehe-new-hork-eimes:focus,
-							.featured-on-module .logo-shareable:hover,
-							.featured-on-module .logo-shareable:focus,
-							.featured-on-module .logo-philanthropy:hover,
-							.featured-on-module .logo-philanthropy:focus,
-							.featured-on-module .logo-clean-technica:hover,
-							.featured-on-module .logo-clean-technica:focus {
-								background-position: center bottom;
-							}
-			.featured-on-module .carousel-control.left,
-			.featured-on-module .carousel-control.right {
-				background-color: rgba(41,41,41,0.15);
-				text-shadow: none;
-				background-image: none;
-				box-shadow: none;
-				opacity: 1;
-				width: 49px;
-				height: 47px;
-				border: 2px solid #fff;
-				top: 60px;
-			}
-				.featured-on-module .carousel-control.left {
-					text-align: center;
-					left: -76px;
-				}
-				.featured-on-module .carousel-control.right {
-					text-align: center;
-					right: -76px;
-				}
-					.featured-on-module .carousel-control.left .icons,
-					.featured-on-module .carousel-control.right .icons {
-						width: 24px;
-						height: 24px;
-						top: 0;
-						right: auto;
-						left: auto;
-						position: static;
-						margin: 10px auto 0 auto;
-					}
-						.featured-on-module .carousel-control.left .icons {
-							background-position: -288px -16px;
-						}
-							.featured-on-module .carousel-control:hover.left .icons {
-								background-position: -336px -16px;
-							}
-						.featured-on-module .carousel-control.right .icons {
-							background-position: -360px -16px;
-						}
-							.featured-on-module .carousel-control:hover.right .icons {
-								background-position: -384px -16px;
-							}
+.active-projects-module .img-main {
+  position: relative;
+}
+.active-projects-module .img-main .img-link {
+  background-color: #000;
+  display: block;
+}
+.active-projects-module .img-main .img-link img {
+  opacity: 0.6;
+  width: 100%;
+}
+.active-projects-module .img-main .img-link:hover img {
+  opacity: 1;
+}
+.active-projects-module .img-main .txt-table {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 297px;
+  display: table;
+  z-index: 99;
+}
+.active-projects-module .img-main .txt {
+  font-family: 'Source Sans Pro';
+  font-weight: 700;
+  font-size: 30px;
+  line-height: 32px;
+  color: #fff;
+  padding: 0 20px 30px 20px;
+  display: table-cell;
+  vertical-align: middle;
+}
+.active-projects-module .img-main .funded-round {
+  text-align: center;
+  background-color: #fff;
+  width: 128px;
+  height: 135px;
+  padding: 10px;
+  border-radius: 100%;
+  position: absolute;
+  bottom: -67.5px;
+  margin: 0 0 0 -67.5px;
+  left: 50%;
+  z-index: 99;
+}
+.active-projects-module .img-main .funded-round .round-depict {
+  font-family: 'Source Sans Pro';
+  font-weight: 700;
+  font-size: 14px;
+  color: #039;
+  display: block;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 110px;
+  margin: 2px 0 0 -55px;
+}
+.active-projects-module .img-main .funded-round .status-indicator input {
+  margin-top: 27px !important;
+  font-size: 29px !important;
+}
+.active-projects-module .img-main .funded-round .status-indicator input.smaller {
+  font-size: 23px !important;
+  margin-top: 29px !important;
+  -webkit-transition: all 0.25s ease;
+  transition: all 0.25s ease;
+}
+.active-projects-module.embedded .img-main .funded-round .status-indicator input {
+  margin-top: -85px !important;
+  margin-left: 26px!important;
+  box-shadow: none;
+}
+.active-projects-module.embedded .img-main .funded-round .status-indicator input.smaller {
+  margin-top: -81px !important;
+  margin-left: 27px!important;
+  font-size: 23px !important;
+  box-shadow: none;
+  -webkit-transition: font-size 0.25s ease;
+  transition: font-size 0.25s ease;
+}
+.status-indicator {
+  transform: rotateY(180deg);
+  -webkit-transform: rotateY(180deg);
+}
+.status-indicator input {
+  transform: rotateY(180deg);
+  -webkit-transform: rotateY(180deg);
+}
+.desktop-circle {
+  display: block;
+}
+.small-circle, .mobile-circle, .tablet-circle {
+  display: none;
+}
 
-	/* .newsletter-module */
-	.newsletter-module {
-		text-align: center;
-		position: relative;
-		height: 448px;
-		overflow: hidden;
-	}
-	.newsletter-module .img-area {
-		/*background: rgba(40,40,40,1);*/
-		position: relative;
-	}
-	.newsletter-module .img-area .desktop-img {
-		min-height: 449px;
-		background: transparent;
-		overflow: hidden;
-	}
-		.newsletter-module .img-area .img-opacity {
-			background: rgba(0,0,0,0);
-			position: absolute;
-			top: 0;
-			left: 0;
-			width: 100%;
-			height: 100%;
-		}
-	.newsletter-module .small-img,
-	.newsletter-module .mobile-img {
-		display: none;
-	}
-	.newsletter-module .img-area img {
-		width: 100%;
-		height: 449px;
-	}
-		.newsletter-module .title-newsletter {
-			letter-spacing: 8.5px;
-			background: none;
-			padding-left: 20px;
-			width: 370px;
-			margin: 84px auto 43px auto;
-		}
-			/* .newsletter-module .container */
-			.newsletter-module .container {
-				position: absolute;
-				z-index: 999;
-				top: 0;
-				left: 50%;
-				margin: 0 0 0 -600px;
-				padding: 0;
-			}
-				.newsletter-module .group-main p {
-					font-size: 20px;
-					color: #fff;
-					line-height: 25px;
-					padding: 0 0 33px 0;
-				}
-				.newsletter-module .group-main .group {
-					background-color: #fff;
-					min-height: 113px;
-					margin: 0 168px 0 162px;
-					padding: 31px 30px 29px 67px;
-				}
-					.newsletter-module .group-main .group .btn-sign-up {
-						letter-spacing: 4px;
-						text-transform: uppercase;
-						float: right;
-						width: 132px;
-                        border: none;
-					}
-					.newsletter-module .group-main .group .inputs {
-						margin-right: 147px;
-						height: 53px;
-						display: block;
-					}
-						.newsletter-module .group-main .group .inputs input {
-							font-size: 26px;
-							color: #4b4b4b;
-							background: none;
-							border: none;
-							outline: none;
-							height: 53px;
-							line-height: 53px;
-							width: 100%;
-						}
-							.newsletter-module .group-main .group .inputs input::-webkit-input-placeholder {
-								color: rgba(142,142,142,0.5);
-							}
-							.newsletter-module .group-main .group .inputs input:-moz-placeholder {
-								color: rgba(142,142,142,0.5);
-							}
-							.newsletter-module .group-main .group .inputs input::-moz-placeholder {
-								color: rgba(142,142,142,0.5);
-								opacity: 1;
-							}
-							.newsletter-module .group-main .group .inputs input:-ms-input-placeholder {
-								color: rgba(142,142,142,0.5);
-							}
+/* .active-projects-module .info-main */
 
+.active-projects-module .info-main {
+  padding: 41px 29px 34px 27px;
+  position: relative;
+  z-index: 199;
+}
+.active-projects-module .info-main .blue-bar, .active-projects-module .info-main .dark-blue-bar {
+  font-family: 'Source Sans Pro';
+  font-weight: 700;
+  font-size: 16px;
+  color: #fff;
+  height: 60px;
+  line-height: 60px;
+  padding: 0 16px 0 24px;
+  overflow: hidden;
+  margin-top: 19px;
+}
+.active-projects-module .info-main .blue-bar {
+  background: #14b1e7;
+}
+.active-projects-module .info-main .dark-blue-bar {
+  background: #003399;
+}
+.active-projects-module .info-main .blue-bar span, .active-projects-module .info-main .dark-blue-bar span {
+  font-family: 'Source Sans Pro';
+  font-weight: 700;
+}
 
+/* .our-impacts-module */
+
+.our-impacts-module {
+  text-align: center;
+}
+.our-impacts-module .title-our-impacts {
+  letter-spacing: 8px;
+  background: none;
+  padding-left: 20px;
+  width: 276px;
+  margin: 72px auto 53px auto;
+}
+.our-impacts-module .row {
+  margin: 0 86px 0 113px;
+  padding: 0 0 40px 0;
+  border-bottom: 1px solid #8a8a8a;
+}
+.our-impacts-module .row .col-md-3 {
+  padding: 0;
+}
+.our-impacts-module .row .col-md-3:nth-child(1) .module-box {
+  float: left;
+  width: 170px;
+  margin-left: -11px;
+}
+.our-impacts-module .row .col-md-3:nth-child(2) .module-box .titles {
+  padding-right: 30px;
+}
+.our-impacts-module .row .col-md-3:nth-child(3) .module-box .icons {
+  margin-left: 8%;
+}
+.our-impacts-module .row .col-md-3:nth-child(3) .module-box .titles {
+  letter-spacing: -1.8px;
+  padding-top: 20px;
+  line-height: 40px;
+}
+.our-impacts-module .row .col-md-3:nth-child(4) .module-box {
+  float: right;
+  width: 194px;
+}
+.our-impacts-module .row .col-md-3:nth-child(4) .module-box .titles {
+  padding-top: 20px;
+  line-height: 50px;
+}
+.our-impacts-module .module-box {
+  text-align: center;
+}
+.our-impacts-module .module-box .icons {
+  width: 168px;
+  height: 160px;
+  margin: 0 auto;
+  display: block;
+}
+.our-impacts-module .module-box .icon-people {
+  background-position: 0 -184px;
+}
+.our-impacts-module .module-box .icon-home-ok {
+  background-position: -168px -184px;
+}
+.our-impacts-module .module-box .icon-tree {
+  background-position: -336px -190px;
+}
+.our-impacts-module .module-box .icon-user {
+  background-position: -504px -178px;
+}
+.our-impacts-module .module-box .titles {
+  font-family: 'Source Sans Pro';
+  font-weight: 900;
+  color: #282828;
+  line-height: 66px;
+  display: block;
+}
+.our-impacts-module .module-box .font20 {
+  font-size: 20px;
+}
+.our-impacts-module .module-box .font48 {
+  font-size: 48px;
+}
+.our-impacts-module .module-box .font72 {
+  font-size: 72px;
+}
+.our-impacts-module .module-box .titles .font20 {
+  font-family: 'Source Sans Pro';
+  font-weight: 900;
+}
+.our-impacts-module .module-box .txt {
+  font-size: 18px;
+  color: #4b4b4b;
+  text-transform: uppercase;
+  line-height: 22px;
+  display: block;
+  position: relative;
+}
+.our-impacts-module .module-box .txt .position {
+  position: relative;
+  min-width: 8px;
+  display: inline-block;
+}
+.our-impacts-module .module-box .txt .position .font10 {
+  font-size: 10px;
+  position: absolute;
+  top: -7px;
+  left: 3px;
+}
+
+/* .how-it-works-module */
+
+.how-it-works-module {
+  text-align: center;
+}
+.how-it-works-module .title-how-it-works {
+  letter-spacing: 8px;
+  background: none;
+  padding-left: 20px;
+  width: 276px;
+  margin: 58px auto 0 auto;
+}
+
+/* .how-it-works-module .info-row */
+
+.how-it-works-module .info-row {
+  text-align: left;
+  margin: 0;
+  padding: 57px 86px 0 113px;
+}
+.how-it-works-module .info-row .video-area .video {
+  background: #000;
+  width: 501px;
+  height: 326px;
+  position: relative;
+}
+.how-it-works-module .info-row .video-area .video iframe {
+  width: 501px;
+  height: 326px;
+  border: none;
+}
+.how-it-works-module .info-row .video-area .video-opacity {
+  background: rgba(0, 0, 0, 0.5);
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+.how-it-works-module .info-row .video-area .btn-play {
+  text-align: center;
+  border: 5px solid #fff;
+  border-radius: 100%;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 130px;
+  height: 130px;
+  margin: -75px 0 0 -75px;
+}
+.how-it-works-module .info-row .video-area .btn-play .icons {
+  background-position: 0 -88px;
+  width: 96px;
+  height: 96px;
+  margin: 13px 0 0 0;
+}
+.how-it-works-module .info-row .video-area .btn-play:hover, .how-it-works-module .info-row .video-area .btn-play:focus {
+  border: 5px solid #1cb0e6;
+}
+.how-it-works-module .info-row .video-area .btn-play:hover .icons, .how-it-works-module .info-row .video-area .btn-play:focus .icons {
+  background-position: -96px -88px;
+}
+.how-it-works-module .info-row .txt-area {
+  margin: 0 530px 0 0;
+}
+.how-it-works-module .info-row .txt-area .txt-table {
+  width: 100%;
+  display: table;
+  min-height: 326px;
+}
+.how-it-works-module .info-row .txt-area .txt-td {
+  display: table-cell;
+  vertical-align: middle;
+  line-height: 20px;
+}
+.how-it-works-module .info-row .txt-area .txt-td p {
+  font-size: 14px;
+  color: #4b4b4b;
+  line-height: 28px;
+  letter-spacing: -0.5px;
+}
+
+/* .how-it-works-module .step-row */
+
+.how-it-works-module .step-row {
+  text-align: left;
+  margin: 65px 86px 0 113px;
+  border-bottom: 1px solid #8a8a8a;
+}
+.how-it-works-module .step-row .item {
+  float: left;
+  display: block;
+}
+.how-it-works-module .step-row .item:nth-child(1), .how-it-works-module .step-row .item:nth-child(2) {
+  width: 35.5%;
+}
+.how-it-works-module .step-row .item:nth-child(3) {
+  width: 29%;
+}
+.how-it-works-module .step-row .item:nth-child(3) .info-txt {
+  margin-right: 0;
+}
+.how-it-works-module .step-row .module-box {
+  position: relative;
+  padding-top: 10px;
+  min-height: 170px;
+}
+.how-it-works-module .step-row .icon-blue-round {
+  text-align: center;
+  background: #00a1d9;
+  width: 70px;
+  height: 70px;
+  border-radius: 100%;
+}
+.how-it-works-module .step-row .icon-blue-round .icons {
+  width: 48px;
+  height: 48px;
+  margin-top: 12px;
+}
+.how-it-works-module .step-row .icon-fundraise .icons {
+  background-position: 0 -40px;
+}
+.how-it-works-module .step-row .icon-invest .icons {
+  background-position: -48px -40px;
+}
+.how-it-works-module .step-row .icon-pay-it-forward .icons {
+  background-position: -96px -40px;
+}
+.how-it-works-module .step-row .icon-arrow-right {
+  background-position: -144px -40px;
+  width: 48px;
+  height: 48px;
+  position: absolute;
+  top: 34px;
+  right: 15px;
+}
+.how-it-works-module .step-row .info-txt {
+  margin: 0 55px 0 100px;
+}
+.how-it-works-module .step-row .info-txt h4 {
+  font-family: 'Source Sans Pro';
+  font-weight: 700;
+  font-size: 18px;
+  line-height: 20px;
+  padding-bottom: 10px;
+  margin-top: -4px;
+}
+.how-it-works-module .step-row .info-txt p {
+  font-size: 14px;
+  color: #8a8a8a;
+  line-height: 24px;
+}
+.how-it-works-module .row .carousel-control, .how-it-works-module .row .carousel-indicators {
+  display: none;
+}
+
+/* .how-it-works-module */
+
+.testimonial-module {
+  text-align: center;
+  padding-bottom: 65px;
+}
+.testimonial-module .title-testimonial {
+  letter-spacing: 8px;
+  background: none;
+  padding-left: 20px;
+  width: 231px;
+  margin: 54px auto 0 auto;
+}
+
+/* .testimonial-module .head-row */
+
+.testimonial-module .head-row {
+  margin: 0;
+  padding: 63px 86px 0 85px;
+}
+.testimonial-module .head-row ul {
+  display: table;
+  margin: 0 auto;
+}
+.testimonial-module .head-row li {
+  display: table-cell;
+}
+.testimonial-module .head-row li .head-img {
+  display: block;
+  margin: 25px;
+  position: relative;
+}
+.testimonial-module .head-row li .head-img .desktop-head {
+  display: block;
+}
+.testimonial-module .head-row li .head-img .mobile-head {
+  display: none;
+}
+.testimonial-module .head-row li .head-img .icon-arrow-down {
+  display: none;
+}
+.testimonial-module .head-row li.mobile-show {
+  display: none;
+}
+
+/*.testimonial-module .head-row li .head-img:hover,
+        .testimonial-module .head-row li .head-img:focus,*/
+
+.testimonial-module .head-row li .head-img.active {
+  background-color: #ebfaff;
+  border: 2px solid #14b1e7;
+  border-radius: 6px;
+  margin: 0;
+  padding: 23px;
+}
+
+/*.testimonial-module .head-row li .head-img:hover .icon-arrow-down,
+          .testimonial-module .head-row li .head-img:focus .icon-arrow-down,*/
+
+.testimonial-module .head-row li .head-img.active .icon-arrow-down {
+  background-position: -201px -55px;
+  width: 29px;
+  height: 22px;
+  display: block;
+  position: absolute;
+  bottom: -22px;
+  left: 50%;
+  margin: 0 0 0 -15px;
+}
+.testimonial-module .head-row li .head-img img {
+  width: 72px;
+  height: 72px;
+  border-radius: 6px;
+}
+
+/* .testimonial-module .info-area */
+
+.testimonial-module .info-area {
+  padding: 47px 0 0 0;
+}
+.testimonial-module .info-area p {
+  font-size: 14px;
+  color: #4b4b4b;
+  text-align: justify;
+  line-height: 28px;
+  width: 770px;
+  margin: 0 auto;
+  padding-bottom: 15px;
+}
+.testimonial-module .info-area .block {
+  display: block;
+}
+.testimonial-module .user-group {
+  padding-top: 14px;
+}
+.testimonial-module .user-group .link-blue {
+  font-family: 'Source Sans Pro';
+  font-weight: 700;
+  font-size: 18px;
+  color: #00a1d9;
+}
+.testimonial-module .user-group .txt {
+  font-family: 'Source Sans Pro';
+  font-weight: 700;
+  font-size: 14px;
+  color: rgba(121, 121, 121, 0.5);
+  line-height: 25px;
+  padding: 3px 0 40px 0;
+}
+.testimonial-module .user-group .btn-blue {
+  height: 43px;
+  line-height: 43px;
+  padding-top: 2px;
+  min-width: 298px;
+  letter-spacing: 4px;
+}
+
+/* .featured-on-module */
+
+.featured-on-module {
+  background-color: #ededed;
+  text-align: center;
+  padding-bottom: 45px;
+}
+.featured-on-module .title-featured-on {
+  letter-spacing: 8px;
+  background: none;
+  padding-left: 20px;
+  width: 241px;
+  margin: 44px auto 43px auto;
+}
+#featured-on-example-generic {
+  display: block;
+}
+#mobile-featured-on-example-generic {
+  display: none;
+}
+
+/* .featured-on-module .carousel-main */
+
+.featured-on-module .carousel-main {
+  min-height: 171px;
+  margin-right: 70px;
+  margin-left: 70px;
+}
+.featured-on-module .carousel-main .logo-ul {
+  display: table;
+  width: 100%;
+}
+.featured-on-module .carousel-main .logo-ul li {
+  text-align: center;
+  vertical-align: middle;
+  width: 20%;
+  height: 171px;
+  display: table-cell;
+}
+.featured-on-module .logo {
+  margin-right: auto;
+  margin-left: auto;
+  display: block;
+  overflow: hidden;
+}
+.featured-on-module .logo-fast-mpany {
+  background: url(../images/logo-fast-mpany.png) no-repeat;
+  width: 154px;
+  height: 23px;
+}
+.featured-on-module .logo-ehe-new-hork-eimes {
+  background: url(../images/logo-ehe-new-hork-eimes.png) no-repeat;
+  width: 137px;
+  height: 113px;
+}
+.featured-on-module .logo-shareable {
+  background: url(../images/logo-shareable.png) no-repeat;
+  width: 144px;
+  height: 21px;
+}
+.featured-on-module .logo-philanthropy {
+  background: url(../images/logo-philanthropy.png) no-repeat;
+  width: 153px;
+  height: 28px;
+}
+.featured-on-module .logo-clean-technica {
+  background: url(../images/logo-clean-technica.png) no-repeat;
+  width: 153px;
+  height: 44px;
+  margin-bottom: 25px;
+}
+.featured-on-module .logo-fast-mpany:hover, .featured-on-module .logo-fast-mpany:focus, .featured-on-module .logo-ehe-new-hork-eimes:hover, .featured-on-module .logo-ehe-new-hork-eimes:focus, .featured-on-module .logo-shareable:hover, .featured-on-module .logo-shareable:focus, .featured-on-module .logo-philanthropy:hover, .featured-on-module .logo-philanthropy:focus, .featured-on-module .logo-clean-technica:hover, .featured-on-module .logo-clean-technica:focus {
+  background-position: center bottom;
+}
+.featured-on-module .carousel-control.left, .featured-on-module .carousel-control.right {
+  background-color: rgba(41, 41, 41, 0.15);
+  text-shadow: none;
+  background-image: none;
+  box-shadow: none;
+  opacity: 1;
+  width: 49px;
+  height: 47px;
+  border: 2px solid #fff;
+  top: 60px;
+}
+.featured-on-module .carousel-control.left {
+  text-align: center;
+  left: -76px;
+}
+.featured-on-module .carousel-control.right {
+  text-align: center;
+  right: -76px;
+}
+.featured-on-module .carousel-control.left .icons, .featured-on-module .carousel-control.right .icons {
+  width: 24px;
+  height: 24px;
+  top: 0;
+  right: auto;
+  left: auto;
+  position: static;
+  margin: 10px auto 0 auto;
+}
+.featured-on-module .carousel-control.left .icons {
+  background-position: -288px -16px;
+}
+.featured-on-module .carousel-control:hover.left .icons {
+  background-position: -336px -16px;
+}
+.featured-on-module .carousel-control.right .icons {
+  background-position: -360px -16px;
+}
+.featured-on-module .carousel-control:hover.right .icons {
+  background-position: -384px -16px;
+}
+
+/* .newsletter-module */
+
+.newsletter-module {
+  text-align: center;
+  position: relative;
+  height: 448px;
+  overflow: hidden;
+}
+.newsletter-module .img-area {
+  /*background: rgba(40,40,40,1);*/
+  position: relative;
+}
+.newsletter-module .img-area .desktop-img {
+  min-height: 449px;
+  background: transparent;
+  overflow: hidden;
+}
+.newsletter-module .img-area .img-opacity {
+  background: rgba(0, 0, 0, 0);
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+.newsletter-module .small-img, .newsletter-module .mobile-img {
+  display: none;
+}
+.newsletter-module .img-area img {
+  width: 100%;
+  height: 449px;
+}
+.newsletter-module .title-newsletter {
+  letter-spacing: 8.5px;
+  background: none;
+  padding-left: 20px;
+  width: 370px;
+  margin: 84px auto 43px auto;
+}
+
+/* .newsletter-module .container */
+
+.newsletter-module .container {
+  position: absolute;
+  z-index: 999;
+  top: 0;
+  left: 50%;
+  margin: 0 0 0 -600px;
+  padding: 0;
+}
+.newsletter-module .group-main p {
+  font-size: 20px;
+  color: #fff;
+  line-height: 25px;
+  padding: 0 0 33px 0;
+}
+.newsletter-module .group-main .group {
+  background-color: #fff;
+  min-height: 113px;
+  margin: 0 168px 0 162px;
+  padding: 31px 30px 29px 67px;
+}
+.newsletter-module .group-main .group .btn-sign-up {
+  letter-spacing: 4px;
+  text-transform: uppercase;
+  float: right;
+  width: 132px;
+  border: none;
+}
+.newsletter-module .group-main .group .inputs {
+  margin-right: 147px;
+  height: 53px;
+  display: block;
+}
+.newsletter-module .group-main .group .inputs input {
+  font-size: 26px;
+  color: #4b4b4b;
+  background: none;
+  border: none;
+  outline: none;
+  height: 53px;
+  line-height: 53px;
+  width: 100%;
+}
+.newsletter-module .group-main .group .inputs input::-webkit-input-placeholder {
+  color: rgba(142, 142, 142, 0.5);
+}
+.newsletter-module .group-main .group .inputs input:-moz-placeholder {
+  color: rgba(142, 142, 142, 0.5);
+}
+.newsletter-module .group-main .group .inputs input::-moz-placeholder {
+  color: rgba(142, 142, 142, 0.5);
+  opacity: 1;
+}
+.newsletter-module .group-main .group .inputs input:-ms-input-placeholder {
+  color: rgba(142, 142, 142, 0.5);
+}
 
 /* .contents */
+
 header.edit-project-header {
-	text-align: center;
+  text-align: center;
 }
-	header.edit-project-header > .container > h1 {
-		display: inline-block;
-		color: #11ADE5;
-		font-size: 2rem;
-		text-align: center;
-		line-height: 75px;
-	}
+header.edit-project-header > .container > h1 {
+  display: inline-block;
+  color: #11ADE5;
+  font-size: 2rem;
+  text-align: center;
+  line-height: 75px;
+}
 .edit-project .header-container {
-    height: 0;
+  height: 0;
 }
 .edit-project .form-section {
-    margin-top: 20px;
+  margin-top: 20px;
 }
 .contents {
-	min-height: 450px;
-}
-	.top150 {
-		margin-top: 150px;
-	}
-    .top100 {
-		margin-top: 100px;
-	}
-
-	/* .titles */
-	.titles.container {
-		padding: 43px 0 0 0;
-		min-height: 103px;
-	}
-		.titles.container .title-get-involved {
-			margin-right: 83px;
-			min-width: 272px;
-			letter-spacing: 9px;
-			padding-left: 20px;
-		}
-		.title-h1 {
-			font-family: 'Source Sans Pro';
-            font-weight: 900;
-			font-size: 48px;
-			color: #2c3691;
-			line-height: 56px;
-		}
-
-
-	/* sign in page */
-	.contents.sign-in-contents {
-		min-height: 508px;
-	}
-	.contents.sign-in-contents .container {
-		padding: 0;
-	}
-		.sign-in {
-			padding: 43px 83px 102px 83px;
-		}
-			.sign-in .title-sign-in {
-				float: right;
-				padding-left: 31px;
-				padding-right: 21px;
-			}
-		/* .sign-in .sign-in-left */
-		.sign-in .sign-in-left {
-			float: left;
-			padding-top: 71px;
-		}
-			.sign-in .sign-in-left h2 {
-				font-family: 'Source Sans Pro';
-                font-weight: 900;
-				font-size: 48px;
-				line-height: 52px;
-				color: #2e3192;
-				margin-bottom: 9px;
-			}
-			.sign-in .sign-in-left p {
-				font-size: 14px;
-				line-height: 24px;
-				color: #4b4b4b;
-				padding-left: 4px;
-			}
-			.sign-in .sign-in-left p i {
-				display: block;
-			}
-			.sign-in .sign-in-left .account {
-				margin-top: 27px;
-			}
-			.sign-in .sign-in-left a {
-				font-size: 14px;
-				line-height: 20px;
-				color: #14b1e7;
-				padding-left: 4px;
-			}
-			/* .sign-in .login-area */
-			.sign-in .login-area {
-				padding: 140px 231px 0 332px;
-			}
-				.sign-in .login-area .input-wrap {
-					width: 100%;
-					height: 55px;
-					border: 1px solid #9d9d9d;
-					background-color: #f0f0f0;
-					margin-bottom: 11px;
-				}
-				.sign-in .login-area .input-wrap.input-error-style {
-					border-color: #f00;
-				}
-					.sign-in .login-area .input-wrap input {
-						border: none;
-						outline: none;
-						width: 100%;
-						height: 100%;
-						background-color: #f0f0f0;
-						font-size: 12px;
-						line-height: 16px;
-						color: #9d9d9d;
-						padding-left: 31px;
-						padding-right: 31px;
-						letter-spacing: 6px;
-					}
-				.sign-in .check-wrap {
-					display: block;
-					overflow: hidden;
-					min-height: 47px;
-					padding: 9px 0 16px 0;
-				}
-				.sign-in .login-area .btn-login {
-					padding-left: 23px;
-					padding-right: 19px;
-					height: 43px;
-					line-height: 43px;
-					letter-spacing: 4px;
-				}
-
-
-	/* sign up page */
-	.contents.sign-up-contents {
-		min-height: 851px;
-	}
-	.contents.sign-up-contents .container {
-		padding: 0;
-	}
-
-	.sign-up {
-		padding: 43px 83px 102px 83px;
-	}
-		.sign-up .title-sign-up {
-			float: right;
-			padding-left: 23px;
-			padding-right: 16px;
-		}
-		/* .sign-up .sign-up-left */
-		.sign-up .sign-up-left {
-			float: left;
-			padding-top: 76px;
-		}
-			.sign-up .sign-up-left h2 {
-				font-family: 'Source Sans Pro';
-                font-weight: 900;
-				font-size: 48px;
-				line-height: 52px;
-				color: #2e3192;
-				margin-bottom: 4px;
-			}
-			.sign-up .sign-up-left p {
-				font-size: 14px;
-				line-height: 28px;
-				color: #4b4b4b;
-				padding-left: 4px;
-			}
-			.sign-up .sign-up-left p i {
-				display: block;
-			}
-			.sign-up .sign-up-left .account {
-				margin-top: 27px;
-			}
-			.sign-up .sign-up-left a {
-				font-size: 14px;
-				line-height: 28px;
-				color: #14b1e7;
-				padding-left: 4px;
-			}
-			/* .sign-up .reg-area */
-			.sign-up .reg-area {
-				padding: 140px 231px 0 332px;
-			}
-				.sign-up .reg-area .input-wrap {
-					width: 100%;
-					height: 55px;
-					border: 1px solid #9d9d9d;
-					background-color: #f0f0f0;
-					margin-bottom: 11px;
-				}
-				.sign-up .reg-area .input-wrap.input-error-style {
-				  border-color: #f00;
-				}
-				.sign-up .reg-area .input-wrap.less-margin {
-					margin-bottom: 9px;
-				}
-				.sign-up .reg-area .input-wrap.high-margin {
-					margin-bottom: 13px;
-				}
-				.sign-up .reg-area .input-wrap.higher-margin {
-					margin-bottom: 17px;
-				}
-					.sign-up .reg-area .input-wrap input {
-						border: none;
-						outline: none;
-						width: 100%;
-						height: 100%;
-						background-color: #f0f0f0;
-						font-size: 12px;
-						line-height: 16px;
-						color: #9d9d9d;
-						padding-left: 31px;
-						padding-right: 31px;
-						letter-spacing: 6px;
-					}
-				.sign-up .check-wrap {
-					display: block;
-					overflow: hidden;
-					min-height: 45px;
-					padding: 13px 0 10px 0;
-				}
-				.sign-up .reg-area p {
-					font-size: 12px;
-					line-height: 24px;
-					color: #4b4b4b;
-					padding-left: 30px;
-					padding-right: 120px;
-					margin-bottom: 17px;
-					display: block;
-				}
-				.sign-up .reg-area .btn-signup {
-					padding-left: 13px;
-					padding-right: 10px;
-					height: 43px;
-					line-height: 43px;
-					letter-spacing: 4px;
-				}
-
-
-	/* what do page */
-	.contents.what-we-do-contents {
-		min-height: 1000px;
-	}
-	.contents.what-we-do-contents .container {
-		padding: 0;
-	}
-		.what-we-do-contents .article-detail {
-			padding: 43px 84px 107px 85px;
-		}
-		/* .article-detail */
-		.article-detail {
-			padding: 43px 84px 129px 85px;
-		}
-			.article-detail .title-do {
-				float: right;
-				padding-left: 23px;
-				padding-right: 18px;
-				word-spacing: 2px;
-			}
-			.article-detail .detail-left {
-				padding-right: 300px;
-				padding-top: 55px;
-			}
-			.article-detail .detail-left .title-img {
-				width: 700px;
-				height: 270px;
-				margin-bottom: 43px;
-			}
-				.article-detail .detail-left .title-img img {
-					width: 100%;
-					height: 100%;
-				}
-			.article-detail .detail-left h2 {
-				font-family: 'Source Sans Pro';
-                font-weight: 900;
-				font-size: 48px;
-				line-height: 56px;
-				color: #2c3691;
-				padding-right: 50px;
-			}
-			.article-detail .detail-left p {
-				font-size: 14px;
-				line-height: 28px;
-				color: #4b4b4b;
-				margin-top: 29px;
-				padding-right: 90px;
-			}
-			.article-detail .detail-left .btn-group {
-				padding-top: 18px;
-				padding-right: 40px;
-				width: 960px;
-			}
-				.article-detail .detail-left .btn-group .btn-blue {
-					display: block;
-					float: left;
-					font-family: 'Source Sans Pro';
-                    font-weight: 700;
-					font-size: 14px;
-					line-height: 43px;
-					height: 43px;
-					margin-bottom: 22px;
-					letter-spacing: 4px;
-					margin-right: 28px;
-				}
-				.article-detail .detail-left .btn-group .btn-leasing {
-					padding-left: 19px;
-					padding-right: 11px;
-					margin-top: 4px;
-				}
-				.article-detail .detail-left .btn-group .btn-communities {
-					padding-left: 19px;
-					padding-right: 13px;
-					margin-bottom: 26px;
-				}
-				.article-detail .detail-left .btn-group .btn-services {
-					padding-left: 32px;
-					padding-right: 33px;
-				}
-
-
-	/* about us page */
-	.contents.about-us-contents {
-		min-height: 600px;
-	}
-	.contents.about-us-contents .container {
-		padding: 0;
-	}
-	.about-us {
-		padding: 43px 84px 102px 85px;
-	}
-		.about-us .title-about-us {
-			float: right;
-			padding-left: 28px;
-			padding-right: 24px;
-		}
-		.about-us .about-us-left {
-			padding-right: 250px;
-			padding-top: 73px;
-		}
-		.about-us .about-us-left h2 {
-			font-family: 'Source Sans Pro';
-            font-weight: 700;
-			font-size: 48px;
-			line-height: 60px;
-			color: #2c3691;
-		}
-		.about-us .about-us-left p {
-			font-size: 14px;
-			line-height: 28px;
-			color: #4b4b4b;
-			margin-top: 8px;
-			margin-bottom: 35px;
-			padding-right: 140px;
-		}
-		.about-us .about-us-left .btn-works {
-			font-family: 'Source Sans Pro';
-            font-weight: 700;
-			font-size: 14px;
-			line-height: 43px;
-			height: 43px;
-			letter-spacing: 4px;
-			padding-left: 28px;
-			padding-right: 26px;
-		}
-		/* .mains-tabs */
-		.mains-tabs .tab-index .row {
-			padding-right: 360px;
-			padding-left: 80px;
-			margin: 0;
-		}
-			.mains-tabs .tab-index .row .col-lg-3 {
-				padding: 0;
-				padding-right: 1px;
-			}
-			.mains-tabs .tab-index .row .col-lg-3 a {
-				display: block;
-				font-family: 'Source Sans Pro';
-                font-weight: 700;
-				font-size: 16px;
-				height: 53px;
-				line-height: 53px;
-				color: rgba(138,138,138,0.5);
-				background-color: #ededed;
-				border-top: 4px solid #fff;
-				text-decoration: none;
-				text-align: center;
-			}
-			.mains-tabs .tab-index .row .col-lg-3 a:hover,
-			.mains-tabs .tab-index .row .col-lg-3 a.active {
-				border-top: 4px solid #00a1d9;
-				color: #4b4b4b;
-				background-color: #f4f4f4;
-			}
-		.mains-tabs .tab-content {
-			min-height: 412px;
-			background-color: #f4f4f4;
-		}
-		.mains-tabs .tab-content .tab-why,
-		.mains-tabs .tab-content .tab-how,
-		.mains-tabs .tab-content .tab-funded,
-		.mains-tabs .tab-content .tab-involved {
-			display: none;
-			padding-left: 85px;
-		}
-		.mains-tabs .tab-content .tab-why.active,
-		.mains-tabs .tab-content .tab-how.active,
-		.mains-tabs .tab-content .tab-funded.active,
-		.mains-tabs .tab-content .tab-involved.active {
-			display: block;
-		}
-			.mains-tabs .tab-content .img-left {
-				float: left;
-				margin-top: 56px;
-				width: 300px;
-				height: 216px;
-			}
-				.mains-tabs .tab-content .img-left img {
-					width: 100%;
-					height: 100%;
-				}
-				.mains-tabs .tab-content .img-left .desktop-img {
-					display: block;
-				}
-				.mains-tabs .tab-content .img-left .small-img {
-					display: none;
-				}
-			.mains-tabs .tab-content .content-right {
-				margin-left: 330px;
-			}
-				.mains-tabs .tab-content .content-right p {
-					font-size: 14px;
-					line-height: 28px;
-					color: #4b4b4b;
-				}
-				.mains-tabs .tab-content .tab-why .content-right p {
-					padding-top: 111px;
-					padding-right: 280px;
-				}
-				.mains-tabs .tab-content .tab-how .content-right,
-				.mains-tabs .tab-content .tab-funded .content-right  {
-					padding-top: 45px;
-				}
-					.mains-tabs .tab-content .tab-how .content-right p,
-					.mains-tabs .tab-content .tab-funded .content-right p {
-						margin-bottom: 28px;
-						padding-right: 96px;
-					}
-				.mains-tabs .tab-content .tab-involved .content-right {
-					padding-top: 52px;
-				}
-					.mains-tabs .tab-content .tab-involved .btn-blue {
-						float: left;
-						margin-right: 70px;
-						margin-bottom: 25px;
-						font-family: 'Source Sans Pro';
-                        font-weight: 700;
-						font-size: 14px;
-						line-height: 43px;
-						width: 300px;
-						height: 43px;
-						letter-spacing: 4px;
-					}
-
-
-	/* get involved page */
-
-		/* .info-area */
-		.info-area.container {
-			padding: 0 83px 35px 83px;
-		}
-			.info-area.container .title-h1 {
-				padding: 15px 600px 28px 0;
-			}
-			.info-area.container .txt {
-				font-size: 14px;
-				color: #4b4b4b;
-				line-height: 28px;
-				padding-right: 430px;
-				padding-bottom: 17px;
-			}
-
-		/* .list-area */
-		.list-area.container {
-			padding: 0 83px 40px 83px;
-		}
-			/* .list-area .row */
-			.list-area .row {
-				margin: 0 0 65px 0;
-			}
-				/* .list-area  .lefts */
-				.list-area .row .lefts {
-					float: left;
-					width: 499px;
-				}
-					.list-area .desktop-img {
-						display: block;
-					}
-					.list-area .mobile-img {
-						display: none;
-					}
-					/* .list-area .img-main */
-					.list-area .img-main {
-						position: relative;
-					}
-						.list-area .img-main .img-link {
-							background-color: #000;
-							display: block;
-						}
-						.list-area .img-main .img-link img {
-							opacity: 0.9;
-							width: 100%;
-						}
-							.list-area .img-main .img-link:hover img {
-								opacity: 1;
-							}
-						.list-area .mobile-show {
-							display: none;
-						}
-						.list-area .img-main .funded-round {
-							background-color: #fff;
-							width: 118px;
-							height: 120px;
-							padding: 5px;
-							border-radius: 100%;
-							position: absolute;
-							bottom: -99px;
-							margin: 0 0 0 -60px;
-							left: 50%;
-							z-index: 109;
-						}
-							.get-involved-contents .funded-round .status-indicator {
-								margin: 1px 0 0 -2px;
-							}
-							.get-involved-contents .funded-round .round-depict {
-								font-family: 'Source Sans Pro';
-                                font-weight: 700;
-								font-size: 14px;
-								color: #039;
-								text-align: center;
-								display: block;
-								position: absolute;
-								top: 50%;
-								left: 50%;
-								width: 110px;
-								margin: 2px 0 0 -55px;
-							}
-						    .get-involved-contents .funded-round .status-indicator input {
-								font-size: 30px !important;
-								margin-top: 27px !important;
-						    }
-					/* .list-area .info-main */
-					.list-area .info-main {
-						padding: 0;
-						position: relative;
-						z-index: 99;
-					}
-						.list-area .info-main .blue-bar,
-						.list-area .info-main .dark-blue-bar {
-							font-size: 14px;
-							color: #fff;
-							height: 33px;
-							line-height: 33px;
-							padding: 0 28px;
-							overflow: hidden;
-							margin-top: 8px;
-						}
-							.list-area .info-main .blue-bar {
-								background: #14b1e7;
-							}
-							.list-area .info-main .dark-blue-bar {
-								background: #003399;
-							}
-								.list-area .info-main .blue-bar span,
-								.list-area .info-main .dark-blue-bar span {
-									font-family: 'Source Sans Pro';
-								}
-									.list-area .info-main .blue-bar .bold,
-									.list-area .info-main .dark-blue-bar .bold {
-										font-family: 'Source Sans Pro';
-                                        font-weight: 700;
-									}
-				/* .list-area  .rights */
-				.list-area .row .rights {
-					margin: 0 0 0 530px;
-				}
-					.list-area .row .rights h2 {
-						line-height: 30px;
-						margin-top: -3px;
-					}
-						.list-area .row .rights h2 a {
-							font-family: 'Source Sans Pro'; font-weight: 700;
-							font-size: 30px;
-							color: #4b4b4b;
-						}
-							.list-area .row .rights h2 a:hover {
-								color: #14b1e7;
-							}
-					.list-area .row .rights .time {
-						font-family: 'Source Sans Pro'; font-weight: 700;
-						font-size: 16px;
-						color: #4b4b4b;
-						padding: 3px 0 13px 0;
-						display: block;
-					}
-					.list-area .row .rights p {
-						font-size: 14px;
-						color: #4b4b4b;
-						line-height: 28px;
-						padding-right: 35px;
-						padding-bottom: 31px;
-					}
-					.list-area .row .rights .bottom-bar {
-						padding-right: 35px;
-					}
-						.list-area .row .rights .bottom-bar .btn-read-more {
-							font-size: 14px;
-							text-transform: uppercase;
-							letter-spacing: 4px;
-							padding-left: 15px;
-							width: 169px;
-							height: 43px;
-							line-height: 43px;
-						}
-						.list-area .row .rights .bottom-bar .social-ul {
-							float: right;
-						}
-							.list-area .row .rights .bottom-bar .social-ul li {
-								float: left;
-								margin-left: 12px;
-							}
-
-		/* .past-projects-module */
-		.past-projects-module {
-			background-color: #ededed;
-			text-align: center;
-			padding-bottom: 45px;
-		}
-			.past-projects-module .container {
-				padding: 0;
-			}
-				.past-projects-module .title-past-projects {
-					letter-spacing: 8px;
-					background: none;
-					padding-left: 20px;
-					width: 272px;
-					margin: 38px auto 54px auto;
-				}
-					/* .past-projects-module .carousel-main */
-					.past-projects-module .carousel-main {
-						min-height: 360px;
-						margin-right: 92px;
-						margin-left: 92px;
-					}
-						.past-projects-module .carousel.desktop-show {
-							display: block;
-						}
-						.past-projects-module .carousel.mobile-show {
-							display: none;
-						}
-						/* .past-projects-module .carousel .item */
-						.past-projects-module .carousel .item {
-							padding: 0;
-							min-height: 360px;
-						}
-							.past-projects-module .carousel .module-box {
-								float: left;
-								width: 33.33333333%;
-							}
-								.past-projects-module .carousel .spacing {
-									padding: 0 19px 0 20px;
-								}
-									.past-projects-module .desktop-img {
-										display: block;
-									}
-									.past-projects-module .mobile-img {
-										display: none;
-									}
-									    /* .past-projects-module .carousel .img-main */
-									    .past-projects-module .img-main {
-											position: relative;
-										}
-											.past-projects-module .img-main .img-link {
-												display: block;
-												position: relative;
-											}
-											.past-projects-module .img-main .img-gradient {
-												opacity: 0.8;
-												background-image: -webkit-linear-gradient(bottom,rgba(0,0,0,1) 0,rgba(0,0,0,.0) 100%);
-												background-image: -o-linear-gradient(bottom,rgba(0,0,0,1) 0,rgba(0,0,0,.0) 100%);
-												background-image: -webkit-gradient(linear,bottom top,right top,from(rgba(0,0,0,1)),to(rgba(0,0,0,0)));
-												background-image: linear-gradient(to top,rgba(0,0,0,1) 0,rgba(0,0,0,0) 100%);
-												width: 100%;
-												height: 40%;
-												display: block;
-												position: absolute;
-												top: 60%;
-												left: 0;
-												z-index: 9;
-											}
-												.past-projects-module .img-main .img-link:hover .img-gradient {
-													background-image: none;
-												}
-											.past-projects-module .img-main .img-link img {
-												width: 100%;
-											}
-												.past-projects-module .img-main .img-link:hover img {
-													opacity: 1;
-												}
-											.past-projects-module .img-main .funded-round {
-												background-color: #fff;
-												width: 121px;
-												height: 121px;
-												padding: 6px;
-												border-radius: 100%;
-												position: absolute;
-												right: 7px;
-												bottom: 8px;
-												z-index: 99;
-											}
-									    /* .past-projects-module .carousel .info-main */
-									    .past-projects-module .info-main {
-											text-align: left;
-											padding: 10px 0 0 0;
-										}
-											.past-projects-module .info-main h2 {
-												line-height: 35px;
-											}
-												.past-projects-module .info-main h2 a {
-													font-family: 'Source Sans Pro'; font-weight: 700;
-													font-size: 24px;
-													color: #282828;
-												}
-													.past-projects-module .info-main h2 a:hover {
-														color: #14b1e7;
-													}
-											.past-projects-module .info-main .time {
-												font-family: 'Source Sans Pro'; font-weight: 700;
-												font-size: 16px;
-												color: #4b4b4b;
-												padding: 3px 0 13px 0;
-												display: block;
-											}
-											.past-projects-module .info-main .bottom-bar {
-												padding-right: 35px;
-											}
-												.past-projects-module .info-main .bottom-bar .btn-read-more {
-													font-size: 14px;
-													text-transform: uppercase;
-													letter-spacing: 4px;
-													padding-left: 15px;
-													width: 169px;
-													height: 43px;
-													line-height: 43px;
-												}
-										.past-projects-module .carousel-control.left,
-										.past-projects-module .carousel-control.right {
-											background-color: rgba(41,41,41,0.15);
-											text-shadow: none;
-											background-image: none;
-											box-shadow: none;
-											opacity: 1;
-											width: 49px;
-											height: 47px;
-											border: 2px solid #fff;
-											top: 93px;
-										}
-											.past-projects-module .carousel-control.left {
-												text-align: center;
-												left: -88px;
-											}
-											.past-projects-module .carousel-control.right {
-												text-align: center;
-												right: -88px;
-											}
-												.past-projects-module .carousel-control.left .icons,
-												.past-projects-module .carousel-control.right .icons {
-													width: 24px;
-													height: 24px;
-													top: 0;
-													right: auto;
-													left: auto;
-													position: static;
-													margin: 10px auto 0 auto;
-												}
-													.past-projects-module .carousel-control.left .icons {
-														background-position: -288px -16px;
-													}
-														.past-projects-module .carousel-control:hover.left .icons {
-															background-position: -336px -16px;
-														}
-													.past-projects-module .carousel-control.right .icons {
-														background-position: -360px -16px;
-													}
-														.past-projects-module .carousel-control:hover.right .icons {
-															background-position: -384px -16px;
-														}
-
-
-	/* project details page */
-	.details-active-project-module {
-		background: #ededed;
-		position: relative;
-	}
-		.details-active-project-module .banners.min-height455 {
-			background: #292929;
-			min-height: 455px;
-		}
-			.desktop-banner {
-				display: block;
-			}
-			.mobile-banner {
-				display: none;
-			}
-			.details-active-project-module .banners img {
-				width: 100%;
-				height: 455px;
-				opacity: 0.3;
-			}
-				/* .details-active-project-module .banner-section */
-				.details-active-project-module .banner-section {
-					width: 100%;
-					position: absolute;
-					top: 0;
-					left: 0;
-					z-index: 999;
-				}
-					.details-active-project-module .banner-section .container {
-						padding: 43px 0 0 0;
-						min-height: 455px;
-						position: relative;
-					}
-						.details-active-project-module .banner-section .title-active-project {
-							letter-spacing: 9px;
-							padding-left: 20px;
-							margin-right: 83px;
-							width: 303px;
-						}
-						.details-active-project-module .banner-section .title-h1 {
-							color: #fff;
-							position: absolute;
-							bottom: 30px;
-							left: 87px;
-							width: 450px;
-						}
-						.details-active-project-module .banner-section .funded-round {
-							background: #fff;
-							border-radius: 100%;
-							width: 236px;
-							height: 236px;
-							padding: 12px;
-							margin: 0 0 0 -118px;
-							position: absolute;
-							bottom: -201px;
-							left: 50%;
-							z-index: 299;
-						}
-							.details-active-project-module .banner-section .funded-round .round-depict {
-								font-family: 'Source Sans Pro'; font-weight: 700;
-								font-size: 27.19px;
-								color: #039;
-								display: block;
-								position: absolute;
-								top: 50%;
-								left: 50%;
-								width: 110px;
-								margin: 6px 0 0 -55px;
-							}
-							.details-active-project-module .banner-section .funded-round .status-indicator input {
-								font-size: 58.26px !important;
-								margin-top: 50px !important;
-							}
-							.details-active-project-module .banner-section .funded-round .status-indicator input.smaller {
-								font-size: 44.26px !important;
-								-webkit-transition: font-size 0.25s ease;
-								transition: font-size 0.25s ease;
-							}
-
-				/* .details-active-project-module .info-section */
-				.details-active-project-module .info-section {
-					position: relative;
-				}
-					.details-active-project-module .info-section .container {
-						padding: 4px 116px 0 112px;
-						position: relative;
-					}
-						/* .details-active-project-module .info-main */
-						.details-active-project-module .info-main {
-							padding-bottom: 62px;
-						}
-							.details-active-project-module .info-main .blue-bar,
-							.details-active-project-module .info-main .dark-blue-bar {
-								font-size: 27.19px;
-								color: #fff;
-								height: 65px;
-								line-height: 65px;
-								padding: 0 55px;
-								overflow: hidden;
-								margin-top: 15px;
-							}
-								.details-active-project-module .info-main .blue-bar {
-									background: #14b1e7;
-								}
-								.details-active-project-module .info-main .dark-blue-bar {
-									background: #003399;
-								}
-									.details-active-project-module .info-main .blue-bar span,
-									.details-active-project-module .info-main .dark-blue-bar span {
-										font-family: 'Source Sans Pro';
-									}
-										.details-active-project-module .info-main .blue-bar .bold,
-										.details-active-project-module .info-main .dark-blue-bar .bold {
-											font-family: 'Source Sans Pro'; font-weight: 700;
-										}
-						/* .details-active-project-module .video-main */
-						.details-active-project-module .video-main {
-							padding-bottom: 55px;
-							position: relative;
-						}
-							.details-active-project-module .video-area .video {
-								background: #000;
-								width: 470px;
-								height: 326px;
-								position: relative;
-							}
-							.details-active-project-module .video-area .video iframe {
-								width: 470px;
-								height: 326px;
-								border: none;
-							}
-								.details-active-project-module .video-area .video img {
-									width: 100%;
-									height: 326px;
-								}
-								.details-active-project-module .video-area .video-opacity {
-									background: rgba(0,0,0,0.5);
-									position: absolute;
-									top: 0;
-									left: 0;
-									width: 100%;
-									height: 100%;
-								}
-								.details-active-project-module .video-area .btn-play {
-									text-align: center;
-									border: 5px solid #fff;
-									border-radius: 100%;
-									position: absolute;
-									top: 50%;
-									left: 50%;
-									width: 130px;
-									height: 130px;
-									margin: -75px 0 0 -75px;
-								}
-									.details-active-project-module .video-area .btn-play .icons {
-										background-position: 0 -88px;
-										width: 96px;
-										height: 96px;
-										margin: 13px 0 0 0;
-									}
-										.details-active-project-module .video-area .btn-play:hover,
-										.details-active-project-module .video-area .btn-play:focus {
-											border: 5px solid #1cb0e6;
-										}
-										.details-active-project-module .video-area .btn-play:hover .icons,
-										.details-active-project-module .video-area .btn-play:focus .icons {
-											background-position: -96px -88px;
-										}
-							.details-active-project-module .txt-area {
-								margin: 0 15px 0 500px;
-							}
-							    .details-active-project-module .txt-area .txt-table {
-									min-height: 316px;
-									display: table;
-									width: 100%;
-								}
-								.details-active-project-module .mobile-bottom-bar {
-									display: none;
-								}
-								.details-active-project-module .txt-area .txt-td {
-									display: table-cell;
-									vertical-align: middle;
-									line-height: 20px;
-								}
-									.details-active-project-module .txt-area .txt-td p {
-										color: #4b4b4b;
-									}
-									.details-active-project-module .txt-area .txt-td .font20 {
-										font-size: 20px;
-										line-height: 36px;
-										padding-bottom: 22px;
-									}
-									.details-active-project-module .txt-area .txt-td .font14 {
-										font-size: 14px;
-										line-height: 24px;
-									}
-
-		/* .project-updates-module */
-		.project-updates-module {
-			position: relative;
-		}
-			.project-updates-module .container {
-				padding: 46px 47px 20px 115px;
-			}
-				/* .project-updates-module .main-area */
-				.project-updates-module .main-area {
-					float: left;
-					width: 671px;
-				}
-					.project-updates-module .main-area .title-project-updates {
-						width: 331px;
-						letter-spacing: 9px;
-						padding-left: 20px;
-						margin-bottom: 35px;
-					}
-					 /* .project-updates-module .list-area */
-					 .project-updates-module .list-area .row {
-						 padding: 55px 0 0 0;
-						 margin: 0;
-						 border-bottom: 4px solid #dcdcdc;
-						 overflow: hidden;
-					 }
-						.project-updates-module .list-area .left-date {
-							text-align: center;
-							width: 203px;
-							float: left;
-						}
-							 .project-updates-module .list-area .left-date .date-txt,
-							 .project-updates-module .list-area .left-date .month-txt {
-								 font-family: 'Source Sans Pro'; font-weight: 700;
-								 color: #00a1d9;
-								 display: block;
-								 padding: 0 50px 0 28px;
-							 }
-								 .project-updates-module .list-area .left-date .date-txt {
-									 font-size: 120px;
-									 line-height: 100px;
-									 margin-top: -8px;
-								 }
-								 .project-updates-module .list-area .left-date .month-txt {
-									 font-size: 24px;
-									 letter-spacing: 20px;
-									 padding-left: 32px;
-								 }
-					     .project-updates-module .list-area .main-info {
-							 margin-left: 203px;
-					     }
-							.project-updates-module .list-area .main-info .title-h4 {
-								 line-height: 30px;
-							}
-								 .project-updates-module .list-area .main-info .title-h4 a {
-									 font-family: 'Source Sans Pro'; font-weight: 700;
-									 font-size: 18px;
-									 color: #4b4b4b;
-								 }
-									 .project-updates-module .list-area .main-info .title-h4 a:hover {
-										 color: #1cb0e6;
-									 }
-							.project-updates-module .list-area .main-info p {
-								 font-size: 14px;
-								 color: #8a8a8a;
-								 line-height: 25px;
-								 padding-bottom: 20px;
-							}
-							.project-updates-module .list-area .main-info .social-ul {
-								 margin-bottom: 34px;
-								 overflow: hidden;
-							 }
-								 .project-updates-module .list-area .main-info .social-ul li {
-									 float: left;
-									 margin-right: 7px;
-								 }
-				/* .project-updates-module .right-aside */
-				.project-updates-module .right-aside {
-					width: 305px;
-					float: right;
-					position: relative;
-				}
-					.project-updates-module .right-aside .module-box {
-						text-align: center;
-						background: #ededed;
-						min-height: 200px;
-						padding: 12px 0 32px 0;
-						margin: 0 0 32px 0;
-					}
-						.project-updates-module .right-aside .module-box .type-txt {
-							font-family: 'Source Sans Pro'; font-weight: 700;
-							font-size: 18px;
-							text-transform: uppercase;
-							line-height: 30px;
-							color: rgba(4,4,5,0.4);
-							padding: 11px 0 13px 0;
-						}
-						.project-updates-module .right-aside .module-box .value-txt {
-							font-family: 'Source Sans Pro'; font-weight: 900;
-							font-size: 60px;
-							line-height: 65px;
-							color: #282828;
-							padding: 0 0 20px 0;
-						}
-						.project-updates-module .right-aside .module-box .title-h5 {
-							font-family: 'Source Sans Pro'; font-weight: 700;
-							font-size: 16px;
-							color: #4b4b4b;
-							border-top: 1px solid #c3c3c3;
-							border-bottom: 1px solid #c3c3c3;
-							margin: 0 18px 0 16px;
-							height: 33px;
-							line-height: 33px;
-						}
-						.project-updates-module .right-aside .module-box ul {
-							padding: 34px 0 25px 0;
-						}
-							.project-updates-module .right-aside .module-box li {
-								font-family: 'Source Sans Pro'; font-weight: 700;
-								font-size: 14px;
-								color: rgba(75,75,75,0.8);
-								line-height: 32px;
-							}
-						.project-updates-module .right-aside .btn-i-want-to-donate {
-							background-color: #00a1d9;
-							letter-spacing: 4px;
-							padding-left: 20px;
-							width: 230px;
-							height: 45px;
-							line-height: 45px;
-						}
-							.project-updates-module .right-aside .btn-i-want-to-donate:hover,
-							.project-updates-module .right-aside .btn-i-want-to-donate:focus {
-								background-color: #2c3691;
-							}
-					 /* .project-updates-module .venue-area */
-					 .project-updates-module .venue-area {
-						 padding: 41px 0 0 0;
-					 }
-						 .project-updates-module .main-area .title-venue {
-							width: 172px;
-							margin-bottom: 17px;
-						}
-						 .project-updates-module .main-area .venue-map,
-						 .project-updates-module .main-area .venue-map img {
-							width: 670px;
-							height: 380px;
-						}
-						 .project-updates-module .main-area .venue-bottom {
-							 padding: 22px 0 0 0;
-						 }
-							 .project-updates-module .main-area .venue-bottom .title-h4 {
-								 font-family: 'Source Sans Pro'; font-weight: 700;
-								 font-size: 18px;
-								 color: #4b4b4b;
-								 text-transform: uppercase;
-								 line-height: 30px;
-								 padding-bottom: 5px;
-							 }
-							 .project-updates-module .main-area .venue-bottom p {
-								 line-height: 25px;
-							 }
-								 .project-updates-module .main-area .venue-bottom p span {
-									 font-size: 14px;
-									 color: #8a8a8a;
-									 display: block;
-								 }
-
-		/* .donors-module */
-		.donors-module {
-			position: relative;
-		}
-			.donors-module .titles.container {
-				padding: 19px 0 0 0;
-				min-height: 83px;
-			}
-				.titles.container .title-donors {
-					margin-right: 47px;
-					min-width: 172px;
-					letter-spacing: 9px;
-					padding-left: 20px;
-				}
-			.donors-module .mains-tabs .tab-content {
-				min-height: 100px;
-				padding-bottom: 46px;
-			}
-			.donors-module .tab-content .tab-basic,
-			.donors-module .tab-content .tab-silver,
-			.donors-module .tab-content .tab-gold {
-				display: none;
-			}
-			.donors-module .tab-content .tab-basic.active,
-			.donors-module .tab-content .tab-silver.active,
-			.donors-module .tab-content .tab-gold.active {
-				display: block;
-			}
-			.donors-module .tab-content .row {
-				margin: 4px 37px 0 87px;
-			}
-				.donors-module .tab-content .row .col-md-6 {
-					padding: 46px 0 0 0;
-				}
-					.donors-module .desktop-img {
-						display: block;
-					}
-					.donors-module .mobile-img {
-						display: none;
-					}
-					.donors-module .tab-content .head-img {
-						float: left;
-						width: 128px;
-					}
-						.donors-module .tab-content .head-img img {
-							width: 99px;
-							height: 99px;
-						}
-					.donors-module .info-box {
-						margin-left: 128px;
-					}
-					.donors-module .info-box .title-h4 {
-						padding: 0 0 4px 0;
-						font-family: 'Source Sans Pro'; font-weight: 700;
-						font-size: 18px;
-						color: #282828;
-						text-transform: uppercase;
-				    }
-					.donors-module .info-box p {
-						font-size: 14px;
-						color: #4b4b4b;
-						line-height: 28px;
-						padding: 0 25px 0 0;
-					}
-
-
-
-	/* partners page */
-	.contents.partners-contents {
-		position: relative;
-	}
-		.partners-contents .container {
-			padding: 43px 0 45px 85px;
-		}
-		.partners-contents .title-partners {
-			padding-left: 27px;
-			padding-right: 22px;
-			margin-right: 83px;
-			margin-bottom: 34px;
-		}
-			.partners-contents .titles .title-primary {
-				font-family: 'Source Sans Pro'; font-weight: 900;
-				font-size: 48px;
-				line-height: 52px;
-				color: #2c3691;
-				margin-bottom: 22px;
-			}
-			.partners-contents .titles .title-sub {
-				font-family: 'Source Sans Pro';
-				font-size: 14px;
-				line-height: 28px;
-				color: #4b4b4b;
-			}
-		/* .partners-contents .list */
-		.partners-contents .list-wrap {
-			margin-top: 49px;
-		}
-			.partners-contents .list-wrap .item-wrap {
-				min-height: 209px;
-				position: relative;
-				margin-bottom: 34px;
-			}
-			.partners-contents .list-wrap .item-wrap.large-spacing {
-				margin-bottom: 39px;
-			}
-			.partners-contents .left-img {
-				float: left;
-				width: 200px;
-				height: 200px;
-				margin-top: 9px;
-			}
-				.partners-contents .left-img img {
-					width: 100%;
-					height: 100%;
-				}
-			.partners-contents .content-info {
-				margin-left: 230px;
-				padding-bottom: 5px;
-				min-height: 160px;
-				overflow: hidden;
-			}
-				.partners-contents .content-info h4 {
-					font-family: 'Source Sans Pro'; font-weight: 700;
-					font-size: 30px;
-					line-height: 42px;
-					color: #4b4b4b;
-					margin-bottom: 4px;
-				}
-				.partners-contents .content-info h4 a {
-					font-family: 'Source Sans Pro'; font-weight: 700;
-					font-size: 30px;
-					color: #4b4b4b;
-				}
-				.partners-contents .content-info h4 a:hover {
-					color: #14b1e7;
-				}
-				.partners-contents .content-info p {
-					font-family: 'Source Sans Pro';
-					font-size: 14px;
-					line-height: 28px;
-					color: #4b4b4b;
-					padding-right: 405px;
-					padding-left: 2px;
-				}
-			.partners-contents .btn-wrap {
-				margin: 0 0 0 231px;
-				min-height: 43px;
-			}
-				.partners-contents .btn-wrap .btn-blue {
-					height: 43px;
-					line-height: 43px;
-					padding-left: 18px;
-					padding-right: 14px;
-					letter-spacing: 4px;
-				}
-			/* .partners-contents .pager-info */
-			.partners-contents .pager-info {
-				margin-top: 41px;
-				padding-left: 4px;
-			}
-				.partners-contents .pager-info li {
-					float: left;
-					margin-right: 17px;
-				}
-					.partners-contents .pager-info li a {
-						display: inline-block;
-						padding: 0 20px;
-						font-family: 'Source Sans Pro'; font-weight: 700;
-						font-size: 16px;
-						line-height: 39px;
-						color: #4b4b4b;
-						height: 39px;
-						background-color: #dfdfdf;
-						text-decoration: none;
-					}
-					.partners-contents .pager-info li a:hover {
-						background-color: #c3c1c1;
-					}
-
-		/* .sponsoring-organizations-module */
-		.sponsoring-organizations-module {
-			background: #f4f4f4;
-			position: relative;
-			min-height: 387px;
-		}
-			.sponsoring-organizations-module .container {
-				text-align: center;
-				padding: 37px 83px 0 83px;
-			}
-				.title-sponsoring-organizations {
-					width: 494px;
-					letter-spacing: 9px;
-					padding-left: 15px;
-					margin-bottom: 56px;
-				}
-				#sponsoring-organizations-example-generic {
-					display: block;
-				}
-				#mobile-sponsoring-organizations-example-generic {
-					display: none;
-				}
-					/* .sponsoring-organizations-module .carousel-main */
-					.sponsoring-organizations-module .logo-ul {
-						display: table;
-						width: 100%;
-					}
-						.sponsoring-organizations-module .logo-ul li {
-							text-align: center;
-							vertical-align: middle;
-							width: 25%;
-							height: 200px;
-							display: table-cell;
-						}
-							.sponsoring-organizations-module .logo {
-								margin-right: auto;
-								margin-left: auto;
-								display: block;
-								overflow: hidden;
-							}
-								.sponsoring-organizations-module .logo-the-san-francisco {
-									background: url(../images/logo-the-san-francisco.png) no-repeat;
-									width: 166px;
-									height: 165px;
-								}
-								.sponsoring-organizations-module .logo-toyota-togethergreen {
-									background: url(../images/logo-toyota-togethergreen.png) no-repeat;
-									width: 193px;
-									height: 63px;
-								}
-								.sponsoring-organizations-module .logo-sun-shot {
-									background: url(../images/logo-sun-shot.png) no-repeat;
-									width: 134px;
-									height: 41px;
-								}
-								.sponsoring-organizations-module .logo-patagonia {
-									background: url(../images/logo-patagonia.png) no-repeat;
-									width: 172px;
-									height: 54px;
-								}
-					.sponsoring-organizations-module .carousel-control.left,
-					.sponsoring-organizations-module .carousel-control.right {
-						background-color: rgba(41,41,41,0.15);
-						text-shadow: none;
-						background-image: none;
-						box-shadow: none;
-						opacity: 1;
-						width: 49px;
-						height: 47px;
-						border: 2px solid #fff;
-						top: 90px;
-					}
-						.sponsoring-organizations-module .carousel-control.left {
-							text-align: center;
-							left: -76px;
-						}
-						.sponsoring-organizations-module .carousel-control.right {
-							text-align: center;
-							right: -76px;
-						}
-							.sponsoring-organizations-module .carousel-control.left .icons,
-							.sponsoring-organizations-module .carousel-control.right .icons {
-								width: 24px;
-								height: 24px;
-								top: 0;
-								right: auto;
-								left: auto;
-								position: static;
-								margin: 10px auto 0 auto;
-							}
-								.sponsoring-organizations-module .carousel-control.left .icons {
-									background-position: -288px -16px;
-								}
-									.sponsoring-organizations-module .carousel-control:hover.left .icons {
-										background-position: -336px -16px;
-									}
-								.sponsoring-organizations-module .carousel-control.right .icons {
-									background-position: -360px -16px;
-								}
-									.sponsoring-organizations-module .carousel-control:hover.right .icons {
-										background-position: -384px -16px;
-									}
-
-
-
-	/* solar ambassador program page */
-	.contents.solar-ambassador-program-contents {
-		min-height: 1000px;
-	}
-	.contents.solar-ambassador-program-contents .container {
-		padding: 0;
-	}
-		/* .article-detail */
-		.solar-contents .article-detail {
-			padding: 43px 84px 75px 85px;
-		}
-		.solar-contents .article-detail .bold {
-	        font-family: 'Source Sans Pro';
-            font-weight: 700;
-		}
-		.solar-contents .article-detail .title-solar {
-			float: right;
-			word-spacing: 2px;
-			line-height: 1;
-			width: 274px;
-			height: 63px;
-			padding: 13px 32px;
-		}
-			.solar-contents .article-detail .detail-left {
-				padding-right: 331px;
-				padding-top: 56px;
-			}
-			.solar-contents .article-detail .detail-left .title-img {
-				margin-bottom: 40px;
-			}
-			.solar-contents .article-detail .detail-left .btn-group {
-				padding-top: 27px;
-				padding-right: 0;
-				width: 900px;
-			}
-				.article-detail .detail-left .btn-group .btn-application {
-					padding-left: 29px;
-					padding-right: 23px;
-					margin-top: 4px;
-				}
-				.article-detail .detail-left .btn-group .btn-team {
-					padding-left: 26px;
-					padding-right: 19px;
-					margin-bottom: 26px;
-					margin-right: 0;
-				}
-				.article-detail .detail-left .btn-group .btn-project {
-					padding-left: 41px;
-					padding-right: 39px;
-				}
-
-
-
-
-	/* blog page */
-
-		.titles.container .title-blog {
-			margin-right: 83px;
-			min-width: 133px;
-			letter-spacing: 9px;
-			padding-left: 20px;
-		}
-
-		/* .grid-data */
-		.grid-data.container {
-			padding: 0 68px;
-		}
-			/* .form-area */
-			.form-area {
-				padding: 11px 16px 20px 16px;
-				min-height: 67px;
-			}
-				.form-area .width167 {
-					float: left;
-				}
-					.form-area .width167 .btn-default,
-					.form-area .width167.input-search {
-						width: 167px;
-					}
-					/* .input-search */
-					.input-search {
-						background: #f0f0f0;
-						border: 2px solid #fff;
-						padding: 0 28px 0 23px;
-						height: 36px;
-						line-height: 34px;
-						position: relative;
-					}
-						.input-search input {
-							font-size: 12px;
-							color: #9d9d9d;
-							letter-spacing: 6px;
-							background: none;
-							border: none;
-							height: 32px;
-							width: 100%;
-							line-height: 20px;
-							vertical-align: middle;
-							outline: none;
-						}
-						.input-search .icon-search {
-							background-position: -32px 0;
-							width: 16px;
-							height: 16px;
-							position: absolute;
-							top: 8px;
-							right: 9px;
-							z-index: 9;
-						}
-							.input-search .icon-search:hover {
-								background-position: -80px 0;
-							}
-			/* .grid-area.row */
-			.grid-area.row {
-				margin: 0;
-				min-height: 100px;
-			}
-				.grid-area.row .col-md-6 {
-					padding-right: 16px;
-					padding-left: 16px;
-				}
-				.grid-area.row .img-main {
-					height: 259px;
-					position: relative;
-				}
-					.grid-area.row .video {
-						background: #000;
-						width: 501px;
-						height: 259px;
-						position: relative;
-					}
-					.grid-area.row .video iframe {
-						width: 501px;
-						height: 259px;
-						border: none;
-					}
-						.grid-area.row .video-opacity {
-							background: rgba(0,0,0,0.5);
-							position: absolute;
-							top: 0;
-							left: 0;
-							width: 100%;
-							height: 100%;
-						}
-						.grid-area.row .btn-play {
-							text-align: center;
-							border: 4px solid #fff;
-							border-radius: 100%;
-							position: absolute;
-							top: 50%;
-							left: 50%;
-							width: 106px;
-							height: 106px;
-							margin: -53px 0 0 -53px;
-						}
-							.grid-area.row .btn-play .icons {
-								background-size: 543px auto;
-								background-position: 0 -71px;
-								width: 78px;
-								height: 78px;
-								margin: 10px 0 0 0;
-							}
-								.grid-area.row .btn-play:hover,
-								.grid-area.row .btn-play:focus {
-									border: 4px solid #1cb0e6;
-								}
-								.grid-area.row .btn-play:hover .icons,
-								.grid-area.row .btn-play:focus .icons {
-									background-position: -78px -71px;
-								}
-					.grid-area.row .img-main img {
-						width: 100%;
-						height: 259px;
-					}
-						.grid-area.row .carousel-control.left,
-						.grid-area.row .carousel-control.right {
-							background-color: rgba(255,255,255,0.5);
-							text-shadow: none;
-							background-image: none;
-							box-shadow: none;
-							opacity: 1;
-							width: 49px;
-							height: 47px;
-							border: 2px solid #fff;
-							top: auto;
-							bottom: 3px;
-						}
-							.grid-area.row .carousel-control.left {
-								left: auto;
-								right: 53px;
-							}
-							.grid-area.row .carousel-control.right {
-								right: 3px;
-							}
-								.grid-area.row .carousel-control.left .icons,
-								.grid-area.row .carousel-control.right .icons {
-									width: 24px;
-									height: 24px;
-									margin-top: 9px;
-								}
-									.grid-area.row .carousel-control.left .icons {
-										background-position: -288px -16px;
-									}
-										.grid-area.row .carousel-control:hover.left .icons {
-											background-position: -336px -16px;
-										}
-									.grid-area.row .carousel-control.right .icons {
-										background-position: -360px -16px;
-									}
-										.grid-area.row .carousel-control:hover.right .icons {
-											background-position: -385px -16px;
-										}
-				.grid-area.row .info-main {
-					color: #4b4b4b;
-					position: relative;
-					padding: 36px 0 30px 0;
-				}
-				 .grid-area.row .info-main .title-h2 a {
-					font-family: 'Source Sans Pro'; font-weight: 700;
-					font-size: 30px;
-					color: #4b4b4b;
-				}
-				.grid-area.row .info-main .title-h2 a:hover {
-					color: #14b1e7;
-				}
-					.grid-area.row .info-main .title-h2 {
-						font-family: 'Source Sans Pro'; font-weight: 700;
-						font-size: 30px;
-						line-height: 35px;
-					}
-					.grid-area.row .info-main .date-txt {
-						font-family: 'Source Sans Pro'; font-weight: 700;
-						font-size: 16px;
-						text-transform: uppercase;
-						line-height: 22px;
-						padding-bottom: 14px;
-						display: block;
-					}
-					.grid-area.row .info-main p {
-						font-size: 14px;
-						line-height: 28px;
-						padding: 0 25px 15px 0;
-					}
-					.grid-area.row .info-main .bottom-bar {
-						padding: 24px 0 30px 0;
-						overflow: hidden;
-					}
-						.grid-area.row .info-main .bottom-bar .btn-read-more {
-							text-transform: uppercase;
-							letter-spacing: 4px;
-							width: 130px;
-							height: 43px;
-							padding: 0 0 0 2px;
-							line-height: 43px;
-							float: left;
-						}
-						.grid-area.row .info-main .bottom-bar .social-ul {
-							float: right;
-							margin: 0 24px 0 0;
-						}
-							.grid-area.row .info-main .bottom-bar .social-ul li {
-								float: left;
-								margin: 0 6px 0 7px;
-							}
-
-		/* .loading-bar */
-		.loading-bar {
-			text-align: center;
-			padding: 0 0 70px 0;
-		}
-			.loading-bar .loading-img {
-				background: url(../images/loading.gif) no-repeat;
-				width: 128px;
-				height: 22px;
-				display: block;
-				margin: 0 auto;
-			}
-
-			/* .blog-details-data */
-			.blog-details-data.container {
-				padding: 0 83px;
-				min-height: 300px;
-			}
-				/* .blog-details-data .title-bar */
-				.blog-details-data.container .title-bar {
-					position: relative;
-					padding: 14px 0 17px 0;
-				}
-					.blog-details-data.container .title-bar .date-txt {
-						font-family: 'Source Sans Pro'; font-weight: 700;
-						font-size: 16px;
-						color: #4b4b4b;
-						line-height: 32px;
-					}
-						.blog-details-data.container .title-bar .social-ul {
-							position: absolute;
-							top: 41px;
-							right: 0;
-						}
-							.blog-details-data.container .title-bar .social-ul li {
-								float: left;
-								margin-left: 13px;
-							}
-				/* .blog-details-data .info-box */
-				.blog-details-data.container .info-box {
-					position: relative;
-				}
-					.blog-details-data.container .info-box .img-main,
-					.blog-details-data.container .info-box .img-main img {
-						height: 536px;
-					}
-						.blog-details-data.container .info-box .img-main img {
-							width: 100%;
-						}
-						.blog-details-data.container .info-box .info-main {
-							border-bottom: 1px solid #c6c6c6;
-							padding: 45px 3px 18px 3px;
-							overflow: hidden;
-						}
-						.blog-details-data.container .info-box .info-main .lefts,
-						.blog-details-data.container .info-box .info-main .rights {
-							color: #4b4b4b;
-							width: 50%;
-							float: left;
-						}
-						.blog-details-data.container .info-box .info-main .lefts p {
-							padding-right: 18px;
-						}
-						.blog-details-data.container .info-box .info-main .rights p {
-							padding-left: 18px;
-						}
-							.blog-details-data.container .info-box .info-main .font20 {
-								font-family: 'Source Sans Pro'; font-weight: 700;
-								font-size: 20px;
-								line-height: 36px;
-							}
-							.blog-details-data.container .info-box .info-main .font14 {
-								font-size: 14px;
-								line-height: 28px;
-							}
-							.blog-details-data.container .info-box .down25 {
-								padding-bottom: 23px;
-							}
-							.blog-details-data.container .info-box .info-main .rights .down25 {
-								padding-bottom: 27px;
-							}
-
-			/* .related-blog-module */
-			.related-blog-module {
-				padding: 26px 0 7px 0;
-			}
-				.related-blog-module .container.grid-data {
-					position: relative;
-				}
-					.related-blog-module .form-area {
-						min-height: 83px;
-					}
-					.related-blog-module .title-related-blog {
-						width: 263px;
-						position: absolute;
-						top: 13px;
-						right: 83px;
-					}
-					.related-blog-module .desktop-show {
-						display: block;
-					}
-					.related-blog-module .mobile-show {
-						display: none;
-					}
-					.related-blog-module .carousel-control.left,
-					.related-blog-module .carousel-control.right {
-						background-color: rgba(40,40,40,0.15);
-						text-shadow: none;
-						background-image: none;
-						box-shadow: none;
-						opacity: 1;
-						width: 49px;
-						height: 47px;
-						border: 2px solid #fff;
-						top: 50%;
-						margin-top: -78px;
-					}
-						.related-blog-module .carousel-control.left {
-							left: -53px;
-						}
-						.related-blog-module .carousel-control.right {
-							right: -53px;
-						}
-							.related-blog-module .carousel-control.left .icons,
-							.related-blog-module .carousel-control.right .icons {
-								width: 24px;
-								height: 24px;
-								margin-top: 9px;
-							}
-								.related-blog-module .carousel-control.left .icons {
-									background-position: -288px -16px;
-								}
-									.related-blog-module .carousel-control:hover.left .icons {
-										background-position: -336px -16px;
-									}
-								.related-blog-module .carousel-control.right .icons {
-									background-position: -360px -16px;
-								}
-									.related-blog-module .carousel-control:hover.right .icons {
-										background-position: -385px -16px;
-									}
-						.related-blog-module .carousel-inner>.active {
-							min-height: 620px;
-						}
-
-		/* .comments-module */
-		.comments-module {
-			background: #f4f4f4;
-			position: relative;
-		}
-			.comments-module .container {
-				padding: 37px 83px 0 83px;
-			}
-				.comments-module .container .title-comments {
-					width: 202px;
-					letter-spacing: 9px;
-					margin-bottom: 20px;
-					padding-left: 20px;
-				}
-				/* .comments-module .comments-area  .comments-list*/
-				.comments-module .comments-area {
-					min-height: 200px;
-				}
-					.comments-module .comments-area .comments-list {
-						padding: 51px 100px 34px 0;
-						border-bottom: 1px solid #c6c6c6;
-						position: relative;
-					}
-					.comments-module .comments-area .spaceleft {
-						padding-left: 100px;
-					}
-					.comments-module .comments-area .spacetop {
-						padding-top: 26px;
-					}
-						.comments-module .comments-area .comments-list .head-img {
-							float: left;
-							width: 130px;
-						}
-							.comments-module .comments-area .comments-list .head-img img {
-								width: 99px;
-								height: 99px;
-							}
-						.comments-module .comments-area .comments-list .info-box {
-							margin-left: 130px;
-						}
-							.comments-module .comments-area .comments-list .info-box .title-h4 {
-								padding: 3px 0 11px 0;
-							}
-								.comments-module .comments-area .comments-list .info-box .title-h4 a {
-									font-family: 'Source Sans Pro'; font-weight: 700;
-									font-size: 18px;
-									color: #282828;
-									text-transform: uppercase;
-								}
-								.comments-module .comments-area .comments-list .info-box .title-h4 a:hover {
-								    color: #00a1d9;
-								}
-							.comments-module .comments-area .comments-list .info-box p {
-								    font-size: 14px;
-								    color: #8a8a8a;
-								    line-height: 24px;
-								    padding: 0 28px 0 0;
-							}
-						.comments-module .comments-area .comments-list .comments-apply {
-							background-color: rgba(41,41,41,0.15);
-							background-image: none;
-							box-shadow: none;
-							opacity: 1;
-							width: 102px;
-							height: 42px;
-							line-height: 42px;
-							letter-spacing: 6px;
-							text-align: center;
-							border: 2px solid #fff;
-							border-bottom-width: 1px;
-							position: absolute;
-							right: 0;
-							bottom: 0px;
-							cursor: pointer;
-						}
-							.comments-module .comments-area .comments-list .comments-apply a {
-								font-family: 'Source Sans Pro'; font-weight: 700;
-								font-size: 14px;
-								color: #898989;
-								display: block;
-								padding-left: 5px;
-
-							}
-								.comments-module .comments-area .comments-list .comments-apply a:hover {
-									color: #1ab1e6;
-									text-decoration: none;
-								}
-				/* .comments-module .comments-area .quick-reply */
-				.comments-module .comments-area .quick-reply {
-					padding: 38px 0 121px 0;
-					position: relative;
-				}
-					.comments-module .comments-area .quick-reply .quick-reply-txt {
-						float: left;
-						width: 130px;
-					}
-						.comments-module .comments-area .quick-reply .quick-reply-txt .title-h4 {
-							padding: 25px 0 22px 0;
-							font-family: 'Source Sans Pro'; font-weight: 700;
-							font-size: 18px;
-							color: #282828;
-							text-transform: uppercase;
-						}
-						.comments-module .comments-area .quick-reply .quick-reply-txt p {
-							font-size: 14px;
-							color: #9d9d9d;
-						}
-							.comments-module .comments-area .quick-reply .quick-reply-txt li {
-							float: left;
-							margin-top: 11px;
-							margin-left: -1px;
-						}
-							.comments-module .comments-area .quick-reply .quick-reply-txt li:nth-child(2) {
-								margin-left: 13px;
-							}
-					.comments-module .comments-area .quick-reply .textarea-box {
-						margin-right: 4px;
-						margin-left: 130px;
-						height: 196px;
-						border: 1px solid #9d9d9d;
-						padding: 21px 29px;
-						display: block;
-						background: #fff;
-					}
-						.comments-module .comments-area .quick-reply .textarea-box textarea {
-							font-size: 12px;
-							color: #9d9d9d;
-							outline: none;
-							border: none;
-							resize: none;
-							width: 100%;
-							height: 115px;
-							line-height: 14px;
-							letter-spacing: 6px;
-						}
-					.comments-module .comments-area .quick-reply .comments-post {
-						background-color: rgba(41,41,41,0.15);
-						background-image: none;
-						box-shadow: none;
-						opacity: 1;
-						width: 101px;
-						height: 43px;
-						line-height: 43px;
-						text-align: center;
-						position: absolute;
-						right: 5px;
-						bottom: 122px;
-						cursor: pointer;
-						letter-spacing: 4px;
-					}
-						.comments-module .comments-area .quick-reply .comments-post a {
-							font-family: 'Source Sans Pro'; font-weight: 700;
-							font-size: 14px;
-							color: #898989;
-							display: block;
-							padding: 2px 0 0 3px;
-
-						}
-							.comments-module .comments-area .quick-reply .comments-post a:hover {
-								color: #1ab1e6;
-								text-decoration: none;
-							}
-
-
-
-
-
-/* .footer */
-.footer {
-	background-color: #282828;
-	min-height: 100px;
-}
-	.footer .container {
-		height: 100%;
-		position: relative;
-		padding: 0;
-		top: 0;
-		left: 0;
-		z-index: 99;
-	}
-	/* .footer .row */
-	.footer .row {
-		margin: 0;
-		padding: 0 112px 0 115px;
-	}
-		.footer .row .col-menu,
-		.footer .row .col-info {
-			float: left;
-			padding: 66px 0 62px 0;
-		}
-			.footer .row .col-menu dt,
-			.footer .row .col-info dt {
-				line-height: 25px;
-			}
-				.footer .row .col-menu dt a,
-				.footer .row .col-info dt a {
-					font-family: 'Source Sans Pro'; font-weight: 700;
-					color: #14b1e7;
-					font-size: 14px;
-					text-transform: uppercase;
-				}
-			.footer .row .col-menu dd,
-			.footer .row .col-info dd {
-				line-height: 24px;
-			}
-		/* .footer .col-menu */
-		.footer .row .col-menu {
-			width: 17%;
-		}
-			.footer .row .col-menu dt {
-				padding-bottom: 0;
-			}
-		/* .footer .col-info */
-		.footer .row .col-info {
-			width: 20.75%;
-		}
-			.footer .row .col-info dt {
-				padding-bottom: 4px;
-			}
-				.footer .row .col-info a {
-					color: #8a8a8a;
-					font-size: 12px;
-				}
-				.footer .row .col-info p {
-					color: #8a8a8a;
-					font-size: 12px;
-					text-align: justify;
-					line-height: 24px;
-					padding: 5px 0 0 0;
-				}
-	/* .footer .bottoms */
-	.footer .bottoms {
-		border-top: 1px solid #393939;
-		margin: 0 121px 0 119px;
-		min-height: 120px;
-	}
-		.footer .bottoms .logo {
-			background: url(../images/logo-white.png) no-repeat;
-			background-size: 171px auto;
-			margin: 16px 0 0 -4px;
-			width: 171px;
-			height: 68px;
-			display: block;
-		}
-		.footer .bottoms .social-ul {
-			margin: 38px -8px 0 0;
-		}
-			.footer .bottoms .social-ul li {
-				float: left;
-				margin: 0 0 0 28px;
-			}
-				.footer .bottoms .social-ul li .icons {
-					width: 24px;
-					height: 24px;
-				}
-					.footer .bottoms .social-ul li .icon-fb {
-						background-position: 0 -16px;
-					}
-						.footer .bottoms .social-ul li .icon-fb:hover {
-							background-position: -24px -16px;
-						}
-					.footer .bottoms .social-ul li .icon-tw {
-						background-position: -48px -16px;
-					}
-						.footer .bottoms .social-ul li .icon-tw:hover {
-							background-position: -72px -16px;
-						}
-					.footer .bottoms .social-ul li .icon-gg {
-						background-position: -96px -16px;
-					}
-						.footer .bottoms .social-ul li .icon-gg:hover {
-							background-position: -120px -16px;
-						}
-
-
-
-/* .modal-default */
-.modal-backdrop.in {
-	filter: alpha(opacity=63);
-	opacity: .63;
-}
-.modal.modal-default .modal-dialog {
-	width: 1170px;
-	margin: 109px auto;
-}
-	.modal.modal-default .modal-content {
-		-webkit-box-shadow: 0 0 40px rgba(34,34,33,.9);
-		box-shadow: 0 0 40px rgba(34,34,33,.9);
-		border-radius: 0;
-		border: none;
-	}
-	/* .modal-default .modal-header */
-	.modal.modal-default .modal-header {
-		text-align: center;
-		padding: 0;
-		border-bottom: none;
-	}
-		.modal.modal-default .btn-close {
-			background-position: 0 0;
-			width: 16px;
-			height: 16px;
-			position: absolute;
-			opacity: 1;
-			top: 54px;
-			right: 61px;
-			z-index: 99;
-		}
-			.modal.modal-default .btn-close:hover {
-				background-position: -16px 0;
-			}
-	/* .modal-default .modal-body */
-	.modal.modal-default .modal-body {
-		padding: 0;
-		min-height: 100px;
-	}
-
-	/* #modal-how-it-works */
-	#modal-how-it-works .title-how-it-works {
-		width: 277px;
-		margin: 44px auto 0 auto;
-	}
-		#modal-how-it-works .txt-info {
-			font-size: 14px;
-			color: #4b4b4b;
-			line-height: 28px;
-			text-align: center;
-			padding: 41px 200px;
-		}
-	  /* #modal-how-it-works .info-row */
-	  #modal-how-it-works .info-row {
-		  padding: 25px 99px 7px 99px;
-	  }
-		  #modal-how-it-works .info-row .video-area .video {
-			  background: #000;
-			  width: 501px;
-			  height: 326px;
-			  position: relative;
-		  }
-		  #modal-how-it-works .info-row .video-area .video iframe {
-			  width: 501px;
-			  height: 326px;
-			  border: none;
-		  }
-			  #modal-how-it-works .info-row .video-area .video-opacity {
-				  background: rgba(0,0,0,0.5);
-				  position: absolute;
-				  top: 0;
-				  left: 0;
-				  width: 100%;
-				  height: 100%;
-			  }
-			  #modal-how-it-works .info-row .video-area .btn-play {
-				  text-align: center;
-				  border: 5px solid #fff;
-				  border-radius: 100%;
-				  position: absolute;
-				  top: 50%;
-				  left: 50%;
-				  width: 130px;
-				  height: 130px;
-				  margin: -75px 0 0 -75px;
-			  }
-				  #modal-how-it-works .info-row .video-area .btn-play .icons {
-					  background-position: 0 -88px;
-					  width: 96px;
-					  height: 96px;
-					  margin: 13px 0 0 0;
-				  }
-					  #modal-how-it-works .info-row .video-area .btn-play:hover,
-					  #modal-how-it-works .info-row .video-area .btn-play:focus {
-						  border: 5px solid #1cb0e6;
-					  }
-					  #modal-how-it-works .info-row .video-area .btn-play:hover .icons,
-					  #modal-how-it-works .info-row .video-area .btn-play:focus .icons {
-						  background-position: -96px -88px;
-					  }
-		  #modal-how-it-works .info-row .step-area {
-			  margin: 3px 530px 0 0;
-			  min-height: 326px;
-			  position: relative;
-		  }
-			  #modal-how-it-works .step-area .module-box {
-				  padding: 0 20px 0 0;
-				  margin-bottom: 44px;
-			  }
-				  #modal-how-it-works .step-area .icon-blue-round {
-					  text-align: center;
-					  background: #00a1d9;
-					  width: 70px;
-					  height: 70px;
-					  border-radius: 100%;
-					  margin-top: 3px;
-				  }
-					  #modal-how-it-works .step-area .icon-blue-round .icons {
-						  width: 48px;
-						  height: 48px;
-						  margin-top: 12px;
-					  }
-						  #modal-how-it-works .step-area .icon-fundraise .icons {
-							  background-position: 0 -40px;
-						  }
-						  #modal-how-it-works .step-area .icon-invest .icons {
-							  background-position: -48px -40px;
-						  }
-						  #modal-how-it-works .step-area .icon-pay-it-forward .icons {
-							  background-position: -96px -40px;
-						  }
-					  #modal-how-it-works .step-area .info-txt {
-						  margin: 0 55px 0 100px;
-					  }
-						  #modal-how-it-works .step-area .info-txt h4 {
-							  font-family: 'Source Sans Pro'; font-weight: 700;
-							  font-size: 18px;
-							  line-height: 20px;
-							  padding-bottom: 10px;
-							  margin-top: -4px;
-						  }
-						  #modal-how-it-works .step-area .info-txt p {
-							  font-size: 14px;
-							  color: #8a8a8a;
-							  line-height: 24px;
-						  }
-
-
-
-/*fix layout issue when smaller than 1221px width*/
-@media (min-width: 1221px) {
-.container {
-    width: 1200px;
-}
-}
-
-
-
-
-/*fix layout issue when smaller than 1200px width*/
-@media (max-width: 1199px) {
-.icons {
-	background: url(../images/icon-sprites.png) no-repeat;
-	background-size: 543px auto;
-}
-/* btn */
-.btn-blue {
-	font-size: 11.57px;
-	height: 43px;
-	line-height: 43px;
-	padding: 2px 5px 0 5px;
-}
-.btn-icon-gray {
-	width: 44px;
-	height: 35px;
-}
-	.btn-icon-gray .icons {
-		width: 19px;
-		height: 19px;
-		margin-top: 6px;
-	}
-		.btn-icon-gray .icon-fb {
-			background-position: -116px -13px;
-		}
-			.btn-icon-gray:hover .icon-fb {
-				background-position: -135px -13px;
-			}
-		.btn-icon-gray .icon-tw {
-			background-position: -155px -13px;
-		}
-			.btn-icon-gray:hover .icon-tw {
-				background-position: -175px -13px;
-			}
-		.btn-icon-gray .icon-gg {
-			background-position: -194px -13px;
-		}
-			.btn-icon-gray:hover .icon-gg {
-				background-position: -213px -13px;
-			}
-
-
-
-	/* .dropdown-default */
-	.dropdown-default .btn-default {
-		font-size: 9.92px;
-		letter-spacing: 4px;
-		padding: 0 22px 0 18px;
-		height: 30px;
-		line-height: 28px;
-	}
-		.dropdown-default .btn-default .icon-arrow-down {
-			background-position: -39px 0;
-			width: 13px;
-			height: 13px;
-			top: 6px;
-			right: 7px;
-		}
-			.dropdown-default .btn-default.active .icon-arrow-down,
-			.dropdown-default .btn-default:active .icon-arrow-down,
-			.open.dropdown-default>.dropdown-toggle.btn-default .icon-arrow-down {
-				background-position: -52px 0;
-			}
-		.dropdown-default .dropdown-menu {
-			font-size: 9.92px;
-			min-width: 30px;
-			padding: 2.5px 0;
-		}
-			.dropdown-default .dropdown-menu>li>a {
-				padding: 0 19px;
-				line-height: 20px;
-			}
-/* title */
-.title-white-border,
-.title-blue-border {
-	font-size: 14.88px;
-	letter-spacing: 7px;
-	height: 35px;
-	line-height: 35px;
-	padding: 0 5px;
-}
-
-
-.container {
-	width: auto;
-}
-
-
-/* .header */
-.header {
-	margin-top: 30px;
-	height: 85px;
-}
-	.header .logo {
-		background: url(../images/logo-white.png) no-repeat;
-		background-size: 141px auto;
-		margin: 9px 0 0 70px;
-		width: 141px;
-		height: 56px;
-	}
-	.header .btn-donate {
-		min-width: 110px;
-	}
-	.header .rights {
-		padding: 15px 54px 0 0;
-	}
-		.header .txt {
-			font-size: 11.57px;
-			padding: 2px 14px 3px 0;
-			line-height: 22px;
-		}
-	/* .after-scroll-header */
-	.header.after-scroll-header .logo {
-		background-size: 141px auto;
-		margin: 14px 0 0 70px;
-		width: 141px;
-		height: 56px;
-	}
-	.header.after-scroll-header .rights {
-		padding: 19px 71px 0 0;
-	}
-
-
-
-/* .top-section */
-.top-section {
-	min-height: 124px;
-}
-	.top-section .sub-section-bg {
-		background: url(../images/small/small-sub-section-bg.jpg) no-repeat center top;
-		background-size: 100% 124px;
-	}
-		.top-section.min-height {
-			min-height: 815px;
-		}
-			.top-section .section-video img {
-				width: 100%;
-				height: 815px;
-			}
-			.top-section .section-video-area iframe,
-			.top-section .section-video-area video,
-			.top-section .section-video-area .mejs-container,
-			.top-section .section-video-area .me-plugin,
-			.top-section .section-video-area embed,
-			.top-section .section-video-area .mejs-overlay-play {
-				width: 100%!important;
-				height: 815px!important;
-				border: none;
-			}
-	.top-section.min-height .container {
-		top: 0;
-		width: 100%;
-		margin-left: 0;
-		left: 0;
-	}
-	/* .top-section .carousel */
-	.top-section .carousel {
-		padding-right: 65px;
-		padding-left: 65px;
-	}
-	/* .top-section .carousel */
-	.top-section .carousel {
-		top: 95px;
-	}
-		/* .top-section .carousel .item */
-		.top-section .carousel .item {
-			padding: 155px 0 0 0;
-			min-height: 673px;
-		}
-			.top-section .carousel .item-info {
-				width: 500px;
-			}
-				.top-section .carousel .item-info .titles {
-					font-size: 39.68px;
-					line-height: 48px;
-				}
-				.top-section .carousel .item-info p {
-					font-size: 16.53px;
-					line-height: 28px;
-					width: 480px;
-					padding: 9px 0 32px 0;
-				}
-				.top-section .carousel .item-info .btn-donate-now {
-					letter-spacing: 4.5px;
-					min-width: 144px;
-					padding-left: 8px;
-				}
-		/* .top-section .carousel-indicators */
-		.top-section .carousel-indicators li {
-			width: 10px;
-			height: 10px;
-		}
-			.top-section .icon-arrow-down {
-				background-position: -194px -32px;
-				width: 40px;
-				height: 40px;
-				bottom: -40px;
-				margin: 0 0 0 -20px;
-			}
-			.top-section .carousel-control.left,
-			.top-section .carousel-control.right {
-				width: 40px;
-				height: 40px;
-				top: 279px;
-			}
-				.top-section .carousel-control.left {
-					left: 13px;
-				}
-				.top-section .carousel-control.right {
-					right: 13px;
-				}
-					.top-section .carousel-control.left .icons,
-					.top-section .carousel-control.right .icons {
-						width: 19px;
-						height: 19px;
-						margin-top: 9px;
-					}
-						.top-section .carousel-control.left .icons {
-							background-position: -252px -13px;
-						}
-							.top-section .carousel-control:hover.left .icons {
-								background-position: -272px -13px;
-							}
-						.top-section .carousel-control.right .icons {
-							background-position: -330px -13px;
-						}
-							.top-section .carousel-control:hover.right .icons {
-								background-position: -311px -13px;
-							}
-							.top-section .carousel-indicators {
-								bottom: 8px;
-							}
-
-
-
-/* home page */
-
-	/* .active-projects-module */
-	.active-projects-module {
-		padding-bottom: 65px;
-	}
-		.active-projects-module .title-active-projects {
-			width: 306px;
-			margin: 45px auto 57px auto;
-		}
-		.active-projects-module .row {
-			margin: 0 80px;
-		}
-			/* .active-projects-module .module-box */
-			.active-projects-module .module-box {
-				margin: 0 15px;
-			}
-				.active-projects-module .img-main .txt-table {
-					height: 241px;
-				}
-					.active-projects-module .img-main .txt {
-						font-size: 24.8px;
-						line-height: 27px;
-						padding: 0 20px 10px 20px;
-					}
-			  .active-projects-module .img-main .funded-round {
-				  width: 110px;
-				  height: 110px;
-				  padding: 8px;
-				  bottom: -55px;
-				  margin: 0 0 0 -55px;
-			  }
-				  .active-projects-module .img-main .funded-round .round-depict {
-					  font-size: 11.57px;
-					  top: 50%;
-					  left: 50%;
-					  width: 94px;
-					  margin: 2px 0 0 -47px;
-				  }
-				  .active-projects-module .img-main .funded-round .status-indicator input {
-					  font-size: 24.8px !important;
-					  margin-top: 22px !important;
-				  }
-						.active-projects-module.embedded .img-main .funded-round .status-indicator input {
-							margin-top: -75px !important;
-							margin-left: 22px !important;
-						}
-						.active-projects-module.embedded .img-main .funded-round .status-indicator input.smaller {
-							font-size: 20.5px !important;
-							margin-top: -73px !important;
-							margin-left: 22px !important;
-							-webkit-transition: font-size 0.25s ease;
-							transition: font-size 0.25s ease;
-						}
-						.active-projects-module .img-main .funded-round .status-indicator input.smaller {
-							font-size: 20px !important;
-							margin-top: 22px !important;
-							-webkit-transition: font-size 0.25s ease;
-							transition: font-size 0.25s ease;
-						}
-				  .small-circle {
-					  display: block;
-				  }
-				  .desktop-circle,
-				  .tablet-circle,
-				  .mobile-circle {
-					  display: none;
-				  }
-		  /* .active-projects-module .info-main */
-		  .active-projects-module .info-main {
-			  padding: 33px 25px 29px 23px;
-		  }
-			  .active-projects-module .info-main .blue-bar,
-			  .active-projects-module .info-main .dark-blue-bar {
-				  font-size: 13.23px;
-				  height: 50px;
-				  line-height: 50px;
-				  padding: 0 11px 0 19px;
-				  margin-top: 16px;
-			  }
-
-	/* .our-impacts-module */
-	.our-impacts-module .title-our-impacts {
-		letter-spacing: 8px;
-		padding-left: 12px;
-		width: 228px;
-		margin: 58px auto 47px auto;
-	}
-		.our-impacts-module .row {
-			margin: 0 58px 0 80px;
-			padding: 0 0 30px 0;
-		}
-				.our-impacts-module .row .col-md-3:nth-child(1) .module-box {
-					width: 140px;
-					margin-left: -11px;
-				}
-					.our-impacts-module .row .col-md-3:nth-child(2) .module-box .titles {
-						padding-right: 30px;
-					}
-					.our-impacts-module .row .col-md-3:nth-child(3) .module-box .icons {
-						margin-left: 5%;
-					}
-					.our-impacts-module .row .col-md-3:nth-child(3) .module-box .titles {
-						padding-top: 14px;
-						line-height: 25px;
-					}
-				.our-impacts-module .row .col-md-3:nth-child(4) .module-box {
-					float: right;
-					width: 155px;
-				}
-					.our-impacts-module .row .col-md-3:nth-child(4) .module-box .titles {
-						padding-top: 14px;
-						line-height: 35px;
-					}
-			.our-impacts-module .module-box .icons {
-				width: 136px;
-				height: 136px;
-			}
-				.our-impacts-module .module-box .icon-people {
-					background-position: 0 -149px;
-				}
-				.our-impacts-module .module-box .icon-home-ok {
-					background-position: -136px -149px;
-				}
-				.our-impacts-module .module-box .icon-tree {
-					background-position: -272px -149px;
-				}
-				.our-impacts-module .module-box .icon-user {
-					background-position: -407px -149px;
-				}
-					.our-impacts-module .module-box .titles {
-						line-height: 45px;
-					}
-						.our-impacts-module .module-box .font20 {
-							font-size: 16.53px;
-						}
-						.our-impacts-module .module-box .font48 {
-							font-size: 39.68px;
-						}
-						.our-impacts-module .module-box .font72 {
-							font-size: 59.52px;
-						}
-					.our-impacts-module .module-box .txt {
-						font-size: 14.88px;
-						line-height: 17px;
-						padding-top: 6px
-					}
-
-	/* .how-it-works-module */
-	.how-it-works-module .container {
-		padding: 0;
-	}
-		.how-it-works-module .title-how-it-works {
-			letter-spacing: 8px;
-			width: 230px;
-			margin: 48px auto 0 auto;
-		}
-			/* .how-it-works-module .info-row */
-			.how-it-works-module .info-row {
-				padding: 47px 74px 0 95px;
-			}
-				.how-it-works-module .info-row .video-area .video,
-				.how-it-works-module .info-row .video-area .video img,
-				.how-it-works-module .info-row .video-area .video iframe {
-					width: 414px;
-					height: 269px;
-				}
-					.how-it-works-module .info-row .video-area .btn-play {
-						width: 108px;
-						height: 108px;
-						margin: -54px 0 0 -54px;
-					}
-						.how-it-works-module .info-row .video-area .btn-play .icons {
-							background-position: 0 -71px;
-							width: 78px;
-							height: 78px;
-							margin: 8px 0 0 0;
-						}
-							.how-it-works-module .info-row .video-area .btn-play:hover .icons,
-							.how-it-works-module .info-row .video-area .btn-play:focus .icons {
-								background-position: -78px -71px;
-							}
-				.how-it-works-module .info-row .txt-area {
-					margin: 0 436px 0 0;
-				}
-				.how-it-works-module .info-row .txt-area .txt-table {
-					min-height: 269px;
-				}
-					.how-it-works-module .info-row .txt-area .txt-td p {
-						font-size: 11.57px;
-						line-height: 23px;
-						letter-spacing: 0;
-					}
-			/* .how-it-works-module .step-row */
-			.how-it-works-module .step-row {
-				margin: 53px 74px 0 95px;
-			}
-				.how-it-works-module .step-row .module-box {
-					position: relative;
-					padding-top: 10px;
-					min-height: 141px;
-				}
-					.how-it-works-module .step-row .icon-blue-round {
-						width: 58px;
-						height: 58px;
-					}
-						.how-it-works-module .step-row .icon-blue-round .icons {
-							width: 39px;
-							height: 39px;
-							margin-top: 9px;
-						}
-							.how-it-works-module .step-row .icon-fundraise .icons {
-								background-position: -0 -32px;
-							}
-							.how-it-works-module .step-row .icon-invest .icons {
-								background-position: -39px -32px;
-							}
-							.how-it-works-module .step-row .icon-pay-it-forward .icons {
-								background-position: -78px -32px;
-							}
-					.how-it-works-module .step-row .icon-arrow-right {
-						background-position: -116px -32px;
-						width: 39px;
-						height: 39px;
-						top: 29px;
-						right: 14px;
-					}
-					.how-it-works-module .step-row .info-txt {
-						margin: 0 45px 0 80px;
-					}
-						.how-it-works-module .step-row .info-txt h4 {
-							font-size: 14.88px;
-							line-height: 20px;
-							padding-bottom: 4px;
-							margin-top: -7px;
-						}
-						.how-it-works-module .step-row .info-txt p {
-							font-size: 11.57px;
-							line-height: 21px;
-						}
-
-	/* .how-it-works-module */
-	.testimonial-module {
-		padding-bottom: 52px;
-	}
-		.testimonial-module .title-testimonial {
-			padding-left: 10px;
-			width: 192px;
-			margin: 44px auto 0 auto;
-		}
-			/* .testimonial-module .head-row */
-			.testimonial-module .head-row {
-				padding: 53px 86px 0 64px;
-			}
-				.testimonial-module .head-row li .head-img {
-					margin: 22px 20px;
-				}
-				/*.testimonial-module .head-row li .head-img:hover,
-				.testimonial-module .head-row li .head-img:focus,*/
-				.testimonial-module .head-row li .head-img.active {
-					border-radius: 4px;
-					padding: 16px 18px;
-				}
-					/*.testimonial-module .head-row li .head-img:hover .icon-arrow-down,
-					.testimonial-module .head-row li .head-img:focus .icon-arrow-down,*/
-					.testimonial-module .head-row li .head-img.active .icon-arrow-down {
-						background-position: -162px -45px;
-						width: 24px;
-						height: 18px;
-						bottom: -18px;
-						margin: 0 0 0 -12px;
-					}
-					.testimonial-module .head-row li .head-img img {
-						width: 60px;
-						height: 60px;
-						border-radius: 4px;
-					}
-			/* .testimonial-module .info-area */
-			.testimonial-module .info-area {
-				padding: 39px 0 0 0;
-			}
-				.testimonial-module .info-area p {
-					font-size: 11.57px;
-					line-height: 23px;
-					width: 640px;
-					padding-bottom: 15px;
-				}
-					.testimonial-module .info-area .block {
-						display: block;
-					}
-					    .testimonial-module .user-group {
-							padding-top: 8px;
-						}
-							.testimonial-module .user-group .link-blue {
-								font-size: 14.88px;
-							}
-							.testimonial-module .user-group .txt {
-								font-size: 11.57px;
-								line-height: 25px;
-								padding: 3px 0 30px 0;
-							}
-							.testimonial-module .user-group .btn-blue {
-								font-size: 11.57px;
-								height: 34px;
-								line-height: 34px;
-								min-width: 246px;
-								letter-spacing: 3px;
-							}
-
-	/* .featured-on-module */
-	.featured-on-module {
-		padding-bottom: 31px;
-	}
-		.featured-on-module .title-featured-on {
-			font-size: 14.88px;
-			letter-spacing: 7px;
-			padding-left: 12px;
-			width: 200px;
-			margin: 35px auto 43px auto;
-		}
-			/* .featured-on-module .carousel-main */
-			.featured-on-module .carousel-main {
-				min-height: 141px;
-				margin-right: 50px;
-				margin-left: 50px;
-			}
-				.featured-on-module .carousel-main .logo-ul li {
-					height: 141px;
-				}
-					.featured-on-module .logo-fast-mpany {
-						background-size: 127.5px auto;
-						width: 127.5px;
-						height: 19px;
-					}
-					.featured-on-module .logo-ehe-new-hork-eimes {
-						background-size: 115.5px auto;
-						width: 116px;
-						height: 96px;
-					}
-					.featured-on-module .logo-shareable {
-						background-size: 119px auto;
-						width: 119px;
-						height: 17px;
-					}
-						.featured-on-module .logo-shareable:hover,
-						.featured-on-module .logo-shareable:focus {
-							background-position: center -16px;
-						}
-					.featured-on-module .logo-philanthropy {
-						background-size: 126px auto;
-						width: 126px;
-						height: 23px;
-					}
-					.featured-on-module .logo-clean-technica {
-						background-size: 126px auto;
-						width: 126px;
-						height: 37px;
-						margin-bottom: 13px;
-					}
-						.featured-on-module .logo-clean-technica:hover,
-						.featured-on-module .logo-clean-technica:focus {
-							background-position: center -36.5px;
-						}
-						.featured-on-module .carousel-control.left,
-						.featured-on-module .carousel-control.right {
-							width: 41px;
-							height: 39px;
-							top: 43px;
-						}
-							.featured-on-module .carousel-control.left {
-								left: -52px;
-							}
-							.featured-on-module .carousel-control.right {
-								right: -52px;
-							}
-								.featured-on-module .carousel-control.left .icons,
-								.featured-on-module .carousel-control.right .icons {
-									width: 19px;
-									height: 19px;
-									margin: 8px auto 0 auto;
-								}
-									.featured-on-module .carousel-control.left .icons {
-										background-position: -233px -13px;
-									}
-										.featured-on-module .carousel-control:hover.left .icons {
-											background-position: -272px -13px;
-										}
-									.featured-on-module .carousel-control.right .icons {
-										background-position: -291px -13px;
-									}
-										.featured-on-module .carousel-control:hover.right .icons {
-											background-position: -310px -13px;
-										}
-
-	/* .newsletter-module */
-	.newsletter-module {
-		height: 370px;
-	}
-	.newsletter-module .desktop-img {
-		display: none;
-	}
-	.newsletter-module .small-img {
-		display: block;
-	}
-	.newsletter-module .img-area .small-img {
-		min-height: 371px;
-        background: transparent;
-	}
-	.newsletter-module .img-area img {
-		height: 371px;
-	}
-		.newsletter-module .title-newsletter {
-			height: 36px;
-			line-height: 36px;
-			letter-spacing: 7px;
-			padding-left: 12px;
-			width: 306px;
-			margin: 69px auto 32px auto;
-		}
-			/* .newsletter-module .container */
-			.newsletter-module .container {
-				margin: 0;
-				width: 100%;
-				left: 0;
-			}
-				.newsletter-module .group-main p {
-					font-size: 16.53px;
-					line-height: 25px;
-					padding: 0 0 26px 0;
-				}
-				.newsletter-module .group-main .group {
-					min-height: 93px;
-					margin: 0 134px 0 139px;
-					padding: 26px 25px 24px 50px;
-				}
-					.newsletter-module .group-main .group .btn-sign-up {
-						font-size: 11.57px;
-						letter-spacing: 4px;
-						height: 43px;
-						line-height: 43px;
-						width: 110px;
-                        border: none;
-					}
-					.newsletter-module .group-main .group .inputs {
-						margin-right: 120px;
-						height: 43px;
-					}
-						.newsletter-module .group-main .group .inputs input {
-							font-size: 21.49px;
-							height: 43px;
-							line-height: 43px;
-						}
-
-
-
-/* .contents */
-.contents {
-	min-height: 124px;
+  min-height: 450px;
 }
 .top150 {
-	margin-top: 124px;
+  margin-top: 150px;
+}
+.top100 {
+  margin-top: 100px;
 }
 
-	/* .titles */
-	.titles.container {
-		padding: 35px 0 0 0;
-		min-height: 83px;
-	}
-		.titles.container .title-get-involved {
-			margin-right: 69px;
-			min-width: 225px;
-			letter-spacing: 9px;
-			padding-left: 12px;
-		}
-		.title-h1 {
-			font-size: 39.68px;
-			line-height: 48px;
-		}
+/* .titles */
+
+.titles.container {
+  padding: 43px 0 0 0;
+  min-height: 103px;
+}
+.titles.container .title-get-involved {
+  margin-right: 83px;
+  min-width: 272px;
+  letter-spacing: 9px;
+  padding-left: 20px;
+}
+.title-h1 {
+  font-family: 'Source Sans Pro';
+  font-weight: 900;
+  font-size: 48px;
+  color: #2c3691;
+  line-height: 56px;
+}
+
+/* sign in page */
+
+.contents.sign-in-contents {
+  min-height: 508px;
+}
+.contents.sign-in-contents .container {
+  padding: 0;
+}
+.sign-in {
+  padding: 43px 83px 102px 83px;
+}
+.sign-in .title-sign-in {
+  float: right;
+  padding-left: 31px;
+  padding-right: 21px;
+}
+
+/* .sign-in .sign-in-left */
+
+.sign-in .sign-in-left {
+  float: left;
+  padding-top: 71px;
+}
+.sign-in .sign-in-left h2 {
+  font-family: 'Source Sans Pro';
+  font-weight: 900;
+  font-size: 48px;
+  line-height: 52px;
+  color: #2e3192;
+  margin-bottom: 9px;
+}
+.sign-in .sign-in-left p {
+  font-size: 14px;
+  line-height: 24px;
+  color: #4b4b4b;
+  padding-left: 4px;
+}
+.sign-in .sign-in-left p i {
+  display: block;
+}
+.sign-in .sign-in-left .account {
+  margin-top: 27px;
+}
+.sign-in .sign-in-left a {
+  font-size: 14px;
+  line-height: 20px;
+  color: #14b1e7;
+  padding-left: 4px;
+}
+
+/* .sign-in .login-area */
+
+.sign-in .login-area {
+  padding: 140px 231px 0 332px;
+}
+.sign-in .login-area .input-wrap {
+  width: 100%;
+  height: 55px;
+  border: 1px solid #9d9d9d;
+  background-color: #f0f0f0;
+  margin-bottom: 11px;
+}
+.sign-in .login-area .input-wrap.input-error-style {
+  border-color: #f00;
+}
+.sign-in .login-area .input-wrap input {
+  border: none;
+  outline: none;
+  width: 100%;
+  height: 100%;
+  background-color: #f0f0f0;
+  font-size: 12px;
+  line-height: 16px;
+  color: #9d9d9d;
+  padding-left: 31px;
+  padding-right: 31px;
+  letter-spacing: 6px;
+}
+.sign-in .check-wrap {
+  display: block;
+  overflow: hidden;
+  min-height: 47px;
+  padding: 9px 0 16px 0;
+}
+.sign-in .login-area .btn-login {
+  padding-left: 23px;
+  padding-right: 19px;
+  height: 43px;
+  line-height: 43px;
+  letter-spacing: 4px;
+}
+
+/* sign up page */
+
+.contents.sign-up-contents {
+  min-height: 851px;
+}
+.contents.sign-up-contents .container {
+  padding: 0;
+}
+.sign-up {
+  padding: 43px 83px 102px 83px;
+}
+.sign-up .title-sign-up {
+  float: right;
+  padding-left: 23px;
+  padding-right: 16px;
+}
+
+/* .sign-up .sign-up-left */
+
+.sign-up .sign-up-left {
+  float: left;
+  padding-top: 76px;
+}
+.sign-up .sign-up-left h2 {
+  font-family: 'Source Sans Pro';
+  font-weight: 900;
+  font-size: 48px;
+  line-height: 52px;
+  color: #2e3192;
+  margin-bottom: 4px;
+}
+.sign-up .sign-up-left p {
+  font-size: 14px;
+  line-height: 28px;
+  color: #4b4b4b;
+  padding-left: 4px;
+}
+.sign-up .sign-up-left p i {
+  display: block;
+}
+.sign-up .sign-up-left .account {
+  margin-top: 27px;
+}
+.sign-up .sign-up-left a {
+  font-size: 14px;
+  line-height: 28px;
+  color: #14b1e7;
+  padding-left: 4px;
+}
+
+/* .sign-up .reg-area */
+
+.sign-up .reg-area {
+  padding: 140px 231px 0 332px;
+}
+.sign-up .reg-area .input-wrap {
+  width: 100%;
+  height: 55px;
+  border: 1px solid #9d9d9d;
+  background-color: #f0f0f0;
+  margin-bottom: 11px;
+}
+.sign-up .reg-area .input-wrap.input-error-style {
+  border-color: #f00;
+}
+.sign-up .reg-area .input-wrap.less-margin {
+  margin-bottom: 9px;
+}
+.sign-up .reg-area .input-wrap.high-margin {
+  margin-bottom: 13px;
+}
+.sign-up .reg-area .input-wrap.higher-margin {
+  margin-bottom: 17px;
+}
+.sign-up .reg-area .input-wrap input {
+  border: none;
+  outline: none;
+  width: 100%;
+  height: 100%;
+  background-color: #f0f0f0;
+  font-size: 12px;
+  line-height: 16px;
+  color: #9d9d9d;
+  padding-left: 31px;
+  padding-right: 31px;
+  letter-spacing: 6px;
+}
+.sign-up .check-wrap {
+  display: block;
+  overflow: hidden;
+  min-height: 45px;
+  padding: 13px 0 10px 0;
+}
+.sign-up .reg-area p {
+  font-size: 12px;
+  line-height: 24px;
+  color: #4b4b4b;
+  padding-left: 30px;
+  padding-right: 120px;
+  margin-bottom: 17px;
+  display: block;
+}
+.sign-up .reg-area .btn-signup {
+  padding-left: 13px;
+  padding-right: 10px;
+  height: 43px;
+  line-height: 43px;
+  letter-spacing: 4px;
+}
+
+/* what do page */
+
+.contents.what-we-do-contents {
+  min-height: 1000px;
+}
+.contents.what-we-do-contents .container {
+  padding: 0;
+}
+.what-we-do-contents .article-detail {
+  padding: 43px 84px 107px 85px;
+}
+
+/* .article-detail */
+
+.article-detail {
+  padding: 43px 84px 129px 85px;
+}
+.article-detail .title-do {
+  float: right;
+  padding-left: 23px;
+  padding-right: 18px;
+  word-spacing: 2px;
+}
+.article-detail .detail-left {
+  padding-right: 300px;
+  padding-top: 55px;
+}
+.article-detail .detail-left .title-img {
+  width: 700px;
+  height: 270px;
+  margin-bottom: 43px;
+}
+.article-detail .detail-left .title-img img {
+  width: 100%;
+  height: 100%;
+}
+.article-detail .detail-left h2 {
+  font-family: 'Source Sans Pro';
+  font-weight: 900;
+  font-size: 48px;
+  line-height: 56px;
+  color: #2c3691;
+  padding-right: 50px;
+}
+.article-detail .detail-left p {
+  font-size: 14px;
+  line-height: 28px;
+  color: #4b4b4b;
+  margin-top: 29px;
+  padding-right: 90px;
+}
+.article-detail .detail-left .btn-group {
+  padding-top: 18px;
+  padding-right: 40px;
+  width: 960px;
+}
+.article-detail .detail-left .btn-group .btn-blue {
+  display: block;
+  float: left;
+  font-family: 'Source Sans Pro';
+  font-weight: 700;
+  font-size: 14px;
+  line-height: 43px;
+  height: 43px;
+  margin-bottom: 22px;
+  letter-spacing: 4px;
+  margin-right: 28px;
+}
+.article-detail .detail-left .btn-group .btn-leasing {
+  padding-left: 19px;
+  padding-right: 11px;
+  margin-top: 4px;
+}
+.article-detail .detail-left .btn-group .btn-communities {
+  padding-left: 19px;
+  padding-right: 13px;
+  margin-bottom: 26px;
+}
+.article-detail .detail-left .btn-group .btn-services {
+  padding-left: 32px;
+  padding-right: 33px;
+}
+
+/* about us page */
+
+.contents.about-us-contents {
+  min-height: 600px;
+}
+.contents.about-us-contents .container {
+  padding: 0;
+}
+.about-us {
+  padding: 43px 84px 102px 85px;
+}
+.about-us .title-about-us {
+  float: right;
+  padding-left: 28px;
+  padding-right: 24px;
+}
+.about-us .about-us-left {
+  padding-right: 250px;
+  padding-top: 73px;
+}
+.about-us .about-us-left h2 {
+  font-family: 'Source Sans Pro';
+  font-weight: 700;
+  font-size: 48px;
+  line-height: 60px;
+  color: #2c3691;
+}
+.about-us .about-us-left p {
+  font-size: 14px;
+  line-height: 28px;
+  color: #4b4b4b;
+  margin-top: 8px;
+  margin-bottom: 35px;
+  padding-right: 140px;
+}
+.about-us .about-us-left .btn-works {
+  font-family: 'Source Sans Pro';
+  font-weight: 700;
+  font-size: 14px;
+  line-height: 43px;
+  height: 43px;
+  letter-spacing: 4px;
+  padding-left: 28px;
+  padding-right: 26px;
+}
+
+/* .mains-tabs */
+
+.mains-tabs .tab-index .row {
+  padding-right: 360px;
+  padding-left: 80px;
+  margin: 0;
+}
+.mains-tabs .tab-index .row .col-lg-3 {
+  padding: 0;
+  padding-right: 1px;
+}
+.mains-tabs .tab-index .row .col-lg-3 a {
+  display: block;
+  font-family: 'Source Sans Pro';
+  font-weight: 700;
+  font-size: 16px;
+  height: 53px;
+  line-height: 53px;
+  color: rgba(138, 138, 138, 0.5);
+  background-color: #ededed;
+  border-top: 4px solid #fff;
+  text-decoration: none;
+  text-align: center;
+}
+.mains-tabs .tab-index .row .col-lg-3 a:hover, .mains-tabs .tab-index .row .col-lg-3 a.active {
+  border-top: 4px solid #00a1d9;
+  color: #4b4b4b;
+  background-color: #f4f4f4;
+}
+.mains-tabs .tab-content {
+  min-height: 412px;
+  background-color: #f4f4f4;
+}
+.mains-tabs .tab-content .tab-why, .mains-tabs .tab-content .tab-how, .mains-tabs .tab-content .tab-funded, .mains-tabs .tab-content .tab-involved {
+  display: none;
+  padding-left: 85px;
+}
+.mains-tabs .tab-content .tab-why.active, .mains-tabs .tab-content .tab-how.active, .mains-tabs .tab-content .tab-funded.active, .mains-tabs .tab-content .tab-involved.active {
+  display: block;
+}
+.mains-tabs .tab-content .img-left {
+  float: left;
+  margin-top: 56px;
+  width: 300px;
+  height: 216px;
+}
+.mains-tabs .tab-content .img-left img {
+  width: 100%;
+  height: 100%;
+}
+.mains-tabs .tab-content .img-left .desktop-img {
+  display: block;
+}
+.mains-tabs .tab-content .img-left .small-img {
+  display: none;
+}
+.mains-tabs .tab-content .content-right {
+  margin-left: 330px;
+}
+.mains-tabs .tab-content .content-right p {
+  font-size: 14px;
+  line-height: 28px;
+  color: #4b4b4b;
+}
+.mains-tabs .tab-content .tab-why .content-right p {
+  padding-top: 111px;
+  padding-right: 280px;
+}
+.mains-tabs .tab-content .tab-how .content-right, .mains-tabs .tab-content .tab-funded .content-right {
+  padding-top: 45px;
+}
+.mains-tabs .tab-content .tab-how .content-right p, .mains-tabs .tab-content .tab-funded .content-right p {
+  margin-bottom: 28px;
+  padding-right: 96px;
+}
+.mains-tabs .tab-content .tab-involved .content-right {
+  padding-top: 52px;
+}
+.mains-tabs .tab-content .tab-involved .btn-blue {
+  float: left;
+  margin-right: 70px;
+  margin-bottom: 25px;
+  font-family: 'Source Sans Pro';
+  font-weight: 700;
+  font-size: 14px;
+  line-height: 43px;
+  width: 300px;
+  height: 43px;
+  letter-spacing: 4px;
+}
+
+/* get involved page */
 
 
-	/* sign in page */
-	.contents.sign-in-contents {
-		min-height: 420px;
-		margin-top: 124px;
-	}
-	.sign-in {
-		padding: 35px 68px 84px 68px;
-	}
-		.sign-in .title-sign-in {
-			padding-left: 23px;
-			padding-right: 16px;
-			height: 36px;
-			line-height: 36px;
-			font-size: 15px;
-			letter-spacing: 7px;
-		}
-		/* .sign-in .sign-in-left */
-		.sign-in .sign-in-left {
-			padding-top: 56px;
-		}
-			.sign-in .sign-in-left h2 {
-				font-size: 40px;
-				line-height: 48px;
-				margin-bottom: 7px;
-			}
-			.sign-in .sign-in-left p {
-				font-size: 12px;
-				line-height: 20px;
-			}
-			.sign-in .sign-in-left .account {
-				margin-top: 19px;
-			}
-			.sign-in .sign-in-left a {
-				font-size: 12px;
-				line-height: 20px;
-			}
-			/* .sign-in .login-area */
-			.sign-in .login-area {
-				padding: 116px 193px 0 275px;
-			}
-				.sign-in .login-area .input-wrap {
-					height: 46px;
-					margin-bottom: 9px;
-				}
-					.sign-in .login-area .input-wrap input {
-						font-size: 10px;
-						line-height: 16px;
-						padding-left: 25px;
-						padding-right: 25px;
-						letter-spacing: 5px;
-					}
-				.sign-in .check-wrap {
-					min-height: 39px;
-					padding: 6px 0 11px 0;
-				}
-				.sign-in .login-area .btn-login {
-					padding-left: 20px;
-					padding-right: 21px;
-					height: 36px;
-					line-height: 36px;
-					font-size: 12px;
-					letter-spacing: 2px;
-				}
+/* .info-area */
 
+.info-area.container {
+  padding: 0 83px 35px 83px;
+}
+.info-area.container .title-h1 {
+  padding: 15px 600px 28px 0;
+}
+.info-area.container .txt {
+  font-size: 14px;
+  color: #4b4b4b;
+  line-height: 28px;
+  padding-right: 430px;
+  padding-bottom: 17px;
+}
 
-	/* sign up page */
-	.contents.sign-up-contents {
-		min-height: 600px;
-		margin-top: 124px;
-	}
-	.sign-up {
-		padding: 35px 69px 52px 69px;
-	}
-		.sign-up .title-sign-up {
-			padding-left: 17px;
-			padding-right: 10px;
-			height: 36px;
-			line-height: 36px;
-			font-size: 15px;
-			letter-spacing: 7px;
-		}
-		/* .sign-in .sign-in-left */
-		.sign-up .sign-up-left {
-			padding-top: 61px;
-		}
-			.sign-up .sign-up-left h2 {
-				font-size: 40px;
-				line-height: 48px;
-				margin-bottom: 1px;
-			}
-			.sign-up .sign-up-left p {
-				font-size: 12px;
-				line-height: 23px;
-			}
-			.sign-up .sign-up-left .account {
-				margin-top: 23px;
-			}
-			.sign-up .sign-up-left a {
-				font-size: 12px;
-				line-height: 23px;
-			}
-			/* .sign-up .reg-area */
-			.sign-up .reg-area {
-				padding: 116px 192px 0 275px;
-			}
-				.sign-up .reg-area .input-wrap {
-					height: 46px;
-					margin-bottom: 9px;
-				}
-				.sign-up .reg-area .input-wrap.less-margin {
-					margin-bottom: 6px;
-				}
-				.sign-up .reg-area .input-wrap.high-margin {
-					margin-bottom: 11px;
-				}
-				.sign-up .reg-area .input-wrap.higher-margin {
-					margin-bottom: 13px;
-				}
-					.sign-up .reg-area .input-wrap input {
-						font-size: 10px;
-						line-height: 16px;
-						padding-left: 25px;
-						padding-right: 25px;
-						letter-spacing: 5px;
-					}
-				.sign-up .reg-area p {
-					font-size: 10px;
-					line-height: 20px;
-					padding-left: 25px;
-					padding-right: 100px;
-					margin-bottom: 14px;
-				}
-				.sign-up .reg-area .btn-signup {
-					padding-left: 10px;
-					padding-right: 8px;
-					height: 36px;
-					line-height: 36px;
-					letter-spacing: 3px;
-				}
+/* .list-area */
 
+.list-area.container {
+  padding: 0 83px 40px 83px;
+}
 
-	/* what do page */
-	.contents.what-we-do-contents {
-		min-height: 800px;
-		margin-top: 124px;
-	}
-		/* .article-detail */
-		.article-detail {
-			padding: 35px 69px 106px 70px;
-		}
-			.article-detail .title-do {
-				padding-left: 22px;
-				padding-right: 17px;
-				word-spacing: 2px;
-				font-size: 15px;
-				height: 36px;
-				line-height: 36px;
-				letter-spacing: 6px;
-			}
-			.article-detail .detail-left {
-				padding-right: 250px;
-				padding-top: 46px;
-			}
-			.article-detail .detail-left .title-img {
-				width: 579px;
-				height: 223px;
-				margin-bottom: 33px;
-			}
-			.article-detail .detail-left h2 {
-				font-size: 40px;
-				line-height: 48px;
-				padding-right: 50px;
-				padding-bottom: 3px;
-			}
-			.article-detail .detail-left p {
-				font-size: 12px;
-				line-height: 24px;
-				margin-top: 21px;
-				padding-right: 80px;
-			}
-			.article-detail .detail-left .btn-group {
-				padding-top: 13px;
-				width: auto;
-			}
-				.article-detail .detail-left .btn-group .btn-blue {
-					font-size: 12px;
-					line-height: 36px;
-					height: 36px;
-					letter-spacing: 3px;
-					margin-right: 23px;
-					margin-bottom: 18px;
-				}
-				.article-detail .detail-left .btn-group .btn-leasing {
-					padding-left: 16px;
-					padding-right: 11px;
-					margin-top: 4px;
-				}
-				.article-detail .detail-left .btn-group .btn-communities {
-					padding-left: 17px;
-					padding-right: 10px;
-					margin-bottom: 22px;
-					margin-right: 0;
-				}
-				.article-detail .detail-left .btn-group .btn-services {
-					padding-left: 27px;
-					padding-right: 29px;
-				}
+/* .list-area .row */
 
+.list-area .row {
+  margin: 0 0 65px 0;
+}
 
-	/* about us page */
-	.contents.about-us-contents {
-		min-height: 490px;
-		margin-top: 124px;
-	}
-	.about-us {
-		padding: 35px 69px 84px 70px;
-	}
-		.about-us .title-about-us {
-    		font-size: 15px;
-			height: 36px;
-			line-height: 36px;
-			padding-left: 19px;
-			padding-right: 13px;
-		}
-		.about-us .about-us-left {
-			padding-right: 220px;
-			padding-top: 60px;
-		}
-		.about-us .about-us-left h2 {
-			font-size: 40px;
-			line-height: 50px;
-		}
-		.about-us .about-us-left p {
-			font-size: 12px;
-			line-height: 24px;
-			margin-top: 6px;
-			margin-bottom: 27px;
-			padding-right: 100px;
-		}
-		.about-us .about-us-left .btn-works {
-			font-size: 12px;
-			line-height: 36px;
-			height: 36px;
-			letter-spacing: 3px;
-			padding-left: 24px;
-			padding-right: 22px;
-		}
-		/* .mains-tabs */
-		.mains-tabs .tab-index .row {
-			padding-right: 297px;
-			padding-left: 66px;
-		}
-			.mains-tabs .tab-index .row .col-lg-3 a {
-				font-size: 14px;
-				height: 44px;
-				line-height: 44px;
-			}
-		.mains-tabs .tab-content {
-			min-height: 342px;
-		}
-		.mains-tabs .tab-content .tab-why,
-		.mains-tabs .tab-content .tab-how,
-		.mains-tabs .tab-content .tab-funded,
-		.mains-tabs .tab-content .tab-involved {
-			padding-left: 70px;
-		}
-			.mains-tabs .tab-content .img-left {
-				float: left;
-				margin-top: 46px;
-				width: 249px;
-				height: 180px;
-			}
-			.mains-tabs .tab-content .content-right {
-				margin-left: 274px;
-			}
-				.mains-tabs .tab-content .content-right p {
-					font-size: 12px;
-					line-height: 24px;
-				}
-				.mains-tabs .tab-content .tab-why .content-right p {
-					padding-top: 91px;
-					padding-right: 240px;
-				}
-				.mains-tabs .tab-content .tab-how .content-right,
-				.mains-tabs .tab-content .tab-funded .content-right  {
-					padding-top: 37px;
-				}
-					.mains-tabs .tab-content .tab-how .content-right p,
-					.mains-tabs .tab-content .tab-funded .content-right p {
-						margin-bottom: 20px;
-						padding-right: 66px;
-					}
-				.mains-tabs .tab-content .tab-involved .content-right {
-					padding-top: 44px;
-				}
-					.mains-tabs .tab-content .tab-involved .btn-blue {
-						margin-right: 58px;
-						margin-bottom: 20px;
-						font-size: 12px;
-						line-height: 36px;
-						width: 248px;
-						height: 36px;
-						letter-spacing: 3px;
-					}
+/* .list-area  .lefts */
 
+.list-area .row .lefts {
+  float: left;
+  width: 499px;
+}
+.list-area .desktop-img {
+  display: block;
+}
+.list-area .mobile-img {
+  display: none;
+}
 
-	/* get involved page */
+/* .list-area .img-main */
 
-		/* .info-area */
-		.info-area.container {
-			padding: 0 69px 35px 69px;
-		}
-			.info-area.container .title-h1 {
-				padding: 12px 460px 20px 0;
-			}
-			.info-area.container .txt {
-				font-size: 11.57px;
-				line-height: 24px;
-				padding-right: 340px;
-				padding-bottom: 17px;
-			}
+.list-area .img-main {
+  position: relative;
+}
+.list-area .img-main .img-link {
+  background-color: #000;
+  display: block;
+}
+.list-area .img-main .img-link img {
+  opacity: 0.9;
+  width: 100%;
+}
+.list-area .img-main .img-link:hover img {
+  opacity: 1;
+}
+.list-area .mobile-show {
+  display: none;
+}
+.list-area .img-main .funded-round {
+  background-color: #fff;
+  width: 118px;
+  height: 120px;
+  padding: 5px;
+  border-radius: 100%;
+  position: absolute;
+  bottom: -99px;
+  margin: 0 0 0 -60px;
+  left: 50%;
+  z-index: 109;
+}
+.get-involved-contents .funded-round .status-indicator {
+  margin: 1px 0 0 -2px;
+}
+.get-involved-contents .funded-round .round-depict {
+  font-family: 'Source Sans Pro';
+  font-weight: 700;
+  font-size: 14px;
+  color: #039;
+  text-align: center;
+  display: block;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 110px;
+  margin: 2px 0 0 -55px;
+}
+.get-involved-contents .funded-round .status-indicator input {
+  font-size: 30px !important;
+  margin-top: 27px !important;
+}
 
-		/* .list-area */
-		.list-area.container {
-			padding: 0 69px 34px 69px;
-		}
-			/* .list-area .row */
-			.list-area .row {
-				margin: 0 0 54px 0;
-			}
-				/* .list-area  .lefts */
-				.list-area .row .lefts {
-					width: 415px;
-				}
-					/* .list-area .img-main */
-					.list-area .img-main .funded-round {
-						width: 100px;
-						height: 100px;
-						bottom: -83px;
-						margin: 0 0 0 -50px;
-					}
-						.get-involved-contents .funded-round .status-indicator {
-							margin: 0 0 0 -2px;
-						}
-						.get-involved-contents .funded-round .round-depict {
-							font-size: 11.57px;
-							width: 110px;
-							margin: 2px 0 0 -55px;
-						}
-						.get-involved-contents .funded-round .status-indicator input {
-							font-size: 24.8px !important;
-							margin-top: 20px !important;
-						}
-						/* .list-area .info-main */
-						.list-area .info-main .blue-bar,
-						.list-area .info-main .dark-blue-bar {
-							font-size: 11.57px;
-							height: 28px;
-							line-height: 28px;
-							padding: 0 24px;
-							margin-top: 6px;
-						}
-				/* .list-area  .rights */
-				.list-area .row .rights {
-					margin: 0 0 0 440px;
-				}
-					.list-area .row .rights h2 {
-						line-height: 26px;
-						margin-top: -6px;
-					}
-						.list-area .row .rights h2 a {
-							font-size: 24.8px;
-						}
-					.list-area .row .rights .time {
-						font-size: 13.23px;
-						padding: 4px 0 9px 0;
-					}
-					.list-area .row .rights p {
-						font-size: 11.57px;
-						line-height: 24px;
-						padding-right: 10px;
-						padding-bottom: 25px;
-					}
-					.list-area .row .rights .bottom-bar {
-						padding-right: 10px;
-					}
-						.list-area .row .rights .bottom-bar .btn-read-more {
-							font-size: 11.57px;
-							letter-spacing: 4px;
-							padding-left: 15px;
-							width: 140px;
-							height: 35px;
-							line-height: 35px;
-						}
-						.list-area .row .rights .bottom-bar .social-ul {
-							float: right;
-						}
-							.list-area .row .rights .bottom-bar .social-ul li {
-								float: left;
-								margin-left: 12px;
-							}
+/* .list-area .info-main */
 
-		/* .past-projects-module */
-		.past-projects-module {
-			padding-bottom: 45px;
-		}
-			.past-projects-module .title-past-projects {
-				letter-spacing: 5px;
-				background: none;
-				padding-left: 12px;
-				width: 225px;
-				margin: 31px auto 45px auto;
-			}
-				/* .past-projects-module .carousel-main */
-				.past-projects-module .carousel-main {
-					min-height: 290px;
-					margin-right: 80px;
-					margin-left: 80px;
-				}
-					/* .past-projects-module .carousel .item */
-					.past-projects-module .carousel .item {
-						padding: 0 0;
-						min-height: 290px;
-					}
-							.past-projects-module .carousel .spacing {
-								padding: 0 16px;
-							}
-								/* .past-projects-module .carousel .img-main */
-								.past-projects-module .img-main .funded-round {
-									width: 101px;
-									height: 101px;
-									padding: 5px;
-									right: 5px;
-									bottom: 6px;
-								}
-								/* .past-projects-module .carousel .info-main */
-								.past-projects-module .info-main {
-									text-align: left;
-									padding: 10px 0 0 0;
-								}
-									.past-projects-module .info-main h2 {
-										line-height: 25px;
-									}
-										.past-projects-module .info-main h2 a {
-											font-size: 19.84px;
-										}
-									.past-projects-module .info-main .time {
-										font-size: 13.23px;
-										padding: 3px 0 11px 0;
-									}
-									.past-projects-module .info-main .bottom-bar {
-										padding-right: 0;
-									}
-										.past-projects-module .info-main .bottom-bar .btn-read-more {
-											font-size: 11.57px;
-											letter-spacing: 4px;
-											padding-left: 10px;
-											width: 141px;
-											height: 35px;
-											line-height: 35px;
-										}
-								.past-projects-module .carousel-control.left,
-								.past-projects-module .carousel-control.right {
-									width: 41px;
-									height: 39px;
-									top: 78px;
-								}
-									.past-projects-module .carousel-control.left {
-										left: -67px;
-									}
-									.past-projects-module .carousel-control.right {
-										right: -67px;
-									}
-										.past-projects-module .carousel-control.left .icons,
-										.past-projects-module .carousel-control.right .icons {
-											width: 19px;
-											height: 19px;
-											margin: 8px auto 0 auto;
-										}
-											.past-projects-module .carousel-control.left .icons {
-												background-position: -233px -13px;
-											}
-												.past-projects-module .carousel-control:hover.left .icons {
-													background-position: -272px -13px;
-												}
-											.past-projects-module .carousel-control.right .icons {
-												background-position: -291px -13px;
-											}
-												.past-projects-module .carousel-control:hover.right .icons {
-													background-position: -310px -13px;
-												}
+.list-area .info-main {
+  padding: 0;
+  position: relative;
+  z-index: 99;
+}
+.list-area .info-main .blue-bar, .list-area .info-main .dark-blue-bar {
+  font-size: 14px;
+  color: #fff;
+  height: 33px;
+  line-height: 33px;
+  padding: 0 28px;
+  overflow: hidden;
+  margin-top: 8px;
+}
+.list-area .info-main .blue-bar {
+  background: #14b1e7;
+}
+.list-area .info-main .dark-blue-bar {
+  background: #003399;
+}
+.list-area .info-main .blue-bar span, .list-area .info-main .dark-blue-bar span {
+  font-family: 'Source Sans Pro';
+}
+.list-area .info-main .blue-bar .bold, .list-area .info-main .dark-blue-bar .bold {
+  font-family: 'Source Sans Pro';
+  font-weight: 700;
+}
 
+/* .list-area  .rights */
 
-		/* project details page */
-		.details-active-project-module .banners.min-height455 {
-			min-height: 376px;
-		}
-			.details-active-project-module .banners img {
-				height: 376px;
-			}
-				/* .details-active-project-module .banner-section */
-				.details-active-project-module .banner-section .container {
-					padding-top: 35px;
-					min-height: 376px;
-				}
-					.details-active-project-module .banner-section .title-active-project {
-						letter-spacing: 8px;
-						padding-left: 12px;
-						margin-right: 68px;
-						width: 250px;
-					}
-					.details-active-project-module .banner-section .title-h1 {
-						bottom: 24px;
-						left: 72px;
-						width: 420px;
-					}
-					.details-active-project-module .banner-section .funded-round {
-						width: 196px;
-						height: 196px;
-						padding: 10px;
-						margin: 0 0 0 -98px;
-						bottom: -166px;
-					}
-						.details-active-project-module .banner-section .funded-round .round-depict {
-							font-size: 22.48px;
-							text-align: center;
-							width: 170px;
-							margin: 6px 0 0 -85px;
-						}
-						.details-active-project-module .banner-section .funded-round .status-indicator input {
-							font-size: 48.17px !important;
-							margin-top: 40px !important;
-						}
-						.details-active-project-module .banner-section .funded-round .status-indicator input.smaller {
-							font-size: 37.17px !important;
-							-webkit-transition: font-size 0.25s ease;
-							transition: font-size 0.25s ease;
-						}
-				/* .details-active-project-module .info-section */
-				.details-active-project-module .info-section .container {
-					padding: 4px 96px 0 92px;
-				}
-					/* .details-active-project-module .info-main */
-					.details-active-project-module .info-main {
-						padding-bottom: 51px;
-					}
-						.details-active-project-module .info-main .blue-bar,
-						.details-active-project-module .info-main .dark-blue-bar {
-							font-size: 22.48px;
-							height: 53px;
-							line-height: 53px;
-							padding: 0 47px;
-							margin-top: 13px;
-						}
-						/* .details-active-project-module .video-main */
-						.details-active-project-module .video-main {
-							padding-bottom: 45px;
-						}
-							.details-active-project-module .video-area .video,
-							.details-active-project-module .video-area .video img,
-							.details-active-project-module .video-area .video iframe {
-								width: 388px;
-								height: 269px;
-							}
-								.details-active-project-module .video-area .btn-play {
-									width: 108px;
-									height: 108px;
-									margin: -54px 0 0 -54px;
-								}
-									.details-active-project-module .video-area .btn-play .icons {
-										background-position: 0 -71px;
-										width: 78px;
-										height: 78px;
-										margin: 8px 0 0 0;
-									}
-										.details-active-project-module .video-area .btn-play:hover .icons,
-										.details-active-project-module .video-area .btn-play:focus .icons {
-											background-position: -78px -71px;
-										}
-							.details-active-project-module .txt-area {
-								margin: 0 0 0 408px;
-								min-height: 269px;
-							}
-									.details-active-project-module .txt-area .txt-td .font20 {
-										font-size: 16.53px;
-										line-height: 30px;
-										padding-bottom: 17px;
-										margin-top: -8px;
-									}
-									.details-active-project-module .txt-area .txt-td .font14 {
-										font-size: 11.57px;
-										line-height: 20px;
-									}
+.list-area .row .rights {
+  margin: 0 0 0 530px;
+}
+.list-area .row .rights h2 {
+  line-height: 30px;
+  margin-top: -3px;
+}
+.list-area .row .rights h2 a {
+  font-family: 'Source Sans Pro';
+  font-weight: 700;
+  font-size: 30px;
+  color: #4b4b4b;
+}
+.list-area .row .rights h2 a:hover {
+  color: #14b1e7;
+}
+.list-area .row .rights .time {
+  font-family: 'Source Sans Pro';
+  font-weight: 700;
+  font-size: 16px;
+  color: #4b4b4b;
+  padding: 3px 0 13px 0;
+  display: block;
+}
+.list-area .row .rights p {
+  font-size: 14px;
+  color: #4b4b4b;
+  line-height: 28px;
+  padding-right: 35px;
+  padding-bottom: 31px;
+}
+.list-area .row .rights .bottom-bar {
+  padding-right: 35px;
+}
+.list-area .row .rights .bottom-bar .btn-read-more {
+  font-size: 14px;
+  text-transform: uppercase;
+  letter-spacing: 4px;
+  padding-left: 15px;
+  width: 169px;
+  height: 43px;
+  line-height: 43px;
+}
+.list-area .row .rights .bottom-bar .social-ul {
+  float: right;
+}
+.list-area .row .rights .bottom-bar .social-ul li {
+  float: left;
+  margin-left: 12px;
+}
 
-		/* .project-updates-module */
-		.project-updates-module .container {
-			padding: 38px 39px 20px 92px;
-			position: relative;
-		}
-			/* .project-updates-module .main-area */
-			.project-updates-module .main-area {
-				width: auto;
-				float: none;
-				margin-right: 304px;
-			}
-				 .project-updates-module .main-area .title-project-updates {
-					width: 274px;
-					letter-spacing: 7px;
-					padding-left: 12px;
-					margin-bottom: 29px;
-				}
-				 /* .project-updates-module .list-area */
-				 .project-updates-module .list-area .row {
-					 padding: 45px 0 0 0;
-				 }
-					 .project-updates-module .list-area .left-date {
-						 width: 168px;
-					 }
-						 .project-updates-module .list-area .left-date .date-txt,
-						 .project-updates-module .list-area .left-date .month-txt {
-							 text-align: center;
-							 padding: 0 45px 0 22px;
-						 }
-							 .project-updates-module .list-area .left-date .date-txt {
-								 font-size: 99.21px;
-								 line-height: 80px;
-								 margin-top: -4px;
-							 }
-							 .project-updates-module .list-area .left-date .month-txt {
-								 font-size: 19.84px;
-								 letter-spacing: 16px;
-							 }
-					 .project-updates-module .list-area .main-info {
-						 margin-left: 168px;
-					 }
-						 .project-updates-module .list-area .main-info .title-h4 {
-							 line-height: 20px;
-							 padding-bottom: 5px;
-						 }
-							 .project-updates-module .list-area .main-info .title-h4 a {
-								 font-size: 14.88px;
-							 }
-						 .project-updates-module .list-area .main-info p {
-							 font-size: 11.57px;
-							 line-height: 20px;
-							 padding-bottom: 18px;
-						 }
-						 .project-updates-module .list-area .main-info .social-ul {
-							 margin-bottom: 29px;
-						 }
-							 .project-updates-module .list-area .main-info .social-ul li {
-								 margin-right: 5px;
-							 }
-				/* .project-updates-module .right-aside */
-				.project-updates-module .right-aside {
-					width: 252px;
-					position: absolute;
-					top: 38px;
-					right: 39px;
-				}
-					.project-updates-module .right-aside .module-box {
-						min-height: 120px;
-						padding: 12px 0 22px 0;
-						margin: 0 0 26px 0;
-					}
-						.project-updates-module .right-aside .module-box .type-txt {
-							font-size: 14.88px;
-							padding: 5px 0 2px 0;
-						}
-						.project-updates-module .right-aside .module-box .value-txt {
-							font-size: 49.6px;
-							padding: 0;
-						}
-						.project-updates-module .right-aside .module-box .title-h5 {
-							font-size: 13.23px;
-							margin: 10px 14px 0 13px;
-							border-top: 2px solid #c3c3c3;
-							border-bottom: 2px solid #c3c3c3;
-							height: 29px;
-							line-height: 29px;
-						}
-						.project-updates-module .right-aside .module-box ul {
-							padding: 29px 0 17px 0;
-						}
-							.project-updates-module .right-aside .module-box li {
-								font-size: 11.57px;
-								line-height: 27px;
-							}
-						.project-updates-module .right-aside .btn-i-want-to-donate {
-							letter-spacing: 4px;
-							padding-left: 12px;
-							width: 190px;
-							height: 38px;
-							line-height: 38px;
-						}
-					 /* .project-updates-module .venue-area */
-					 .project-updates-module .venue-area {
-						 padding: 34px 0 0 0;
-					 }
-						 .project-updates-module .main-area .title-venue {
-							width: 142px;
-							padding-left: 12px;
-							margin-bottom: 14px;
-						}
-						 .project-updates-module .main-area .venue-map,
-						 .project-updates-module .main-area .venue-map img {
-							width: 100%;
-							height: 314px;
-						}
-						 .project-updates-module .main-area .venue-bottom {
-							 padding: 19px 0 0 0;
-						 }
-							 .project-updates-module .main-area .venue-bottom .title-h4 {
-								 font-size: 14.88px;
-								 line-height: 22px;
-								 padding-bottom: 5px;
-							 }
-							 .project-updates-module .main-area .venue-bottom p {
-								 line-height: 21px;
-							 }
-								 .project-updates-module .main-area .venue-bottom p span {
-									 font-size: 11.57px;
-								 }
+/* .past-projects-module */
 
-			/* .donors-module */
-			.donors-module .titles.container {
-				padding: 0;
-				min-height: 49px;
-			}
-				.titles.container .title-donors {
-					margin-right: 39px;
-					min-width: 142px;
-					letter-spacing: 7px;
-					padding-left: 12px;
-				}
-			.donors-module .tab-content .row {
-				margin: 4px 27px 0 70px;
-			}
-				.donors-module .tab-content .row .col-md-6 {
-					padding: 36px 0 0 0;
-				}
-					.donors-module .tab-content .head-img {
-						width: 105px;
-					}
-						.donors-module .tab-content .head-img img {
-							width: 82px;
-							height: 82px;
-						}
-					.donors-module .info-box {
-						margin-left: 105px;
-					}
-					.donors-module .info-box .title-h4 {
-						padding: 0 0 4px 0;
-						margin-top: -2px;
-					}
-						.donors-module .info-box .title-h4 a {
-							font-size: 14.88px;
-						}
-					.donors-module .info-box p {
-						font-size: 11.57px;
-						line-height: 23px;
-						padding: 0 15px 0 0;
-						margin-top: -2px;
-					}
+.past-projects-module {
+  background-color: #ededed;
+  text-align: center;
+  padding-bottom: 45px;
+}
+.past-projects-module .container {
+  padding: 0;
+}
+.past-projects-module .title-past-projects {
+  letter-spacing: 8px;
+  background: none;
+  padding-left: 20px;
+  width: 272px;
+  margin: 38px auto 54px auto;
+}
 
+/* .past-projects-module .carousel-main */
 
+.past-projects-module .carousel-main {
+  min-height: 360px;
+  margin-right: 92px;
+  margin-left: 92px;
+}
+.past-projects-module .carousel.desktop-show {
+  display: block;
+}
+.past-projects-module .carousel.mobile-show {
+  display: none;
+}
 
+/* .past-projects-module .carousel .item */
 
-	/* partners page */
-	.partners-contents .container {
-		padding: 35px 0 37px 70px;
-	}
-	.partners-contents .title-partners {
-		font-size: 15px;
-		height: 36px;
-		line-height: 36px;
-		padding-left: 22px;
-		padding-right: 16px;
-		margin-right: 68px;
-		margin-bottom: 25px;
-	}
-		.partners-contents .titles .title-primary {
-			font-size: 40px;
-			line-height: 46px;
-			margin-bottom: 18px;
-		}
-		.partners-contents .titles .title-sub {
-			font-size: 12px;
-			line-height: 24px;
-		}
+.past-projects-module .carousel .item {
+  padding: 0;
+  min-height: 360px;
+}
+.past-projects-module .carousel .module-box {
+  float: left;
+  width: 33.33333333%;
+}
+.past-projects-module .carousel .spacing {
+  padding: 0 19px 0 20px;
+}
+.past-projects-module .desktop-img {
+  display: block;
+}
+.past-projects-module .mobile-img {
+  display: none;
+}
 
-		/* .partners-contents .list */
-		.partners-contents .list-wrap {
-			margin-top: 41px;
-		}
-			.partners-contents .list-wrap .item-wrap {
-				min-height: 172px;
-				padding-bottom: 25px;
-				position: relative;
-				margin-bottom: 0;
-			}
-			.partners-contents .list-wrap .item-wrap.large-spacing {
-				margin-bottom: 0;
-			}
-			.partners-contents .left-img {
-				width: 170px;
-				height: 170px;
-				margin-top: 3px;
-				margin-left: -2px;
-			}
-			.partners-contents .content-info {
-				margin-left: 190px;
-				min-height: 132px;
-				overflow: hidden;
-			}
-				.partners-contents .content-info h4 {
-					font-size: 25px;
-					line-height: 30px;
-					margin-bottom: 8px;
-				}
-				.partners-contents .content-info h4 a {
-    					font-family: 'Source Sans Pro'; font-weight: 700;
-    					font-size: 25px;
-    					color: #4b4b4b;
-				}
-				.partners-contents .content-info p {
-					font-size: 12px;
-					line-height: 23px;
-					padding-right: 350px;
-					padding-left: 2px;
-				}
-			.partners-contents .btn-wrap {
-				margin: 0 0 0 191px;
-			}
-				.partners-contents .btn-wrap .btn-blue {
-					height: 36px;
-					line-height: 36px;
-					padding-left: 10px;
-					padding-right: 5px;
-				}
-			/* .partners-contents .pager-info */
-			.partners-contents .pager-info {
-				margin-top: 4px;
-			}
-				.partners-contents .pager-info li {
-					float: left;
-					margin-right: 15px;
-				}
-					.partners-contents .pager-info li a {
-						padding: 0 17px;
-						font-size: 13px;
-						line-height: 32px;
-						height: 32px;
-					}
+/* .past-projects-module .carousel .img-main */
 
-		/* .sponsoring-organizations-module */
-		.sponsoring-organizations-module {
-			min-height: 320px;
-		}
-			.sponsoring-organizations-module .container {
-				padding: 31px 0 0 0;
-			}
-				.title-sponsoring-organizations {
-					width: 408px;
-					letter-spacing: 7px;
-					padding-left: 10px;
-					margin-bottom: 30px;
-				}
-					/* .sponsoring-organizations-module .carousel-main */
-					.sponsoring-organizations-module .carousel-main {
-						margin-right: 75px;
-						margin-left: 75px;
-					}
-						.sponsoring-organizations-module .logo-ul li {
-							height: 200px;
-						}
-							.sponsoring-organizations-module .logo-the-san-francisco {
-								background-size: 138px auto;
-								width: 138px;
-								height: 137px;
-							}
-							.sponsoring-organizations-module .logo-toyota-togethergreen {
-								background-size: 158px auto;
-								width: 158px;
-								height: 52px;
-							}
-							.sponsoring-organizations-module .logo-sun-shot {
-								background-size: 111px auto;
-								width: 111px;
-								height: 34px;
-							}
-							.sponsoring-organizations-module .logo-patagonia {
-								background-size: 143px auto;
-								width: 143px;
-								height: 45px;
-							}
-							.sponsoring-organizations-module .carousel-control.left,
-							.sponsoring-organizations-module .carousel-control.right {
-								width: 41px;
-								height: 39px;
-								top: 93px;
-							}
-								  .sponsoring-organizations-module .carousel-control.left {
-									  left: -62px;
-								  }
-								  .sponsoring-organizations-module .carousel-control.right {
-									  right: -62px;
-								  }
-									  .sponsoring-organizations-module .carousel-control.left .icons,
-									  .sponsoring-organizations-module .carousel-control.right .icons {
-										  width: 19px;
-										  height: 19px;
-										  margin: 8px auto 0 auto;
-									  }
-										  .sponsoring-organizations-module .carousel-control.left .icons {
-											  background-position: -233px -13px;
-										  }
-											  .sponsoring-organizations-module .carousel-control:hover.left .icons {
-												  background-position: -272px -13px;
-											  }
-										 .sponsoring-organizations-module .carousel-control.right .icons {
-											  background-position: -291px -13px;
-										  }
-											  .sponsoring-organizations-module .carousel-control:hover.right .icons {
-												  background-position: -310px -13px;
-											  }
+.past-projects-module .img-main {
+  position: relative;
+}
+.past-projects-module .img-main .img-link {
+  display: block;
+  position: relative;
+}
+.past-projects-module .img-main .img-gradient {
+  opacity: 0.8;
+  background-image: -webkit-linear-gradient(bottom, rgba(0, 0, 0, 1) 0, rgba(0, 0, 0, .0) 100%);
+  background-image: -o-linear-gradient(bottom, rgba(0, 0, 0, 1) 0, rgba(0, 0, 0, .0) 100%);
+  background-image: -webkit-gradient(linear, bottom top, right top, from(rgba(0, 0, 0, 1)), to(rgba(0, 0, 0, 0)));
+  background-image: linear-gradient(to top, rgba(0, 0, 0, 1) 0, rgba(0, 0, 0, 0) 100%);
+  width: 100%;
+  height: 40%;
+  display: block;
+  position: absolute;
+  top: 60%;
+  left: 0;
+  z-index: 9;
+}
+.past-projects-module .img-main .img-link:hover .img-gradient {
+  background-image: none;
+}
+.past-projects-module .img-main .img-link img {
+  width: 100%;
+}
+.past-projects-module .img-main .img-link:hover img {
+  opacity: 1;
+}
+.past-projects-module .img-main .funded-round {
+  background-color: #fff;
+  width: 121px;
+  height: 121px;
+  padding: 6px;
+  border-radius: 100%;
+  position: absolute;
+  right: 7px;
+  bottom: 8px;
+  z-index: 99;
+}
 
+/* .past-projects-module .carousel .info-main */
 
+.past-projects-module .info-main {
+  text-align: left;
+  padding: 10px 0 0 0;
+}
+.past-projects-module .info-main h2 {
+  line-height: 35px;
+}
+.past-projects-module .info-main h2 a {
+  font-family: 'Source Sans Pro';
+  font-weight: 700;
+  font-size: 24px;
+  color: #282828;
+}
+.past-projects-module .info-main h2 a:hover {
+  color: #14b1e7;
+}
+.past-projects-module .info-main .time {
+  font-family: 'Source Sans Pro';
+  font-weight: 700;
+  font-size: 16px;
+  color: #4b4b4b;
+  padding: 3px 0 13px 0;
+  display: block;
+}
+.past-projects-module .info-main .bottom-bar {
+  padding-right: 35px;
+}
+.past-projects-module .info-main .bottom-bar .btn-read-more {
+  font-size: 14px;
+  text-transform: uppercase;
+  letter-spacing: 4px;
+  padding-left: 15px;
+  width: 169px;
+  height: 43px;
+  line-height: 43px;
+}
+.past-projects-module .carousel-control.left, .past-projects-module .carousel-control.right {
+  background-color: rgba(41, 41, 41, 0.15);
+  text-shadow: none;
+  background-image: none;
+  box-shadow: none;
+  opacity: 1;
+  width: 49px;
+  height: 47px;
+  border: 2px solid #fff;
+  top: 93px;
+}
+.past-projects-module .carousel-control.left {
+  text-align: center;
+  left: -88px;
+}
+.past-projects-module .carousel-control.right {
+  text-align: center;
+  right: -88px;
+}
+.past-projects-module .carousel-control.left .icons, .past-projects-module .carousel-control.right .icons {
+  width: 24px;
+  height: 24px;
+  top: 0;
+  right: auto;
+  left: auto;
+  position: static;
+  margin: 10px auto 0 auto;
+}
+.past-projects-module .carousel-control.left .icons {
+  background-position: -288px -16px;
+}
+.past-projects-module .carousel-control:hover.left .icons {
+  background-position: -336px -16px;
+}
+.past-projects-module .carousel-control.right .icons {
+  background-position: -360px -16px;
+}
+.past-projects-module .carousel-control:hover.right .icons {
+  background-position: -384px -16px;
+}
 
+/* project details page */
 
-	/* solar ambassador program page */
-	.solar-contents .article-detail {
-		padding: 35px 41px 62px 71px;
-	}
-	.solar-contents .article-detail .title-solar {
-		width: 227px;
-		height: 53px;
-		padding-left: 27px;
-		padding-top: 10px;
-		font-size: 15px;
-	}
-		.solar-contents .article-detail .detail-left {
-			padding-right: 331px;
-			padding-top: 46px;
-		}
-		.solar-contents .article-detail .detail-left .title-img {
-			margin-bottom: 33px;
-		}
-		.solar-contents .article-detail .detail-left .btn-group {
-			padding-top: 27px;
-			padding-right: 0;
-			width: auto;
-		}
-		.solar-contents .article-detail .detail-left .btn-group .btn-blue {
-			margin-bottom: 14px;
-		}
-			.solar-contents .article-detail .detail-left .btn-group .btn-application {
-				padding-left: 24px;
-				padding-right: 17px;
-				margin-top: 4px;
-			}
-			.solar-contents .article-detail .detail-left .btn-group .btn-team {
-				padding-left: 21px;
-				padding-right: 19px;
-				margin-bottom: 22px;
-				margin-right: 0;
-			}
-			.solar-contents .article-detail .detail-left .btn-group .btn-project {
-				padding-left: 33px;
-				padding-right: 36px;
-			}
+.details-active-project-module {
+  background: #ededed;
+  position: relative;
+}
+.details-active-project-module .banners.min-height455 {
+  background: #292929;
+  min-height: 455px;
+}
+.desktop-banner {
+  display: block;
+}
+.mobile-banner {
+  display: none;
+}
+.details-active-project-module .banners img {
+  width: 100%;
+  height: 455px;
+  opacity: 0.3;
+}
 
+/* .details-active-project-module .banner-section */
 
+.details-active-project-module .banner-section {
+  width: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 999;
+}
+.details-active-project-module .banner-section .container {
+  padding: 43px 0 0 0;
+  min-height: 455px;
+  position: relative;
+}
+.details-active-project-module .banner-section .title-active-project {
+  letter-spacing: 9px;
+  padding-left: 20px;
+  margin-right: 83px;
+  width: 303px;
+}
+.details-active-project-module .banner-section .title-h1 {
+  color: #fff;
+  position: absolute;
+  bottom: 30px;
+  left: 87px;
+  width: 450px;
+}
+.details-active-project-module .banner-section .funded-round {
+  background: #fff;
+  border-radius: 100%;
+  width: 236px;
+  height: 236px;
+  padding: 12px;
+  margin: 0 0 0 -118px;
+  position: absolute;
+  bottom: -201px;
+  left: 50%;
+  z-index: 299;
+}
+.details-active-project-module .banner-section .funded-round .round-depict {
+  font-family: 'Source Sans Pro';
+  font-weight: 700;
+  font-size: 27.19px;
+  color: #039;
+  display: block;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 110px;
+  margin: 6px 0 0 -55px;
+}
+.details-active-project-module .banner-section .funded-round .status-indicator input {
+  font-size: 58.26px !important;
+  margin-top: 50px !important;
+}
+.details-active-project-module .banner-section .funded-round .status-indicator input.smaller {
+  font-size: 44.26px !important;
+  -webkit-transition: font-size 0.25s ease;
+  transition: font-size 0.25s ease;
+}
 
+/* .details-active-project-module .info-section */
 
-	/* blog page */
-	.titles.container .title-blog {
-		margin-right: 68px;
-		min-width: 110px;
-		letter-spacing: 8px;
-		padding-left: 12px;
-	}
+.details-active-project-module .info-section {
+  position: relative;
+}
+.details-active-project-module .info-section .container {
+  padding: 4px 116px 0 112px;
+  position: relative;
+}
 
-	/* .grid-data */
-	.grid-data.container {
-		padding: 0 55px;
-	}
-		/* .form-area */
-		.form-area {
-			padding: 12px 13px 16px 13px;
-			min-height: 47px;
-		}
-			.form-area .width167 {
-				float: left;
-			}
-				.form-area .width167 .btn-default,
-				.form-area .width167.input-search {
-					width: 134px;
-				}
-				/* .input-search */
-				.input-search {
-					padding: 0 24px 2px 18px;
-					height: 30px;
-					line-height: 0;
-				}
-					.input-search input {
-						font-size: 9.92px;
-						letter-spacing: 4px;
-						height: 28px;
-					}
-					.input-search .icon-search {
-						background-position: -26px 0;
-						width: 13px;
-						height: 13px;
-						top: 6px;
-						right: 7px;
-					}
-						.input-search .icon-search:hover {
-							background-position: -65px 0;
-					}
-			/* .grid-area.row */
-			.grid-area.row .col-md-6 {
-				padding-right: 13px;
-				padding-left: 13px;
-			}
-			.grid-area.row .img-main {
-				height: 215px;
-			}
-				.grid-area.row .video {
-					width: 100%;
-					height: 215px;
-				}
-				.grid-area.row .video iframe {
-					width: 100%;
-					height: 215px;
-				}
-					.grid-area.row .btn-play {
-						width: 88px;
-						height: 88px;
-						margin: -44px 0 0 -44px;
-					}
-						.grid-area.row .btn-play .icons {
-							background-size: 442px auto;
-							background-position: 0 -58px;
-							width: 63px;
-							height: 63px;
-							margin: 8px 0 0 0;
-						}
-							.grid-area.row .btn-play:hover .icons,
-							.grid-area.row .btn-play:focus .icons {
-								background-position: -63px -58px;
-							}
-				.grid-area.row .img-main img {
-					height: 215px;
-				}
-					.grid-area.row .carousel-control.left,
-					.grid-area.row .carousel-control.right {
-						width: 41px;
-						height: 39px;
-					}
-						.grid-area.row .carousel-control.left {
-							right: 45px;
-						}
-							.grid-area.row .carousel-control.left .icons,
-							.grid-area.row .carousel-control.right .icons {
-								width: 19px;
-								height: 19px;
-								margin: 8px auto 0 auto;
-							}
-								.grid-area.row .carousel-control.left .icons {
-									background-position: -233px -13px;
-								}
-									.grid-area.row .carousel-control:hover.left .icons {
-										background-position: -272px -13px;
-									}
-								.grid-area.row .carousel-control.right .icons {
-									background-position: -291px -13px;
-								}
-									.grid-area.row .carousel-control:hover.right .icons {
-										background-position: -310px -13px;
-									}
-			.grid-area.row .info-main {
-				padding: 29px 0 30px 0;
-			}
-				.grid-area.row .info-main .title-h2 {
-					font-size: 24.8px;
-					line-height: 30px;
-				}
-				.grid-area.row .info-main .title-h2 a {
-					font-size: 24.8px;
-				}
-				.grid-area.row .info-main .date-txt {
-					font-size: 13.23px;
-					line-height: 20px;
-					padding-bottom: 8px;
-				}
-				.grid-area.row .info-main p {
-					font-size: 11.57px;
-					line-height: 24px;
-					padding: 0 25px 15px 0;
-				}
-				.grid-area.row .info-main .bottom-bar {
-					padding: 14px 0 20px 0;
-				}
-					.grid-area.row .info-main .bottom-bar .btn-read-more {
-						font-size: 11.57px;
-						letter-spacing: 3px;
-						width: 108px;
-						height: 35px;
-						padding: 2px 0 0 2px;
-						line-height: 33px;
-					}
-					.grid-area.row .info-main .bottom-bar .social-ul {
-						margin: 0 20px 0 0;
-					}
-						.grid-area.row .info-main .bottom-bar .social-ul li {
-							margin: 0 5px 0 6px;
-						}
+/* .details-active-project-module .info-main */
 
-	/* .loading-bar */
-	.loading-bar {
-		padding: 0 0 58px 0;
-	}
-		.loading-bar .loading-img {
-			background-size: 106px auto;
-			width: 106px;
-			height: 18px;
-		}
+.details-active-project-module .info-main {
+  padding-bottom: 62px;
+}
+.details-active-project-module .info-main .blue-bar, .details-active-project-module .info-main .dark-blue-bar {
+  font-size: 27.19px;
+  color: #fff;
+  height: 65px;
+  line-height: 65px;
+  padding: 0 55px;
+  overflow: hidden;
+  margin-top: 15px;
+}
+.details-active-project-module .info-main .blue-bar {
+  background: #14b1e7;
+}
+.details-active-project-module .info-main .dark-blue-bar {
+  background: #003399;
+}
+.details-active-project-module .info-main .blue-bar span, .details-active-project-module .info-main .dark-blue-bar span {
+  font-family: 'Source Sans Pro';
+}
+.details-active-project-module .info-main .blue-bar .bold, .details-active-project-module .info-main .dark-blue-bar .bold {
+  font-family: 'Source Sans Pro';
+  font-weight: 700;
+}
 
-		/* .blog-details-data */
-		.blog-details-data.container {
-			padding: 0 68px;
-			min-height: 150px;
-		}
-			/* .blog-details-data .title-bar */
-			.blog-details-data.container .title-bar {
-				padding: 14px 0 15px 0;
-			}
-				.blog-details-data.container .title-bar .date-txt {
-					font-size: 13.23px;
-					line-height: 24px;
-				}
-					.blog-details-data.container .title-bar .social-ul {
-						top: 38px;
-					}
-						.blog-details-data.container .title-bar .social-ul li {
-							margin-left: 11px;
-						}
-			/* .blog-details-data .info-box */
-			.blog-details-data.container .info-box .img-main,
-			.blog-details-data.container .info-box .img-main img {
-				height: 442px;
-			}
-				.blog-details-data.container .info-box .info-main {
-					padding: 35px 3px 18px 3px;
-				}
-				.blog-details-data.container .info-box .info-main .lefts p {
-					padding-right: 5px;
-				}
-				.blog-details-data.container .info-box .info-main .rights p {
-					padding-left: 12px;
-				}
-					.blog-details-data.container .info-box .info-main .font20 {
-						font-size: 16.53px;
-						line-height: 30px;
-					}
-					.blog-details-data.container .info-box .info-main .font14 {
-						font-size: 11.57px;
-						line-height: 23px;
-					}
-					.blog-details-data.container .info-box .down25 {
-						padding-bottom: 18px;
-					}
-					.blog-details-data.container .info-box .info-main .rights .down25 {
-						padding-bottom: 20px;
-					}
+/* .details-active-project-module .video-main */
 
-		/* .related-blog-module */
-		.related-blog-module {
-			padding: 20px 0 7px 0;
-		}
-				.related-blog-module .form-area {
-					min-height: 70px;
-				}
-				.related-blog-module .title-related-blog {
-					width: 217px;
-					top: 13px;
-					right: 68px;
-				}
-				.related-blog-module .carousel-control.left,
-				.related-blog-module .carousel-control.right {
-					width: 41px;
-					height: 39px;
-					margin-top: -65px;
-				}
-					.related-blog-module .carousel-control.left {
-						left: -45px;
-					}
-					.related-blog-module .carousel-control.right {
-						right: -45px;
-					}
-						.related-blog-module .carousel-control.left .icons,
-						.related-blog-module .carousel-control.right .icons {
-							width: 19px;
-							height: 19px;
-							margin-top: 7px;
-						}
-							.related-blog-module .carousel-control.left .icons {
-								background-position: -233px -13px;
-							}
-								.related-blog-module .carousel-control:hover.left .icons {
-									background-position: -272px -13px;
-								}
-							.related-blog-module .carousel-control.right .icons {
-								background-position: -291px -13px;
-							}
-								.related-blog-module .carousel-control:hover.right .icons {
-									background-position: -310px -13px;
-								}
-					.related-blog-module .carousel-inner>.active {
-						min-height: 512px;
-					}
+.details-active-project-module .video-main {
+  padding-bottom: 55px;
+  position: relative;
+}
+.details-active-project-module .video-area .video {
+  background: #000;
+  width: 470px;
+  height: 326px;
+  position: relative;
+}
+.details-active-project-module .video-area .video iframe {
+  width: 470px;
+  height: 326px;
+  border: none;
+}
+.details-active-project-module .video-area .video img {
+  width: 100%;
+  height: 326px;
+}
+.details-active-project-module .video-area .video-opacity {
+  background: rgba(0, 0, 0, 0.5);
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+.details-active-project-module .video-area .btn-play {
+  text-align: center;
+  border: 5px solid #fff;
+  border-radius: 100%;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 130px;
+  height: 130px;
+  margin: -75px 0 0 -75px;
+}
+.details-active-project-module .video-area .btn-play .icons {
+  background-position: 0 -88px;
+  width: 96px;
+  height: 96px;
+  margin: 13px 0 0 0;
+}
+.details-active-project-module .video-area .btn-play:hover, .details-active-project-module .video-area .btn-play:focus {
+  border: 5px solid #1cb0e6;
+}
+.details-active-project-module .video-area .btn-play:hover .icons, .details-active-project-module .video-area .btn-play:focus .icons {
+  background-position: -96px -88px;
+}
+.details-active-project-module .txt-area {
+  margin: 0 15px 0 500px;
+}
+.details-active-project-module .txt-area .txt-table {
+  min-height: 316px;
+  display: table;
+  width: 100%;
+}
+.details-active-project-module .mobile-bottom-bar {
+  display: none;
+}
+.details-active-project-module .txt-area .txt-td {
+  display: table-cell;
+  vertical-align: middle;
+  line-height: 20px;
+}
+.details-active-project-module .txt-area .txt-td p {
+  color: #4b4b4b;
+}
+.details-active-project-module .txt-area .txt-td .font20 {
+  font-size: 20px;
+  line-height: 36px;
+  padding-bottom: 22px;
+}
+.details-active-project-module .txt-area .txt-td .font14 {
+  font-size: 14px;
+  line-height: 24px;
+}
 
-		/* .comments-module */
-		.comments-module .container {
-			padding: 30px 68px 0 68px;
-		}
-			.comments-module .container .title-comments {
-				width: 167px;
-				letter-spacing: 7px;
-				margin-bottom: 20px;
-				padding-left: 12px;
-			}
-			/* .comments-module .comments-area  .comments-list*/
-			.comments-module .comments-area {
-				min-height: 150px;
-			}
-				.comments-module .comments-area .comments-list {
-					padding: 41px 100px 34px 0;
-				}
-				.comments-module .comments-area .spaceleft {
-					padding-left: 86px;
-				}
-				.comments-module .comments-area .spacetop {
-					padding-top: 18px;
-				}
-					.comments-module .comments-area .comments-list .head-img {
-						width: 108px;
-					}
-						.comments-module .comments-area .comments-list .head-img img {
-							width: 83px;
-							height: 83px;
-						}
-					.comments-module .comments-area .comments-list .info-box {
-						margin-left: 108px;
-					}
-						.comments-module .comments-area .comments-list .info-box .title-h4 {
-							padding: 0 0 11px 0;
-						}
-							.comments-module .comments-area .comments-list .info-box .title-h4 a {
-								font-size: 14.88px;
-							}
-						.comments-module .comments-area .comments-list .info-box p {
-								font-size: 11.57px;
-								line-height: 20px;
-								padding: 0 18px 0 0;
-						}
-					.comments-module .comments-area .comments-list .comments-apply {
-						width: 85px;
-						height: 35px;
-						line-height: 35px;
-						letter-spacing: 4px;
-					}
-						.comments-module .comments-area .comments-list .comments-apply a {
-							font-size: 11.57px;
-							padding-left: 4px;
+/* .project-updates-module */
 
-						}
-							.comments-module .comments-area .comments-list .comments-apply a:hover {
-								color: #1ab1e6;
-								text-decoration: none;
-							}
-			/* .comments-module .comments-area .quick-reply */
-			.comments-module .comments-area .quick-reply {
-				padding: 31px 0 100px 0;
-			}
-				.comments-module .comments-area .quick-reply .quick-reply-txt {
-					width: 108px;
-				}
-					.comments-module .comments-area .quick-reply .quick-reply-txt .title-h4 {
-						padding: 20px 0 18px 0;
-						font-size: 14.88px;
-					}
-					.comments-module .comments-area .quick-reply .quick-reply-txt p {
-						font-size: 11.57px;
-					}
-						.comments-module .comments-area .quick-reply .quick-reply-txt li {
-							margin-top: 11px;
-							margin-left: -1px;
-						}
-						.comments-module .comments-area .quick-reply .quick-reply-txt li:nth-child(2) {
-							margin-left: 10px;
-						}
-				.comments-module .comments-area .quick-reply .textarea-box {
-					margin-right: 4px;
-					margin-left: 108px;
-					height: 162px;
-					padding: 14px 21px;
-				}
-					.comments-module .comments-area .quick-reply .textarea-box textarea {
-						font-size: 9.92px;
-						height: 100px;
-						line-height: 14px;
-						letter-spacing: 6px;
+.project-updates-module {
+  position: relative;
+}
+.project-updates-module .container {
+  padding: 46px 47px 20px 115px;
+}
 
-					}
-				.comments-module .comments-area .quick-reply .comments-post {
-					width: 83px;
-					height: 35px;
-					line-height: 35px;
-					right: 5px;
-					bottom: 101px;
-					letter-spacing: 3px;
-				}
-					.comments-module .comments-area .quick-reply .comments-post a {
-						font-size: 11.57px;
-						padding: 2px 0 0 3px;
+/* .project-updates-module .main-area */
 
-					}
+.project-updates-module .main-area {
+  float: left;
+  width: 671px;
+}
+.project-updates-module .main-area .title-project-updates {
+  width: 331px;
+  letter-spacing: 9px;
+  padding-left: 20px;
+  margin-bottom: 35px;
+}
 
+/* .project-updates-module .list-area */
 
+.project-updates-module .list-area .row {
+  padding: 55px 0 0 0;
+  margin: 0;
+  border-bottom: 4px solid #dcdcdc;
+  overflow: hidden;
+}
+.project-updates-module .list-area .left-date {
+  text-align: center;
+  width: 203px;
+  float: left;
+}
+.project-updates-module .list-area .left-date .date-txt, .project-updates-module .list-area .left-date .month-txt {
+  font-family: 'Source Sans Pro';
+  font-weight: 700;
+  color: #00a1d9;
+  display: block;
+  padding: 0 50px 0 28px;
+}
+.project-updates-module .list-area .left-date .date-txt {
+  font-size: 120px;
+  line-height: 100px;
+  margin-top: -8px;
+}
+.project-updates-module .list-area .left-date .month-txt {
+  font-size: 24px;
+  letter-spacing: 20px;
+  padding-left: 32px;
+}
+.project-updates-module .list-area .main-info {
+  margin-left: 203px;
+}
+.project-updates-module .list-area .main-info .title-h4 {
+  line-height: 30px;
+}
+.project-updates-module .list-area .main-info .title-h4 a {
+  font-family: 'Source Sans Pro';
+  font-weight: 700;
+  font-size: 18px;
+  color: #4b4b4b;
+}
+.project-updates-module .list-area .main-info .title-h4 a:hover {
+  color: #1cb0e6;
+}
+.project-updates-module .list-area .main-info p {
+  font-size: 14px;
+  color: #8a8a8a;
+  line-height: 25px;
+  padding-bottom: 20px;
+}
+.project-updates-module .list-area .main-info .social-ul {
+  margin-bottom: 34px;
+  overflow: hidden;
+}
+.project-updates-module .list-area .main-info .social-ul li {
+  float: left;
+  margin-right: 7px;
+}
+
+/* .project-updates-module .right-aside */
+
+.project-updates-module .right-aside {
+  width: 305px;
+  float: right;
+  position: relative;
+}
+.project-updates-module .right-aside .module-box {
+  text-align: center;
+  background: #ededed;
+  min-height: 200px;
+  padding: 12px 0 32px 0;
+  margin: 0 0 32px 0;
+}
+.project-updates-module .right-aside .module-box .type-txt {
+  font-family: 'Source Sans Pro';
+  font-weight: 700;
+  font-size: 18px;
+  text-transform: uppercase;
+  line-height: 30px;
+  color: rgba(4, 4, 5, 0.4);
+  padding: 11px 0 13px 0;
+}
+.project-updates-module .right-aside .module-box .value-txt {
+  font-family: 'Source Sans Pro';
+  font-weight: 900;
+  font-size: 60px;
+  line-height: 65px;
+  color: #282828;
+  padding: 0 0 20px 0;
+}
+.project-updates-module .right-aside .module-box .title-h5 {
+  font-family: 'Source Sans Pro';
+  font-weight: 700;
+  font-size: 16px;
+  color: #4b4b4b;
+  border-top: 1px solid #c3c3c3;
+  border-bottom: 1px solid #c3c3c3;
+  margin: 0 18px 0 16px;
+  height: 33px;
+  line-height: 33px;
+}
+.project-updates-module .right-aside .module-box ul {
+  padding: 34px 0 25px 0;
+}
+.project-updates-module .right-aside .module-box li {
+  font-family: 'Source Sans Pro';
+  font-weight: 700;
+  font-size: 14px;
+  color: rgba(75, 75, 75, 0.8);
+  line-height: 32px;
+}
+.project-updates-module .right-aside .btn-i-want-to-donate {
+  background-color: #00a1d9;
+  letter-spacing: 4px;
+  padding-left: 20px;
+  width: 230px;
+  height: 45px;
+  line-height: 45px;
+}
+.project-updates-module .right-aside .btn-i-want-to-donate:hover, .project-updates-module .right-aside .btn-i-want-to-donate:focus {
+  background-color: #2c3691;
+}
+
+/* .project-updates-module .venue-area */
+
+.project-updates-module .venue-area {
+  padding: 41px 0 0 0;
+}
+.project-updates-module .main-area .title-venue {
+  width: 172px;
+  margin-bottom: 17px;
+}
+.project-updates-module .main-area .venue-map, .project-updates-module .main-area .venue-map img {
+  width: 670px;
+  height: 380px;
+}
+.project-updates-module .main-area .venue-bottom {
+  padding: 22px 0 0 0;
+}
+.project-updates-module .main-area .venue-bottom .title-h4 {
+  font-family: 'Source Sans Pro';
+  font-weight: 700;
+  font-size: 18px;
+  color: #4b4b4b;
+  text-transform: uppercase;
+  line-height: 30px;
+  padding-bottom: 5px;
+}
+.project-updates-module .main-area .venue-bottom p {
+  line-height: 25px;
+}
+.project-updates-module .main-area .venue-bottom p span {
+  font-size: 14px;
+  color: #8a8a8a;
+  display: block;
+}
+
+/* .donors-module */
+
+.donors-module {
+  position: relative;
+}
+.donors-module .titles.container {
+  padding: 19px 0 0 0;
+  min-height: 83px;
+}
+.titles.container .title-donors {
+  margin-right: 47px;
+  min-width: 172px;
+  letter-spacing: 9px;
+  padding-left: 20px;
+}
+.donors-module .mains-tabs .tab-content {
+  min-height: 100px;
+  padding-bottom: 46px;
+}
+.donors-module .tab-content .tab-basic, .donors-module .tab-content .tab-silver, .donors-module .tab-content .tab-gold {
+  display: none;
+}
+.donors-module .tab-content .tab-basic.active, .donors-module .tab-content .tab-silver.active, .donors-module .tab-content .tab-gold.active {
+  display: block;
+}
+.donors-module .tab-content .row {
+  margin: 4px 37px 0 87px;
+}
+.donors-module .tab-content .row .col-md-6 {
+  padding: 46px 0 0 0;
+}
+.donors-module .desktop-img {
+  display: block;
+}
+.donors-module .mobile-img {
+  display: none;
+}
+.donors-module .tab-content .head-img {
+  float: left;
+  width: 128px;
+}
+.donors-module .tab-content .head-img img {
+  width: 99px;
+  height: 99px;
+}
+.donors-module .info-box {
+  margin-left: 128px;
+}
+.donors-module .info-box .title-h4 {
+  padding: 0 0 4px 0;
+  font-family: 'Source Sans Pro';
+  font-weight: 700;
+  font-size: 18px;
+  color: #282828;
+  text-transform: uppercase;
+}
+.donors-module .info-box p {
+  font-size: 14px;
+  color: #4b4b4b;
+  line-height: 28px;
+  padding: 0 25px 0 0;
+}
+
+/* partners page */
+
+.contents.partners-contents {
+  position: relative;
+}
+.partners-contents .container {
+  padding: 43px 0 45px 85px;
+}
+.partners-contents .title-partners {
+  padding-left: 27px;
+  padding-right: 22px;
+  margin-right: 83px;
+  margin-bottom: 34px;
+}
+.partners-contents .titles .title-primary {
+  font-family: 'Source Sans Pro';
+  font-weight: 900;
+  font-size: 48px;
+  line-height: 52px;
+  color: #2c3691;
+  margin-bottom: 22px;
+}
+.partners-contents .titles .title-sub {
+  font-family: 'Source Sans Pro';
+  font-size: 14px;
+  line-height: 28px;
+  color: #4b4b4b;
+}
+
+/* .partners-contents .list */
+
+.partners-contents .list-wrap {
+  margin-top: 49px;
+}
+.partners-contents .list-wrap .item-wrap {
+  min-height: 209px;
+  position: relative;
+  margin-bottom: 34px;
+}
+.partners-contents .list-wrap .item-wrap.large-spacing {
+  margin-bottom: 39px;
+}
+.partners-contents .left-img {
+  float: left;
+  width: 200px;
+  height: 200px;
+  margin-top: 9px;
+}
+.partners-contents .left-img img {
+  width: 100%;
+  height: 100%;
+}
+.partners-contents .content-info {
+  margin-left: 230px;
+  padding-bottom: 5px;
+  min-height: 160px;
+  overflow: hidden;
+}
+.partners-contents .content-info h4 {
+  font-family: 'Source Sans Pro';
+  font-weight: 700;
+  font-size: 30px;
+  line-height: 42px;
+  color: #4b4b4b;
+  margin-bottom: 4px;
+}
+.partners-contents .content-info h4 a {
+  font-family: 'Source Sans Pro';
+  font-weight: 700;
+  font-size: 30px;
+  color: #4b4b4b;
+}
+.partners-contents .content-info h4 a:hover {
+  color: #14b1e7;
+}
+.partners-contents .content-info p {
+  font-family: 'Source Sans Pro';
+  font-size: 14px;
+  line-height: 28px;
+  color: #4b4b4b;
+  padding-right: 405px;
+  padding-left: 2px;
+}
+.partners-contents .btn-wrap {
+  margin: 0 0 0 231px;
+  min-height: 43px;
+}
+.partners-contents .btn-wrap .btn-blue {
+  height: 43px;
+  line-height: 43px;
+  padding-left: 18px;
+  padding-right: 14px;
+  letter-spacing: 4px;
+}
+
+/* .partners-contents .pager-info */
+
+.partners-contents .pager-info {
+  margin-top: 41px;
+  padding-left: 4px;
+}
+.partners-contents .pager-info li {
+  float: left;
+  margin-right: 17px;
+}
+.partners-contents .pager-info li a {
+  display: inline-block;
+  padding: 0 20px;
+  font-family: 'Source Sans Pro';
+  font-weight: 700;
+  font-size: 16px;
+  line-height: 39px;
+  color: #4b4b4b;
+  height: 39px;
+  background-color: #dfdfdf;
+  text-decoration: none;
+}
+.partners-contents .pager-info li a:hover {
+  background-color: #c3c1c1;
+}
+
+/* .sponsoring-organizations-module */
+
+.sponsoring-organizations-module {
+  background: #f4f4f4;
+  position: relative;
+  min-height: 387px;
+}
+.sponsoring-organizations-module .container {
+  text-align: center;
+  padding: 37px 83px 0 83px;
+}
+.title-sponsoring-organizations {
+  width: 494px;
+  letter-spacing: 9px;
+  padding-left: 15px;
+  margin-bottom: 56px;
+}
+#sponsoring-organizations-example-generic {
+  display: block;
+}
+#mobile-sponsoring-organizations-example-generic {
+  display: none;
+}
+
+/* .sponsoring-organizations-module .carousel-main */
+
+.sponsoring-organizations-module .logo-ul {
+  display: table;
+  width: 100%;
+}
+.sponsoring-organizations-module .logo-ul li {
+  text-align: center;
+  vertical-align: middle;
+  width: 25%;
+  height: 200px;
+  display: table-cell;
+}
+.sponsoring-organizations-module .logo {
+  margin-right: auto;
+  margin-left: auto;
+  display: block;
+  overflow: hidden;
+}
+.sponsoring-organizations-module .logo-the-san-francisco {
+  background: url(../images/logo-the-san-francisco.png) no-repeat;
+  width: 166px;
+  height: 165px;
+}
+.sponsoring-organizations-module .logo-toyota-togethergreen {
+  background: url(../images/logo-toyota-togethergreen.png) no-repeat;
+  width: 193px;
+  height: 63px;
+}
+.sponsoring-organizations-module .logo-sun-shot {
+  background: url(../images/logo-sun-shot.png) no-repeat;
+  width: 134px;
+  height: 41px;
+}
+.sponsoring-organizations-module .logo-patagonia {
+  background: url(../images/logo-patagonia.png) no-repeat;
+  width: 172px;
+  height: 54px;
+}
+.sponsoring-organizations-module .carousel-control.left, .sponsoring-organizations-module .carousel-control.right {
+  background-color: rgba(41, 41, 41, 0.15);
+  text-shadow: none;
+  background-image: none;
+  box-shadow: none;
+  opacity: 1;
+  width: 49px;
+  height: 47px;
+  border: 2px solid #fff;
+  top: 90px;
+}
+.sponsoring-organizations-module .carousel-control.left {
+  text-align: center;
+  left: -76px;
+}
+.sponsoring-organizations-module .carousel-control.right {
+  text-align: center;
+  right: -76px;
+}
+.sponsoring-organizations-module .carousel-control.left .icons, .sponsoring-organizations-module .carousel-control.right .icons {
+  width: 24px;
+  height: 24px;
+  top: 0;
+  right: auto;
+  left: auto;
+  position: static;
+  margin: 10px auto 0 auto;
+}
+.sponsoring-organizations-module .carousel-control.left .icons {
+  background-position: -288px -16px;
+}
+.sponsoring-organizations-module .carousel-control:hover.left .icons {
+  background-position: -336px -16px;
+}
+.sponsoring-organizations-module .carousel-control.right .icons {
+  background-position: -360px -16px;
+}
+.sponsoring-organizations-module .carousel-control:hover.right .icons {
+  background-position: -384px -16px;
+}
+
+/* solar ambassador program page */
+
+.contents.solar-ambassador-program-contents {
+  min-height: 1000px;
+}
+.contents.solar-ambassador-program-contents .container {
+  padding: 0;
+}
+
+/* .article-detail */
+
+.solar-contents .article-detail {
+  padding: 43px 84px 75px 85px;
+}
+.solar-contents .article-detail .bold {
+  font-family: 'Source Sans Pro';
+  font-weight: 700;
+}
+.solar-contents .article-detail .title-solar {
+  float: right;
+  word-spacing: 2px;
+  line-height: 1;
+  width: 274px;
+  height: 63px;
+  padding: 13px 32px;
+}
+.solar-contents .article-detail .detail-left {
+  padding-right: 331px;
+  padding-top: 56px;
+}
+.solar-contents .article-detail .detail-left .title-img {
+  margin-bottom: 40px;
+}
+.solar-contents .article-detail .detail-left .btn-group {
+  padding-top: 27px;
+  padding-right: 0;
+  width: 900px;
+}
+.article-detail .detail-left .btn-group .btn-application {
+  padding-left: 29px;
+  padding-right: 23px;
+  margin-top: 4px;
+}
+.article-detail .detail-left .btn-group .btn-team {
+  padding-left: 26px;
+  padding-right: 19px;
+  margin-bottom: 26px;
+  margin-right: 0;
+}
+.article-detail .detail-left .btn-group .btn-project {
+  padding-left: 41px;
+  padding-right: 39px;
+}
+
+/* blog page */
+
+.titles.container .title-blog {
+  margin-right: 83px;
+  min-width: 133px;
+  letter-spacing: 9px;
+  padding-left: 20px;
+}
+
+/* .grid-data */
+
+.grid-data.container {
+  padding: 0 68px;
+}
+
+/* .form-area */
+
+.form-area {
+  padding: 11px 16px 20px 16px;
+  min-height: 67px;
+}
+.form-area .width167 {
+  float: left;
+}
+.form-area .width167 .btn-default, .form-area .width167.input-search {
+  width: 167px;
+}
+
+/* .input-search */
+
+.input-search {
+  background: #f0f0f0;
+  border: 2px solid #fff;
+  padding: 0 28px 0 23px;
+  height: 36px;
+  line-height: 34px;
+  position: relative;
+}
+.input-search input {
+  font-size: 12px;
+  color: #9d9d9d;
+  letter-spacing: 6px;
+  background: none;
+  border: none;
+  height: 32px;
+  width: 100%;
+  line-height: 20px;
+  vertical-align: middle;
+  outline: none;
+}
+.input-search .icon-search {
+  background-position: -32px 0;
+  width: 16px;
+  height: 16px;
+  position: absolute;
+  top: 8px;
+  right: 9px;
+  z-index: 9;
+}
+.input-search .icon-search:hover {
+  background-position: -80px 0;
+}
+
+/* .grid-area.row */
+
+.grid-area.row {
+  margin: 0;
+  min-height: 100px;
+}
+.grid-area.row .col-md-6 {
+  padding-right: 16px;
+  padding-left: 16px;
+}
+.grid-area.row .img-main {
+  height: 259px;
+  position: relative;
+}
+.grid-area.row .video {
+  background: #000;
+  width: 501px;
+  height: 259px;
+  position: relative;
+}
+.grid-area.row .video iframe {
+  width: 501px;
+  height: 259px;
+  border: none;
+}
+.grid-area.row .video-opacity {
+  background: rgba(0, 0, 0, 0.5);
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+.grid-area.row .btn-play {
+  text-align: center;
+  border: 4px solid #fff;
+  border-radius: 100%;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 106px;
+  height: 106px;
+  margin: -53px 0 0 -53px;
+}
+.grid-area.row .btn-play .icons {
+  background-size: 543px auto;
+  background-position: 0 -71px;
+  width: 78px;
+  height: 78px;
+  margin: 10px 0 0 0;
+}
+.grid-area.row .btn-play:hover, .grid-area.row .btn-play:focus {
+  border: 4px solid #1cb0e6;
+}
+.grid-area.row .btn-play:hover .icons, .grid-area.row .btn-play:focus .icons {
+  background-position: -78px -71px;
+}
+.grid-area.row .img-main img {
+  width: 100%;
+  height: 259px;
+}
+.grid-area.row .carousel-control.left, .grid-area.row .carousel-control.right {
+  background-color: rgba(255, 255, 255, 0.5);
+  text-shadow: none;
+  background-image: none;
+  box-shadow: none;
+  opacity: 1;
+  width: 49px;
+  height: 47px;
+  border: 2px solid #fff;
+  top: auto;
+  bottom: 3px;
+}
+.grid-area.row .carousel-control.left {
+  left: auto;
+  right: 53px;
+}
+.grid-area.row .carousel-control.right {
+  right: 3px;
+}
+.grid-area.row .carousel-control.left .icons, .grid-area.row .carousel-control.right .icons {
+  width: 24px;
+  height: 24px;
+  margin-top: 9px;
+}
+.grid-area.row .carousel-control.left .icons {
+  background-position: -288px -16px;
+}
+.grid-area.row .carousel-control:hover.left .icons {
+  background-position: -336px -16px;
+}
+.grid-area.row .carousel-control.right .icons {
+  background-position: -360px -16px;
+}
+.grid-area.row .carousel-control:hover.right .icons {
+  background-position: -385px -16px;
+}
+.grid-area.row .info-main {
+  color: #4b4b4b;
+  position: relative;
+  padding: 36px 0 30px 0;
+}
+.grid-area.row .info-main .title-h2 a {
+  font-family: 'Source Sans Pro';
+  font-weight: 700;
+  font-size: 30px;
+  color: #4b4b4b;
+}
+.grid-area.row .info-main .title-h2 a:hover {
+  color: #14b1e7;
+}
+.grid-area.row .info-main .title-h2 {
+  font-family: 'Source Sans Pro';
+  font-weight: 700;
+  font-size: 30px;
+  line-height: 35px;
+}
+.grid-area.row .info-main .date-txt {
+  font-family: 'Source Sans Pro';
+  font-weight: 700;
+  font-size: 16px;
+  text-transform: uppercase;
+  line-height: 22px;
+  padding-bottom: 14px;
+  display: block;
+}
+.grid-area.row .info-main p {
+  font-size: 14px;
+  line-height: 28px;
+  padding: 0 25px 15px 0;
+}
+.grid-area.row .info-main .bottom-bar {
+  padding: 24px 0 30px 0;
+  overflow: hidden;
+}
+.grid-area.row .info-main .bottom-bar .btn-read-more {
+  text-transform: uppercase;
+  letter-spacing: 4px;
+  width: 130px;
+  height: 43px;
+  padding: 0 0 0 2px;
+  line-height: 43px;
+  float: left;
+}
+.grid-area.row .info-main .bottom-bar .social-ul {
+  float: right;
+  margin: 0 24px 0 0;
+}
+.grid-area.row .info-main .bottom-bar .social-ul li {
+  float: left;
+  margin: 0 6px 0 7px;
+}
+
+/* .loading-bar */
+
+.loading-bar {
+  text-align: center;
+  padding: 0 0 70px 0;
+}
+.loading-bar .loading-img {
+  background: url(../images/loading.gif) no-repeat;
+  width: 128px;
+  height: 22px;
+  display: block;
+  margin: 0 auto;
+}
+
+/* .blog-details-data */
+
+.blog-details-data.container {
+  padding: 0 83px;
+  min-height: 300px;
+}
+
+/* .blog-details-data .title-bar */
+
+.blog-details-data.container .title-bar {
+  position: relative;
+  padding: 14px 0 17px 0;
+}
+.blog-details-data.container .title-bar .date-txt {
+  font-family: 'Source Sans Pro';
+  font-weight: 700;
+  font-size: 16px;
+  color: #4b4b4b;
+  line-height: 32px;
+}
+.blog-details-data.container .title-bar .social-ul {
+  position: absolute;
+  top: 41px;
+  right: 0;
+}
+.blog-details-data.container .title-bar .social-ul li {
+  float: left;
+  margin-left: 13px;
+}
+
+/* .blog-details-data .info-box */
+
+.blog-details-data.container .info-box {
+  position: relative;
+}
+.blog-details-data.container .info-box .img-main, .blog-details-data.container .info-box .img-main img {
+  height: 536px;
+}
+.blog-details-data.container .info-box .img-main img {
+  width: 100%;
+}
+.blog-details-data.container .info-box .info-main {
+  border-bottom: 1px solid #c6c6c6;
+  padding: 45px 3px 18px 3px;
+  overflow: hidden;
+}
+.blog-details-data.container .info-box .info-main .lefts, .blog-details-data.container .info-box .info-main .rights {
+  color: #4b4b4b;
+  width: 50%;
+  float: left;
+}
+.blog-details-data.container .info-box .info-main .lefts p {
+  padding-right: 18px;
+}
+.blog-details-data.container .info-box .info-main .rights p {
+  padding-left: 18px;
+}
+.blog-details-data.container .info-box .info-main .font20 {
+  font-family: 'Source Sans Pro';
+  font-weight: 700;
+  font-size: 20px;
+  line-height: 36px;
+}
+.blog-details-data.container .info-box .info-main .font14 {
+  font-size: 14px;
+  line-height: 28px;
+}
+.blog-details-data.container .info-box .down25 {
+  padding-bottom: 23px;
+}
+.blog-details-data.container .info-box .info-main .rights .down25 {
+  padding-bottom: 27px;
+}
+
+/* .related-blog-module */
+
+.related-blog-module {
+  padding: 26px 0 7px 0;
+}
+.related-blog-module .container.grid-data {
+  position: relative;
+}
+.related-blog-module .form-area {
+  min-height: 83px;
+}
+.related-blog-module .title-related-blog {
+  width: 263px;
+  position: absolute;
+  top: 13px;
+  right: 83px;
+}
+.related-blog-module .desktop-show {
+  display: block;
+}
+.related-blog-module .mobile-show {
+  display: none;
+}
+.related-blog-module .carousel-control.left, .related-blog-module .carousel-control.right {
+  background-color: rgba(40, 40, 40, 0.15);
+  text-shadow: none;
+  background-image: none;
+  box-shadow: none;
+  opacity: 1;
+  width: 49px;
+  height: 47px;
+  border: 2px solid #fff;
+  top: 50%;
+  margin-top: -78px;
+}
+.related-blog-module .carousel-control.left {
+  left: -53px;
+}
+.related-blog-module .carousel-control.right {
+  right: -53px;
+}
+.related-blog-module .carousel-control.left .icons, .related-blog-module .carousel-control.right .icons {
+  width: 24px;
+  height: 24px;
+  margin-top: 9px;
+}
+.related-blog-module .carousel-control.left .icons {
+  background-position: -288px -16px;
+}
+.related-blog-module .carousel-control:hover.left .icons {
+  background-position: -336px -16px;
+}
+.related-blog-module .carousel-control.right .icons {
+  background-position: -360px -16px;
+}
+.related-blog-module .carousel-control:hover.right .icons {
+  background-position: -385px -16px;
+}
+.related-blog-module .carousel-inner>.active {
+  min-height: 620px;
+}
+
+/* .comments-module */
+
+.comments-module {
+  background: #f4f4f4;
+  position: relative;
+}
+.comments-module .container {
+  padding: 37px 83px 0 83px;
+}
+.comments-module .container .title-comments {
+  width: 202px;
+  letter-spacing: 9px;
+  margin-bottom: 20px;
+  padding-left: 20px;
+}
+
+/* .comments-module .comments-area  .comments-list*/
+
+.comments-module .comments-area {
+  min-height: 200px;
+}
+.comments-module .comments-area .comments-list {
+  padding: 51px 100px 34px 0;
+  border-bottom: 1px solid #c6c6c6;
+  position: relative;
+}
+.comments-module .comments-area .spaceleft {
+  padding-left: 100px;
+}
+.comments-module .comments-area .spacetop {
+  padding-top: 26px;
+}
+.comments-module .comments-area .comments-list .head-img {
+  float: left;
+  width: 130px;
+}
+.comments-module .comments-area .comments-list .head-img img {
+  width: 99px;
+  height: 99px;
+}
+.comments-module .comments-area .comments-list .info-box {
+  margin-left: 130px;
+}
+.comments-module .comments-area .comments-list .info-box .title-h4 {
+  padding: 3px 0 11px 0;
+}
+.comments-module .comments-area .comments-list .info-box .title-h4 a {
+  font-family: 'Source Sans Pro';
+  font-weight: 700;
+  font-size: 18px;
+  color: #282828;
+  text-transform: uppercase;
+}
+.comments-module .comments-area .comments-list .info-box .title-h4 a:hover {
+  color: #00a1d9;
+}
+.comments-module .comments-area .comments-list .info-box p {
+  font-size: 14px;
+  color: #8a8a8a;
+  line-height: 24px;
+  padding: 0 28px 0 0;
+}
+.comments-module .comments-area .comments-list .comments-apply {
+  background-color: rgba(41, 41, 41, 0.15);
+  background-image: none;
+  box-shadow: none;
+  opacity: 1;
+  width: 102px;
+  height: 42px;
+  line-height: 42px;
+  letter-spacing: 6px;
+  text-align: center;
+  border: 2px solid #fff;
+  border-bottom-width: 1px;
+  position: absolute;
+  right: 0;
+  bottom: 0px;
+  cursor: pointer;
+}
+.comments-module .comments-area .comments-list .comments-apply a {
+  font-family: 'Source Sans Pro';
+  font-weight: 700;
+  font-size: 14px;
+  color: #898989;
+  display: block;
+  padding-left: 5px;
+}
+.comments-module .comments-area .comments-list .comments-apply a:hover {
+  color: #1ab1e6;
+  text-decoration: none;
+}
+
+/* .comments-module .comments-area .quick-reply */
+
+.comments-module .comments-area .quick-reply {
+  padding: 38px 0 121px 0;
+  position: relative;
+}
+.comments-module .comments-area .quick-reply .quick-reply-txt {
+  float: left;
+  width: 130px;
+}
+.comments-module .comments-area .quick-reply .quick-reply-txt .title-h4 {
+  padding: 25px 0 22px 0;
+  font-family: 'Source Sans Pro';
+  font-weight: 700;
+  font-size: 18px;
+  color: #282828;
+  text-transform: uppercase;
+}
+.comments-module .comments-area .quick-reply .quick-reply-txt p {
+  font-size: 14px;
+  color: #9d9d9d;
+}
+.comments-module .comments-area .quick-reply .quick-reply-txt li {
+  float: left;
+  margin-top: 11px;
+  margin-left: -1px;
+}
+.comments-module .comments-area .quick-reply .quick-reply-txt li:nth-child(2) {
+  margin-left: 13px;
+}
+.comments-module .comments-area .quick-reply .textarea-box {
+  margin-right: 4px;
+  margin-left: 130px;
+  height: 196px;
+  border: 1px solid #9d9d9d;
+  padding: 21px 29px;
+  display: block;
+  background: #fff;
+}
+.comments-module .comments-area .quick-reply .textarea-box textarea {
+  font-size: 12px;
+  color: #9d9d9d;
+  outline: none;
+  border: none;
+  resize: none;
+  width: 100%;
+  height: 115px;
+  line-height: 14px;
+  letter-spacing: 6px;
+}
+.comments-module .comments-area .quick-reply .comments-post {
+  background-color: rgba(41, 41, 41, 0.15);
+  background-image: none;
+  box-shadow: none;
+  opacity: 1;
+  width: 101px;
+  height: 43px;
+  line-height: 43px;
+  text-align: center;
+  position: absolute;
+  right: 5px;
+  bottom: 122px;
+  cursor: pointer;
+  letter-spacing: 4px;
+}
+.comments-module .comments-area .quick-reply .comments-post a {
+  font-family: 'Source Sans Pro';
+  font-weight: 700;
+  font-size: 14px;
+  color: #898989;
+  display: block;
+  padding: 2px 0 0 3px;
+}
+.comments-module .comments-area .quick-reply .comments-post a:hover {
+  color: #1ab1e6;
+  text-decoration: none;
+}
 
 /* .footer */
-.footer .row {
-	padding: 0 82px 0 95px;
+
+.footer {
+  background-color: #282828;
+  min-height: 100px;
 }
-	.footer .row .col-menu,
-	.footer .row .col-info {
-		padding: 55px 0 48px 0;
-	}
-		.footer .row .col-menu dt,
-		.footer .row .col-info dt {
-			line-height: 20px;
-		}
-			.footer .row .col-menu dt a,
-			.footer .row .col-info dt a {
-				font-size: 11.57px;
-			}
-		.footer .row .col-menu dd,
-		.footer .row .col-info dd {
-			line-height: 19px;
-		}
-		.footer .row .col-info dt {
-			padding-bottom: 4px;
-		}
-			.footer .row .col-info a {
-				font-size: 9.92px;
-			}
-			.footer .row .col-info p {
-				font-size: 9.92px;
-				text-align: justify;
-				line-height: 20px;
-				padding: 5px 0 0 0;
-			}
-	/* .footer .bottoms */
-	.footer .bottoms {
-		margin: 0 86px 0 99px;
-		min-height: 100px;
-	}
-		.footer .bottoms .logo {
-			background-size: 141px auto;
-			margin: 16px 0 0 -4px;
-			width: 141px;
-			height: 56px;
-		}
-		.footer .bottoms .social-ul {
-			margin: 32px -8px 0 0;
-		}
-			.footer .bottoms .social-ul li {
-				margin: 0 0 0 25px;
-			}
-				.footer .bottoms .social-ul li .icons {
-					width: 19px;
-					height: 19px;
-				}
-					.footer .bottoms .social-ul li .icon-fb {
-						background-position: 0 -13px;
-					}
-						.footer .bottoms .social-ul li .icon-fb:hover {
-							background-position: -20px -13px;
-						}
-					.footer .bottoms .social-ul li .icon-tw {
-						background-position: -38px -13px;
-					}
-						.footer .bottoms .social-ul li .icon-tw:hover {
-							background-position: -58px -13px;
-						}
-					.footer .bottoms .social-ul li .icon-gg {
-						background-position: -76px -13px;
-					}
-						.footer .bottoms .social-ul li .icon-gg:hover {
-							background-position: -96px -13px;
-						}
+.footer .container {
+  height: 100%;
+  position: relative;
+  padding: 0;
+  top: 0;
+  left: 0;
+  z-index: 99;
+}
 
+/* .footer .row */
 
+.footer .row {
+  margin: 0;
+  padding: 0 112px 0 115px;
+}
+.footer .row .col-menu, .footer .row .col-info {
+  float: left;
+  padding: 66px 0 62px 0;
+}
+.footer .row .col-menu dt, .footer .row .col-info dt {
+  line-height: 25px;
+}
+.footer .row .col-menu dt a, .footer .row .col-info dt a {
+  font-family: 'Source Sans Pro';
+  font-weight: 700;
+  color: #14b1e7;
+  font-size: 14px;
+  text-transform: uppercase;
+}
+.footer .row .col-menu dd, .footer .row .col-info dd {
+  line-height: 24px;
+}
+
+/* .footer .col-menu */
+
+.footer .row .col-menu {
+  width: 17%;
+}
+.footer .row .col-menu dt {
+  padding-bottom: 0;
+}
+
+/* .footer .col-info */
+
+.footer .row .col-info {
+  width: 20.75%;
+}
+.footer .row .col-info dt {
+  padding-bottom: 4px;
+}
+.footer .row .col-info a {
+  color: #8a8a8a;
+  font-size: 12px;
+}
+.footer .row .col-info p {
+  color: #8a8a8a;
+  font-size: 12px;
+  text-align: justify;
+  line-height: 24px;
+  padding: 5px 0 0 0;
+}
+
+/* .footer .bottoms */
+
+.footer .bottoms {
+  border-top: 1px solid #393939;
+  margin: 0 121px 0 119px;
+  min-height: 120px;
+}
+.footer .bottoms .logo {
+  background: url(../images/logo-white.png) no-repeat;
+  background-size: 171px auto;
+  margin: 16px 0 0 -4px;
+  width: 171px;
+  height: 68px;
+  display: block;
+}
+.footer .bottoms .social-ul {
+  margin: 38px -8px 0 0;
+}
+.footer .bottoms .social-ul li {
+  float: left;
+  margin: 0 0 0 28px;
+}
+.footer .bottoms .social-ul li .icons {
+  width: 24px;
+  height: 24px;
+}
+.footer .bottoms .social-ul li .icon-fb {
+  background-position: 0 -16px;
+}
+.footer .bottoms .social-ul li .icon-fb:hover {
+  background-position: -24px -16px;
+}
+.footer .bottoms .social-ul li .icon-tw {
+  background-position: -48px -16px;
+}
+.footer .bottoms .social-ul li .icon-tw:hover {
+  background-position: -72px -16px;
+}
+.footer .bottoms .social-ul li .icon-gg {
+  background-position: -96px -16px;
+}
+.footer .bottoms .social-ul li .icon-gg:hover {
+  background-position: -120px -16px;
+}
 
 /* .modal-default */
+
+.modal-backdrop.in {
+  filter: alpha(opacity=63);
+  opacity: .63;
+}
 .modal.modal-default .modal-dialog {
-	width: 967px;
-	margin: 90px auto;
+  width: 1170px;
+  margin: 109px auto;
 }
-	/* .modal-default .modal-header */
-	.modal.modal-default .modal-header {
-		text-align: center;
-		padding: 0;
-		border-bottom: none;
-	}
-		.modal.modal-default .btn-close {
-			width: 13px;
-			height: 13px;
-			top: 45px;
-			right: 50px;
-		}
-			.modal.modal-default .btn-close:hover {
-				background-position: -13px 0;
-			}
-
-	/* #modal-how-it-works */
-	#modal-how-it-works .title-how-it-works {
-		width: 229px;
-		margin: 37px auto 0 auto;
-	}
-		#modal-how-it-works .txt-info {
-			font-size: 11.57px;
-			line-height: 23px;
-			padding: 33px 167px;
-		}
-	  /* #modal-how-it-works .info-row */
-	  #modal-how-it-works .info-row {
-		  padding: 25px 80px 7px 80px;
-	  }
-		#modal-how-it-works .info-row .video-area .video,
-		#modal-how-it-works .info-row .video-area .video img{
-			width: 414px;
-			height: 269px;
-		}
-		#modal-how-it-works .info-row .video-area .video iframe {
-			width: 414px;
-			height: 269px;
-			border: none;
-		}
-			#modal-how-it-works .info-row .video-area .btn-play {
-				width: 108px;
-				height: 108px;
-				margin: -54px 0 0 -54px;
-			}
-				#modal-how-it-works .info-row .video-area .btn-play .icons {
-					background-position: 0 -71px;
-					width: 78px;
-					height: 78px;
-					margin: 8px 0 0 0;
-				}
-					#modal-how-it-works .info-row .video-area .btn-play:hover .icons,
-					#modal-how-it-works .info-row .video-area .btn-play:focus .icons {
-						background-position: -78px -71px;
-					}
-		  #modal-how-it-works .info-row .step-area {
-			  margin: 0 436px 0 0;
-			  min-height: 269px;
-		  }
-			  #modal-how-it-works .step-area .module-box {
-				  padding: 0 20px 0 0;
-				  margin-bottom: 40px;
-			  }
-				  #modal-how-it-works .step-area .icon-blue-round {
-					  width: 58px;
-					  height: 58px;
-					  margin: 0;
-				  }
-					  #modal-how-it-works .step-area .icon-blue-round .icons {
-						  width: 39px;
-						  height: 39px;
-						  margin-top: 9px;
-					  }
-						  #modal-how-it-works .step-area .icon-fundraise .icons {
-							  background-position: -0 -32px;
-						  }
-						  #modal-how-it-works .step-area .icon-invest .icons {
-							  background-position: -39px -32px;
-						  }
-						  #modal-how-it-works .step-area .icon-pay-it-forward .icons {
-							  background-position: -78px -32px;
-						  }
-					  #modal-how-it-works .step-area .info-txt {
-						  margin: 0 45px 0 80px;
-					  }
-						  #modal-how-it-works .step-area .info-txt h4 {
-							  font-size: 14.88px;
-							  line-height: 20px;
-							  padding-bottom: 4px;
-							  margin-top: -7px;
-						  }
-						  #modal-how-it-works .step-area .info-txt p {
-							  font-size: 11.57px;
-							  line-height: 21px;
-						  }
+.modal.modal-default .modal-content {
+  -webkit-box-shadow: 0 0 40px rgba(34, 34, 33, .9);
+  box-shadow: 0 0 40px rgba(34, 34, 33, .9);
+  border-radius: 0;
+  border: none;
 }
 
+/* .modal-default .modal-header */
 
+.modal.modal-default .modal-header {
+  text-align: center;
+  padding: 0;
+  border-bottom: none;
+}
+.modal.modal-default .btn-close {
+  background-position: 0 0;
+  width: 16px;
+  height: 16px;
+  position: absolute;
+  opacity: 1;
+  top: 54px;
+  right: 61px;
+  z-index: 99;
+}
+.modal.modal-default .btn-close:hover {
+  background-position: -16px 0;
+}
 
+/* .modal-default .modal-body */
+
+.modal.modal-default .modal-body {
+  padding: 0;
+  min-height: 100px;
+}
+
+/* #modal-how-it-works */
+
+#modal-how-it-works .title-how-it-works {
+  width: 277px;
+  margin: 44px auto 0 auto;
+}
+#modal-how-it-works .txt-info {
+  font-size: 14px;
+  color: #4b4b4b;
+  line-height: 28px;
+  text-align: center;
+  padding: 41px 200px;
+}
+
+/* #modal-how-it-works .info-row */
+
+#modal-how-it-works .info-row {
+  padding: 25px 99px 7px 99px;
+}
+#modal-how-it-works .info-row .video-area .video {
+  background: #000;
+  width: 501px;
+  height: 326px;
+  position: relative;
+}
+#modal-how-it-works .info-row .video-area .video iframe {
+  width: 501px;
+  height: 326px;
+  border: none;
+}
+#modal-how-it-works .info-row .video-area .video-opacity {
+  background: rgba(0, 0, 0, 0.5);
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+#modal-how-it-works .info-row .video-area .btn-play {
+  text-align: center;
+  border: 5px solid #fff;
+  border-radius: 100%;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 130px;
+  height: 130px;
+  margin: -75px 0 0 -75px;
+}
+#modal-how-it-works .info-row .video-area .btn-play .icons {
+  background-position: 0 -88px;
+  width: 96px;
+  height: 96px;
+  margin: 13px 0 0 0;
+}
+#modal-how-it-works .info-row .video-area .btn-play:hover, #modal-how-it-works .info-row .video-area .btn-play:focus {
+  border: 5px solid #1cb0e6;
+}
+#modal-how-it-works .info-row .video-area .btn-play:hover .icons, #modal-how-it-works .info-row .video-area .btn-play:focus .icons {
+  background-position: -96px -88px;
+}
+#modal-how-it-works .info-row .step-area {
+  margin: 3px 530px 0 0;
+  min-height: 326px;
+  position: relative;
+}
+#modal-how-it-works .step-area .module-box {
+  padding: 0 20px 0 0;
+  margin-bottom: 44px;
+}
+#modal-how-it-works .step-area .icon-blue-round {
+  text-align: center;
+  background: #00a1d9;
+  width: 70px;
+  height: 70px;
+  border-radius: 100%;
+  margin-top: 3px;
+}
+#modal-how-it-works .step-area .icon-blue-round .icons {
+  width: 48px;
+  height: 48px;
+  margin-top: 12px;
+}
+#modal-how-it-works .step-area .icon-fundraise .icons {
+  background-position: 0 -40px;
+}
+#modal-how-it-works .step-area .icon-invest .icons {
+  background-position: -48px -40px;
+}
+#modal-how-it-works .step-area .icon-pay-it-forward .icons {
+  background-position: -96px -40px;
+}
+#modal-how-it-works .step-area .info-txt {
+  margin: 0 55px 0 100px;
+}
+#modal-how-it-works .step-area .info-txt h4 {
+  font-family: 'Source Sans Pro';
+  font-weight: 700;
+  font-size: 18px;
+  line-height: 20px;
+  padding-bottom: 10px;
+  margin-top: -4px;
+}
+#modal-how-it-works .step-area .info-txt p {
+  font-size: 14px;
+  color: #8a8a8a;
+  line-height: 24px;
+}
+
+/*fix layout issue when smaller than 1221px width*/
+
+@media (min-width: 1221px) {
+  .container {
+    width: 1200px;
+  }
+}
+
+/*fix layout issue when smaller than 1200px width*/
+
+@media (max-width: 1199px) {
+  .icons {
+    background: url(../images/icon-sprites.png) no-repeat;
+    background-size: 543px auto;
+  }
+  /* btn */
+  .btn-blue {
+    font-size: 11.57px;
+    height: 43px;
+    line-height: 43px;
+    padding: 2px 5px 0 5px;
+  }
+  .btn-icon-gray {
+    width: 44px;
+    height: 35px;
+  }
+  .btn-icon-gray .icons {
+    width: 19px;
+    height: 19px;
+    margin-top: 6px;
+  }
+  .btn-icon-gray .icon-fb {
+    background-position: -116px -13px;
+  }
+  .btn-icon-gray:hover .icon-fb {
+    background-position: -135px -13px;
+  }
+  .btn-icon-gray .icon-tw {
+    background-position: -155px -13px;
+  }
+  .btn-icon-gray:hover .icon-tw {
+    background-position: -175px -13px;
+  }
+  .btn-icon-gray .icon-gg {
+    background-position: -194px -13px;
+  }
+  .btn-icon-gray:hover .icon-gg {
+    background-position: -213px -13px;
+  }
+  /* .dropdown-default */
+  .dropdown-default .btn-default {
+    font-size: 9.92px;
+    letter-spacing: 4px;
+    padding: 0 22px 0 18px;
+    height: 30px;
+    line-height: 28px;
+  }
+  .dropdown-default .btn-default .icon-arrow-down {
+    background-position: -39px 0;
+    width: 13px;
+    height: 13px;
+    top: 6px;
+    right: 7px;
+  }
+  .dropdown-default .btn-default.active .icon-arrow-down, .dropdown-default .btn-default:active .icon-arrow-down, .open.dropdown-default>.dropdown-toggle.btn-default .icon-arrow-down {
+    background-position: -52px 0;
+  }
+  .dropdown-default .dropdown-menu {
+    font-size: 9.92px;
+    min-width: 30px;
+    padding: 2.5px 0;
+  }
+  .dropdown-default .dropdown-menu>li>a {
+    padding: 0 19px;
+    line-height: 20px;
+  }
+  /* title */
+  .title-white-border, .title-blue-border {
+    font-size: 14.88px;
+    letter-spacing: 7px;
+    height: 35px;
+    line-height: 35px;
+    padding: 0 5px;
+  }
+  .container {
+    width: auto;
+  }
+  /* .header */
+  .header {
+    margin-top: 30px;
+    height: 85px;
+  }
+  .header .logo {
+    background: url(../images/logo-white.png) no-repeat;
+    background-size: 141px auto;
+    margin: 9px 0 0 70px;
+    width: 141px;
+    height: 56px;
+  }
+  .header .btn-donate {
+    min-width: 110px;
+  }
+  .header .rights {
+    padding: 15px 54px 0 0;
+  }
+  .header .txt {
+    font-size: 11.57px;
+    padding: 2px 14px 3px 0;
+    line-height: 22px;
+  }
+  /* .after-scroll-header */
+  .header.after-scroll-header .logo {
+    background-size: 141px auto;
+    margin: 14px 0 0 70px;
+    width: 141px;
+    height: 56px;
+  }
+  .header.after-scroll-header .rights {
+    padding: 19px 71px 0 0;
+  }
+  /* .top-section */
+  .top-section {
+    min-height: 124px;
+  }
+  .top-section .sub-section-bg {
+    background: url(../images/small/small-sub-section-bg.jpg) no-repeat center top;
+    background-size: 100% 124px;
+  }
+  .top-section.min-height {
+    min-height: 815px;
+  }
+  .top-section .section-video img {
+    width: 100%;
+    height: 815px;
+  }
+  .top-section .section-video-area iframe, .top-section .section-video-area video, .top-section .section-video-area .mejs-container, .top-section .section-video-area .me-plugin, .top-section .section-video-area embed, .top-section .section-video-area .mejs-overlay-play {
+    width: 100%!important;
+    height: 815px!important;
+    border: none;
+  }
+  .top-section.min-height .container {
+    top: 0;
+    width: 100%;
+    margin-left: 0;
+    left: 0;
+  }
+  /* .top-section .carousel */
+  .top-section .carousel {
+    padding-right: 65px;
+    padding-left: 65px;
+  }
+  /* .top-section .carousel */
+  .top-section .carousel {
+    top: 95px;
+  }
+  /* .top-section .carousel .item */
+  .top-section .carousel .item {
+    padding: 155px 0 0 0;
+    min-height: 673px;
+  }
+  .top-section .carousel .item-info {
+    width: 500px;
+  }
+  .top-section .carousel .item-info .titles {
+    font-size: 39.68px;
+    line-height: 48px;
+  }
+  .top-section .carousel .item-info p {
+    font-size: 16.53px;
+    line-height: 28px;
+    width: 480px;
+    padding: 9px 0 32px 0;
+  }
+  .top-section .carousel .item-info .btn-donate-now {
+    letter-spacing: 4.5px;
+    min-width: 144px;
+    padding-left: 8px;
+  }
+  /* .top-section .carousel-indicators */
+  .top-section .carousel-indicators li {
+    width: 10px;
+    height: 10px;
+  }
+  .top-section .icon-arrow-down {
+    background-position: -194px -32px;
+    width: 40px;
+    height: 40px;
+    bottom: -40px;
+    margin: 0 0 0 -20px;
+  }
+  .top-section .carousel-control.left, .top-section .carousel-control.right {
+    width: 40px;
+    height: 40px;
+    top: 279px;
+  }
+  .top-section .carousel-control.left {
+    left: 13px;
+  }
+  .top-section .carousel-control.right {
+    right: 13px;
+  }
+  .top-section .carousel-control.left .icons, .top-section .carousel-control.right .icons {
+    width: 19px;
+    height: 19px;
+    margin-top: 9px;
+  }
+  .top-section .carousel-control.left .icons {
+    background-position: -252px -13px;
+  }
+  .top-section .carousel-control:hover.left .icons {
+    background-position: -272px -13px;
+  }
+  .top-section .carousel-control.right .icons {
+    background-position: -330px -13px;
+  }
+  .top-section .carousel-control:hover.right .icons {
+    background-position: -311px -13px;
+  }
+  .top-section .carousel-indicators {
+    bottom: 8px;
+  }
+  /* home page */
+  /* .active-projects-module */
+  .active-projects-module {
+    padding-bottom: 65px;
+  }
+  .active-projects-module .title-active-projects {
+    width: 306px;
+    margin: 45px auto 57px auto;
+  }
+  .active-projects-module .row {
+    margin: 0 80px;
+  }
+  /* .active-projects-module .module-box */
+  .active-projects-module .module-box {
+    margin: 0 15px;
+  }
+  .active-projects-module .img-main .txt-table {
+    height: 241px;
+  }
+  .active-projects-module .img-main .txt {
+    font-size: 24.8px;
+    line-height: 27px;
+    padding: 0 20px 10px 20px;
+  }
+  .active-projects-module .img-main .funded-round {
+    width: 110px;
+    height: 110px;
+    padding: 8px;
+    bottom: -55px;
+    margin: 0 0 0 -55px;
+  }
+  .active-projects-module .img-main .funded-round .round-depict {
+    font-size: 11.57px;
+    top: 50%;
+    left: 50%;
+    width: 94px;
+    margin: 2px 0 0 -47px;
+  }
+  .active-projects-module .img-main .funded-round .status-indicator input {
+    font-size: 24.8px !important;
+    margin-top: 22px !important;
+  }
+  .active-projects-module.embedded .img-main .funded-round .status-indicator input {
+    margin-top: -75px !important;
+    margin-left: 22px !important;
+  }
+  .active-projects-module.embedded .img-main .funded-round .status-indicator input.smaller {
+    font-size: 20.5px !important;
+    margin-top: -73px !important;
+    margin-left: 22px !important;
+    -webkit-transition: font-size 0.25s ease;
+    transition: font-size 0.25s ease;
+  }
+  .active-projects-module .img-main .funded-round .status-indicator input.smaller {
+    font-size: 20px !important;
+    margin-top: 22px !important;
+    -webkit-transition: font-size 0.25s ease;
+    transition: font-size 0.25s ease;
+  }
+  .small-circle {
+    display: block;
+  }
+  .desktop-circle, .tablet-circle, .mobile-circle {
+    display: none;
+  }
+  /* .active-projects-module .info-main */
+  .active-projects-module .info-main {
+    padding: 33px 25px 29px 23px;
+  }
+  .active-projects-module .info-main .blue-bar, .active-projects-module .info-main .dark-blue-bar {
+    font-size: 13.23px;
+    height: 50px;
+    line-height: 50px;
+    padding: 0 11px 0 19px;
+    margin-top: 16px;
+  }
+  /* .our-impacts-module */
+  .our-impacts-module .title-our-impacts {
+    letter-spacing: 8px;
+    padding-left: 12px;
+    width: 228px;
+    margin: 58px auto 47px auto;
+  }
+  .our-impacts-module .row {
+    margin: 0 58px 0 80px;
+    padding: 0 0 30px 0;
+  }
+  .our-impacts-module .row .col-md-3:nth-child(1) .module-box {
+    width: 140px;
+    margin-left: -11px;
+  }
+  .our-impacts-module .row .col-md-3:nth-child(2) .module-box .titles {
+    padding-right: 30px;
+  }
+  .our-impacts-module .row .col-md-3:nth-child(3) .module-box .icons {
+    margin-left: 5%;
+  }
+  .our-impacts-module .row .col-md-3:nth-child(3) .module-box .titles {
+    padding-top: 14px;
+    line-height: 25px;
+  }
+  .our-impacts-module .row .col-md-3:nth-child(4) .module-box {
+    float: right;
+    width: 155px;
+  }
+  .our-impacts-module .row .col-md-3:nth-child(4) .module-box .titles {
+    padding-top: 14px;
+    line-height: 35px;
+  }
+  .our-impacts-module .module-box .icons {
+    width: 136px;
+    height: 136px;
+  }
+  .our-impacts-module .module-box .icon-people {
+    background-position: 0 -149px;
+  }
+  .our-impacts-module .module-box .icon-home-ok {
+    background-position: -136px -149px;
+  }
+  .our-impacts-module .module-box .icon-tree {
+    background-position: -272px -149px;
+  }
+  .our-impacts-module .module-box .icon-user {
+    background-position: -407px -149px;
+  }
+  .our-impacts-module .module-box .titles {
+    line-height: 45px;
+  }
+  .our-impacts-module .module-box .font20 {
+    font-size: 16.53px;
+  }
+  .our-impacts-module .module-box .font48 {
+    font-size: 39.68px;
+  }
+  .our-impacts-module .module-box .font72 {
+    font-size: 59.52px;
+  }
+  .our-impacts-module .module-box .txt {
+    font-size: 14.88px;
+    line-height: 17px;
+    padding-top: 6px
+  }
+  /* .how-it-works-module */
+  .how-it-works-module .container {
+    padding: 0;
+  }
+  .how-it-works-module .title-how-it-works {
+    letter-spacing: 8px;
+    width: 230px;
+    margin: 48px auto 0 auto;
+  }
+  /* .how-it-works-module .info-row */
+  .how-it-works-module .info-row {
+    padding: 47px 74px 0 95px;
+  }
+  .how-it-works-module .info-row .video-area .video, .how-it-works-module .info-row .video-area .video img, .how-it-works-module .info-row .video-area .video iframe {
+    width: 414px;
+    height: 269px;
+  }
+  .how-it-works-module .info-row .video-area .btn-play {
+    width: 108px;
+    height: 108px;
+    margin: -54px 0 0 -54px;
+  }
+  .how-it-works-module .info-row .video-area .btn-play .icons {
+    background-position: 0 -71px;
+    width: 78px;
+    height: 78px;
+    margin: 8px 0 0 0;
+  }
+  .how-it-works-module .info-row .video-area .btn-play:hover .icons, .how-it-works-module .info-row .video-area .btn-play:focus .icons {
+    background-position: -78px -71px;
+  }
+  .how-it-works-module .info-row .txt-area {
+    margin: 0 436px 0 0;
+  }
+  .how-it-works-module .info-row .txt-area .txt-table {
+    min-height: 269px;
+  }
+  .how-it-works-module .info-row .txt-area .txt-td p {
+    font-size: 11.57px;
+    line-height: 23px;
+    letter-spacing: 0;
+  }
+  /* .how-it-works-module .step-row */
+  .how-it-works-module .step-row {
+    margin: 53px 74px 0 95px;
+  }
+  .how-it-works-module .step-row .module-box {
+    position: relative;
+    padding-top: 10px;
+    min-height: 141px;
+  }
+  .how-it-works-module .step-row .icon-blue-round {
+    width: 58px;
+    height: 58px;
+  }
+  .how-it-works-module .step-row .icon-blue-round .icons {
+    width: 39px;
+    height: 39px;
+    margin-top: 9px;
+  }
+  .how-it-works-module .step-row .icon-fundraise .icons {
+    background-position: -0 -32px;
+  }
+  .how-it-works-module .step-row .icon-invest .icons {
+    background-position: -39px -32px;
+  }
+  .how-it-works-module .step-row .icon-pay-it-forward .icons {
+    background-position: -78px -32px;
+  }
+  .how-it-works-module .step-row .icon-arrow-right {
+    background-position: -116px -32px;
+    width: 39px;
+    height: 39px;
+    top: 29px;
+    right: 14px;
+  }
+  .how-it-works-module .step-row .info-txt {
+    margin: 0 45px 0 80px;
+  }
+  .how-it-works-module .step-row .info-txt h4 {
+    font-size: 14.88px;
+    line-height: 20px;
+    padding-bottom: 4px;
+    margin-top: -7px;
+  }
+  .how-it-works-module .step-row .info-txt p {
+    font-size: 11.57px;
+    line-height: 21px;
+  }
+  /* .how-it-works-module */
+  .testimonial-module {
+    padding-bottom: 52px;
+  }
+  .testimonial-module .title-testimonial {
+    padding-left: 10px;
+    width: 192px;
+    margin: 44px auto 0 auto;
+  }
+  /* .testimonial-module .head-row */
+  .testimonial-module .head-row {
+    padding: 53px 86px 0 64px;
+  }
+  .testimonial-module .head-row li .head-img {
+    margin: 22px 20px;
+  }
+  /*.testimonial-module .head-row li .head-img:hover,
+        .testimonial-module .head-row li .head-img:focus,*/
+  .testimonial-module .head-row li .head-img.active {
+    border-radius: 4px;
+    padding: 16px 18px;
+  }
+  /*.testimonial-module .head-row li .head-img:hover .icon-arrow-down,
+          .testimonial-module .head-row li .head-img:focus .icon-arrow-down,*/
+  .testimonial-module .head-row li .head-img.active .icon-arrow-down {
+    background-position: -162px -45px;
+    width: 24px;
+    height: 18px;
+    bottom: -18px;
+    margin: 0 0 0 -12px;
+  }
+  .testimonial-module .head-row li .head-img img {
+    width: 60px;
+    height: 60px;
+    border-radius: 4px;
+  }
+  /* .testimonial-module .info-area */
+  .testimonial-module .info-area {
+    padding: 39px 0 0 0;
+  }
+  .testimonial-module .info-area p {
+    font-size: 11.57px;
+    line-height: 23px;
+    width: 640px;
+    padding-bottom: 15px;
+  }
+  .testimonial-module .info-area .block {
+    display: block;
+  }
+  .testimonial-module .user-group {
+    padding-top: 8px;
+  }
+  .testimonial-module .user-group .link-blue {
+    font-size: 14.88px;
+  }
+  .testimonial-module .user-group .txt {
+    font-size: 11.57px;
+    line-height: 25px;
+    padding: 3px 0 30px 0;
+  }
+  .testimonial-module .user-group .btn-blue {
+    font-size: 11.57px;
+    height: 34px;
+    line-height: 34px;
+    min-width: 246px;
+    letter-spacing: 3px;
+  }
+  /* .featured-on-module */
+  .featured-on-module {
+    padding-bottom: 31px;
+  }
+  .featured-on-module .title-featured-on {
+    font-size: 14.88px;
+    letter-spacing: 7px;
+    padding-left: 12px;
+    width: 200px;
+    margin: 35px auto 43px auto;
+  }
+  /* .featured-on-module .carousel-main */
+  .featured-on-module .carousel-main {
+    min-height: 141px;
+    margin-right: 50px;
+    margin-left: 50px;
+  }
+  .featured-on-module .carousel-main .logo-ul li {
+    height: 141px;
+  }
+  .featured-on-module .logo-fast-mpany {
+    background-size: 127.5px auto;
+    width: 127.5px;
+    height: 19px;
+  }
+  .featured-on-module .logo-ehe-new-hork-eimes {
+    background-size: 115.5px auto;
+    width: 116px;
+    height: 96px;
+  }
+  .featured-on-module .logo-shareable {
+    background-size: 119px auto;
+    width: 119px;
+    height: 17px;
+  }
+  .featured-on-module .logo-shareable:hover, .featured-on-module .logo-shareable:focus {
+    background-position: center -16px;
+  }
+  .featured-on-module .logo-philanthropy {
+    background-size: 126px auto;
+    width: 126px;
+    height: 23px;
+  }
+  .featured-on-module .logo-clean-technica {
+    background-size: 126px auto;
+    width: 126px;
+    height: 37px;
+    margin-bottom: 13px;
+  }
+  .featured-on-module .logo-clean-technica:hover, .featured-on-module .logo-clean-technica:focus {
+    background-position: center -36.5px;
+  }
+  .featured-on-module .carousel-control.left, .featured-on-module .carousel-control.right {
+    width: 41px;
+    height: 39px;
+    top: 43px;
+  }
+  .featured-on-module .carousel-control.left {
+    left: -52px;
+  }
+  .featured-on-module .carousel-control.right {
+    right: -52px;
+  }
+  .featured-on-module .carousel-control.left .icons, .featured-on-module .carousel-control.right .icons {
+    width: 19px;
+    height: 19px;
+    margin: 8px auto 0 auto;
+  }
+  .featured-on-module .carousel-control.left .icons {
+    background-position: -233px -13px;
+  }
+  .featured-on-module .carousel-control:hover.left .icons {
+    background-position: -272px -13px;
+  }
+  .featured-on-module .carousel-control.right .icons {
+    background-position: -291px -13px;
+  }
+  .featured-on-module .carousel-control:hover.right .icons {
+    background-position: -310px -13px;
+  }
+  /* .newsletter-module */
+  .newsletter-module {
+    height: 370px;
+  }
+  .newsletter-module .desktop-img {
+    display: none;
+  }
+  .newsletter-module .small-img {
+    display: block;
+  }
+  .newsletter-module .img-area .small-img {
+    min-height: 371px;
+    background: transparent;
+  }
+  .newsletter-module .img-area img {
+    height: 371px;
+  }
+  .newsletter-module .title-newsletter {
+    height: 36px;
+    line-height: 36px;
+    letter-spacing: 7px;
+    padding-left: 12px;
+    width: 306px;
+    margin: 69px auto 32px auto;
+  }
+  /* .newsletter-module .container */
+  .newsletter-module .container {
+    margin: 0;
+    width: 100%;
+    left: 0;
+  }
+  .newsletter-module .group-main p {
+    font-size: 16.53px;
+    line-height: 25px;
+    padding: 0 0 26px 0;
+  }
+  .newsletter-module .group-main .group {
+    min-height: 93px;
+    margin: 0 134px 0 139px;
+    padding: 26px 25px 24px 50px;
+  }
+  .newsletter-module .group-main .group .btn-sign-up {
+    font-size: 11.57px;
+    letter-spacing: 4px;
+    height: 43px;
+    line-height: 43px;
+    width: 110px;
+    border: none;
+  }
+  .newsletter-module .group-main .group .inputs {
+    margin-right: 120px;
+    height: 43px;
+  }
+  .newsletter-module .group-main .group .inputs input {
+    font-size: 21.49px;
+    height: 43px;
+    line-height: 43px;
+  }
+  /* .contents */
+  .contents {
+    min-height: 124px;
+  }
+  .top150 {
+    margin-top: 124px;
+  }
+  /* .titles */
+  .titles.container {
+    padding: 35px 0 0 0;
+    min-height: 83px;
+  }
+  .titles.container .title-get-involved {
+    margin-right: 69px;
+    min-width: 225px;
+    letter-spacing: 9px;
+    padding-left: 12px;
+  }
+  .title-h1 {
+    font-size: 39.68px;
+    line-height: 48px;
+  }
+  /* sign in page */
+  .contents.sign-in-contents {
+    min-height: 420px;
+    margin-top: 124px;
+  }
+  .sign-in {
+    padding: 35px 68px 84px 68px;
+  }
+  .sign-in .title-sign-in {
+    padding-left: 23px;
+    padding-right: 16px;
+    height: 36px;
+    line-height: 36px;
+    font-size: 15px;
+    letter-spacing: 7px;
+  }
+  /* .sign-in .sign-in-left */
+  .sign-in .sign-in-left {
+    padding-top: 56px;
+  }
+  .sign-in .sign-in-left h2 {
+    font-size: 40px;
+    line-height: 48px;
+    margin-bottom: 7px;
+  }
+  .sign-in .sign-in-left p {
+    font-size: 12px;
+    line-height: 20px;
+  }
+  .sign-in .sign-in-left .account {
+    margin-top: 19px;
+  }
+  .sign-in .sign-in-left a {
+    font-size: 12px;
+    line-height: 20px;
+  }
+  /* .sign-in .login-area */
+  .sign-in .login-area {
+    padding: 116px 193px 0 275px;
+  }
+  .sign-in .login-area .input-wrap {
+    height: 46px;
+    margin-bottom: 9px;
+  }
+  .sign-in .login-area .input-wrap input {
+    font-size: 10px;
+    line-height: 16px;
+    padding-left: 25px;
+    padding-right: 25px;
+    letter-spacing: 5px;
+  }
+  .sign-in .check-wrap {
+    min-height: 39px;
+    padding: 6px 0 11px 0;
+  }
+  .sign-in .login-area .btn-login {
+    padding-left: 20px;
+    padding-right: 21px;
+    height: 36px;
+    line-height: 36px;
+    font-size: 12px;
+    letter-spacing: 2px;
+  }
+  /* sign up page */
+  .contents.sign-up-contents {
+    min-height: 600px;
+    margin-top: 124px;
+  }
+  .sign-up {
+    padding: 35px 69px 52px 69px;
+  }
+  .sign-up .title-sign-up {
+    padding-left: 17px;
+    padding-right: 10px;
+    height: 36px;
+    line-height: 36px;
+    font-size: 15px;
+    letter-spacing: 7px;
+  }
+  /* .sign-in .sign-in-left */
+  .sign-up .sign-up-left {
+    padding-top: 61px;
+  }
+  .sign-up .sign-up-left h2 {
+    font-size: 40px;
+    line-height: 48px;
+    margin-bottom: 1px;
+  }
+  .sign-up .sign-up-left p {
+    font-size: 12px;
+    line-height: 23px;
+  }
+  .sign-up .sign-up-left .account {
+    margin-top: 23px;
+  }
+  .sign-up .sign-up-left a {
+    font-size: 12px;
+    line-height: 23px;
+  }
+  /* .sign-up .reg-area */
+  .sign-up .reg-area {
+    padding: 116px 192px 0 275px;
+  }
+  .sign-up .reg-area .input-wrap {
+    height: 46px;
+    margin-bottom: 9px;
+  }
+  .sign-up .reg-area .input-wrap.less-margin {
+    margin-bottom: 6px;
+  }
+  .sign-up .reg-area .input-wrap.high-margin {
+    margin-bottom: 11px;
+  }
+  .sign-up .reg-area .input-wrap.higher-margin {
+    margin-bottom: 13px;
+  }
+  .sign-up .reg-area .input-wrap input {
+    font-size: 10px;
+    line-height: 16px;
+    padding-left: 25px;
+    padding-right: 25px;
+    letter-spacing: 5px;
+  }
+  .sign-up .reg-area p {
+    font-size: 10px;
+    line-height: 20px;
+    padding-left: 25px;
+    padding-right: 100px;
+    margin-bottom: 14px;
+  }
+  .sign-up .reg-area .btn-signup {
+    padding-left: 10px;
+    padding-right: 8px;
+    height: 36px;
+    line-height: 36px;
+    letter-spacing: 3px;
+  }
+  /* what do page */
+  .contents.what-we-do-contents {
+    min-height: 800px;
+    margin-top: 124px;
+  }
+  /* .article-detail */
+  .article-detail {
+    padding: 35px 69px 106px 70px;
+  }
+  .article-detail .title-do {
+    padding-left: 22px;
+    padding-right: 17px;
+    word-spacing: 2px;
+    font-size: 15px;
+    height: 36px;
+    line-height: 36px;
+    letter-spacing: 6px;
+  }
+  .article-detail .detail-left {
+    padding-right: 250px;
+    padding-top: 46px;
+  }
+  .article-detail .detail-left .title-img {
+    width: 579px;
+    height: 223px;
+    margin-bottom: 33px;
+  }
+  .article-detail .detail-left h2 {
+    font-size: 40px;
+    line-height: 48px;
+    padding-right: 50px;
+    padding-bottom: 3px;
+  }
+  .article-detail .detail-left p {
+    font-size: 12px;
+    line-height: 24px;
+    margin-top: 21px;
+    padding-right: 80px;
+  }
+  .article-detail .detail-left .btn-group {
+    padding-top: 13px;
+    width: auto;
+  }
+  .article-detail .detail-left .btn-group .btn-blue {
+    font-size: 12px;
+    line-height: 36px;
+    height: 36px;
+    letter-spacing: 3px;
+    margin-right: 23px;
+    margin-bottom: 18px;
+  }
+  .article-detail .detail-left .btn-group .btn-leasing {
+    padding-left: 16px;
+    padding-right: 11px;
+    margin-top: 4px;
+  }
+  .article-detail .detail-left .btn-group .btn-communities {
+    padding-left: 17px;
+    padding-right: 10px;
+    margin-bottom: 22px;
+    margin-right: 0;
+  }
+  .article-detail .detail-left .btn-group .btn-services {
+    padding-left: 27px;
+    padding-right: 29px;
+  }
+  /* about us page */
+  .contents.about-us-contents {
+    min-height: 490px;
+    margin-top: 124px;
+  }
+  .about-us {
+    padding: 35px 69px 84px 70px;
+  }
+  .about-us .title-about-us {
+    font-size: 15px;
+    height: 36px;
+    line-height: 36px;
+    padding-left: 19px;
+    padding-right: 13px;
+  }
+  .about-us .about-us-left {
+    padding-right: 220px;
+    padding-top: 60px;
+  }
+  .about-us .about-us-left h2 {
+    font-size: 40px;
+    line-height: 50px;
+  }
+  .about-us .about-us-left p {
+    font-size: 12px;
+    line-height: 24px;
+    margin-top: 6px;
+    margin-bottom: 27px;
+    padding-right: 100px;
+  }
+  .about-us .about-us-left .btn-works {
+    font-size: 12px;
+    line-height: 36px;
+    height: 36px;
+    letter-spacing: 3px;
+    padding-left: 24px;
+    padding-right: 22px;
+  }
+  /* .mains-tabs */
+  .mains-tabs .tab-index .row {
+    padding-right: 297px;
+    padding-left: 66px;
+  }
+  .mains-tabs .tab-index .row .col-lg-3 a {
+    font-size: 14px;
+    height: 44px;
+    line-height: 44px;
+  }
+  .mains-tabs .tab-content {
+    min-height: 342px;
+  }
+  .mains-tabs .tab-content .tab-why, .mains-tabs .tab-content .tab-how, .mains-tabs .tab-content .tab-funded, .mains-tabs .tab-content .tab-involved {
+    padding-left: 70px;
+  }
+  .mains-tabs .tab-content .img-left {
+    float: left;
+    margin-top: 46px;
+    width: 249px;
+    height: 180px;
+  }
+  .mains-tabs .tab-content .content-right {
+    margin-left: 274px;
+  }
+  .mains-tabs .tab-content .content-right p {
+    font-size: 12px;
+    line-height: 24px;
+  }
+  .mains-tabs .tab-content .tab-why .content-right p {
+    padding-top: 91px;
+    padding-right: 240px;
+  }
+  .mains-tabs .tab-content .tab-how .content-right, .mains-tabs .tab-content .tab-funded .content-right {
+    padding-top: 37px;
+  }
+  .mains-tabs .tab-content .tab-how .content-right p, .mains-tabs .tab-content .tab-funded .content-right p {
+    margin-bottom: 20px;
+    padding-right: 66px;
+  }
+  .mains-tabs .tab-content .tab-involved .content-right {
+    padding-top: 44px;
+  }
+  .mains-tabs .tab-content .tab-involved .btn-blue {
+    margin-right: 58px;
+    margin-bottom: 20px;
+    font-size: 12px;
+    line-height: 36px;
+    width: 248px;
+    height: 36px;
+    letter-spacing: 3px;
+  }
+  /* get involved page */
+  /* .info-area */
+  .info-area.container {
+    padding: 0 69px 35px 69px;
+  }
+  .info-area.container .title-h1 {
+    padding: 12px 460px 20px 0;
+  }
+  .info-area.container .txt {
+    font-size: 11.57px;
+    line-height: 24px;
+    padding-right: 340px;
+    padding-bottom: 17px;
+  }
+  /* .list-area */
+  .list-area.container {
+    padding: 0 69px 34px 69px;
+  }
+  /* .list-area .row */
+  .list-area .row {
+    margin: 0 0 54px 0;
+  }
+  /* .list-area  .lefts */
+  .list-area .row .lefts {
+    width: 415px;
+  }
+  /* .list-area .img-main */
+  .list-area .img-main .funded-round {
+    width: 100px;
+    height: 100px;
+    bottom: -83px;
+    margin: 0 0 0 -50px;
+  }
+  .get-involved-contents .funded-round .status-indicator {
+    margin: 0 0 0 -2px;
+  }
+  .get-involved-contents .funded-round .round-depict {
+    font-size: 11.57px;
+    width: 110px;
+    margin: 2px 0 0 -55px;
+  }
+  .get-involved-contents .funded-round .status-indicator input {
+    font-size: 24.8px !important;
+    margin-top: 20px !important;
+  }
+  /* .list-area .info-main */
+  .list-area .info-main .blue-bar, .list-area .info-main .dark-blue-bar {
+    font-size: 11.57px;
+    height: 28px;
+    line-height: 28px;
+    padding: 0 24px;
+    margin-top: 6px;
+  }
+  /* .list-area  .rights */
+  .list-area .row .rights {
+    margin: 0 0 0 440px;
+  }
+  .list-area .row .rights h2 {
+    line-height: 26px;
+    margin-top: -6px;
+  }
+  .list-area .row .rights h2 a {
+    font-size: 24.8px;
+  }
+  .list-area .row .rights .time {
+    font-size: 13.23px;
+    padding: 4px 0 9px 0;
+  }
+  .list-area .row .rights p {
+    font-size: 11.57px;
+    line-height: 24px;
+    padding-right: 10px;
+    padding-bottom: 25px;
+  }
+  .list-area .row .rights .bottom-bar {
+    padding-right: 10px;
+  }
+  .list-area .row .rights .bottom-bar .btn-read-more {
+    font-size: 11.57px;
+    letter-spacing: 4px;
+    padding-left: 15px;
+    width: 140px;
+    height: 35px;
+    line-height: 35px;
+  }
+  .list-area .row .rights .bottom-bar .social-ul {
+    float: right;
+  }
+  .list-area .row .rights .bottom-bar .social-ul li {
+    float: left;
+    margin-left: 12px;
+  }
+  /* .past-projects-module */
+  .past-projects-module {
+    padding-bottom: 45px;
+  }
+  .past-projects-module .title-past-projects {
+    letter-spacing: 5px;
+    background: none;
+    padding-left: 12px;
+    width: 225px;
+    margin: 31px auto 45px auto;
+  }
+  /* .past-projects-module .carousel-main */
+  .past-projects-module .carousel-main {
+    min-height: 290px;
+    margin-right: 80px;
+    margin-left: 80px;
+  }
+  /* .past-projects-module .carousel .item */
+  .past-projects-module .carousel .item {
+    padding: 0 0;
+    min-height: 290px;
+  }
+  .past-projects-module .carousel .spacing {
+    padding: 0 16px;
+  }
+  /* .past-projects-module .carousel .img-main */
+  .past-projects-module .img-main .funded-round {
+    width: 101px;
+    height: 101px;
+    padding: 5px;
+    right: 5px;
+    bottom: 6px;
+  }
+  /* .past-projects-module .carousel .info-main */
+  .past-projects-module .info-main {
+    text-align: left;
+    padding: 10px 0 0 0;
+  }
+  .past-projects-module .info-main h2 {
+    line-height: 25px;
+  }
+  .past-projects-module .info-main h2 a {
+    font-size: 19.84px;
+  }
+  .past-projects-module .info-main .time {
+    font-size: 13.23px;
+    padding: 3px 0 11px 0;
+  }
+  .past-projects-module .info-main .bottom-bar {
+    padding-right: 0;
+  }
+  .past-projects-module .info-main .bottom-bar .btn-read-more {
+    font-size: 11.57px;
+    letter-spacing: 4px;
+    padding-left: 10px;
+    width: 141px;
+    height: 35px;
+    line-height: 35px;
+  }
+  .past-projects-module .carousel-control.left, .past-projects-module .carousel-control.right {
+    width: 41px;
+    height: 39px;
+    top: 78px;
+  }
+  .past-projects-module .carousel-control.left {
+    left: -67px;
+  }
+  .past-projects-module .carousel-control.right {
+    right: -67px;
+  }
+  .past-projects-module .carousel-control.left .icons, .past-projects-module .carousel-control.right .icons {
+    width: 19px;
+    height: 19px;
+    margin: 8px auto 0 auto;
+  }
+  .past-projects-module .carousel-control.left .icons {
+    background-position: -233px -13px;
+  }
+  .past-projects-module .carousel-control:hover.left .icons {
+    background-position: -272px -13px;
+  }
+  .past-projects-module .carousel-control.right .icons {
+    background-position: -291px -13px;
+  }
+  .past-projects-module .carousel-control:hover.right .icons {
+    background-position: -310px -13px;
+  }
+  /* project details page */
+  .details-active-project-module .banners.min-height455 {
+    min-height: 376px;
+  }
+  .details-active-project-module .banners img {
+    height: 376px;
+  }
+  /* .details-active-project-module .banner-section */
+  .details-active-project-module .banner-section .container {
+    padding-top: 35px;
+    min-height: 376px;
+  }
+  .details-active-project-module .banner-section .title-active-project {
+    letter-spacing: 8px;
+    padding-left: 12px;
+    margin-right: 68px;
+    width: 250px;
+  }
+  .details-active-project-module .banner-section .title-h1 {
+    bottom: 24px;
+    left: 72px;
+    width: 420px;
+  }
+  .details-active-project-module .banner-section .funded-round {
+    width: 196px;
+    height: 196px;
+    padding: 10px;
+    margin: 0 0 0 -98px;
+    bottom: -166px;
+  }
+  .details-active-project-module .banner-section .funded-round .round-depict {
+    font-size: 22.48px;
+    text-align: center;
+    width: 170px;
+    margin: 6px 0 0 -85px;
+  }
+  .details-active-project-module .banner-section .funded-round .status-indicator input {
+    font-size: 48.17px !important;
+    margin-top: 40px !important;
+  }
+  .details-active-project-module .banner-section .funded-round .status-indicator input.smaller {
+    font-size: 37.17px !important;
+    -webkit-transition: font-size 0.25s ease;
+    transition: font-size 0.25s ease;
+  }
+  /* .details-active-project-module .info-section */
+  .details-active-project-module .info-section .container {
+    padding: 4px 96px 0 92px;
+  }
+  /* .details-active-project-module .info-main */
+  .details-active-project-module .info-main {
+    padding-bottom: 51px;
+  }
+  .details-active-project-module .info-main .blue-bar, .details-active-project-module .info-main .dark-blue-bar {
+    font-size: 22.48px;
+    height: 53px;
+    line-height: 53px;
+    padding: 0 47px;
+    margin-top: 13px;
+  }
+  /* .details-active-project-module .video-main */
+  .details-active-project-module .video-main {
+    padding-bottom: 45px;
+  }
+  .details-active-project-module .video-area .video, .details-active-project-module .video-area .video img, .details-active-project-module .video-area .video iframe {
+    width: 388px;
+    height: 269px;
+  }
+  .details-active-project-module .video-area .btn-play {
+    width: 108px;
+    height: 108px;
+    margin: -54px 0 0 -54px;
+  }
+  .details-active-project-module .video-area .btn-play .icons {
+    background-position: 0 -71px;
+    width: 78px;
+    height: 78px;
+    margin: 8px 0 0 0;
+  }
+  .details-active-project-module .video-area .btn-play:hover .icons, .details-active-project-module .video-area .btn-play:focus .icons {
+    background-position: -78px -71px;
+  }
+  .details-active-project-module .txt-area {
+    margin: 0 0 0 408px;
+    min-height: 269px;
+  }
+  .details-active-project-module .txt-area .txt-td .font20 {
+    font-size: 16.53px;
+    line-height: 30px;
+    padding-bottom: 17px;
+    margin-top: -8px;
+  }
+  .details-active-project-module .txt-area .txt-td .font14 {
+    font-size: 11.57px;
+    line-height: 20px;
+  }
+  /* .project-updates-module */
+  .project-updates-module .container {
+    padding: 38px 39px 20px 92px;
+    position: relative;
+  }
+  /* .project-updates-module .main-area */
+  .project-updates-module .main-area {
+    width: auto;
+    float: none;
+    margin-right: 304px;
+  }
+  .project-updates-module .main-area .title-project-updates {
+    width: 274px;
+    letter-spacing: 7px;
+    padding-left: 12px;
+    margin-bottom: 29px;
+  }
+  /* .project-updates-module .list-area */
+  .project-updates-module .list-area .row {
+    padding: 45px 0 0 0;
+  }
+  .project-updates-module .list-area .left-date {
+    width: 168px;
+  }
+  .project-updates-module .list-area .left-date .date-txt, .project-updates-module .list-area .left-date .month-txt {
+    text-align: center;
+    padding: 0 45px 0 22px;
+  }
+  .project-updates-module .list-area .left-date .date-txt {
+    font-size: 99.21px;
+    line-height: 80px;
+    margin-top: -4px;
+  }
+  .project-updates-module .list-area .left-date .month-txt {
+    font-size: 19.84px;
+    letter-spacing: 16px;
+  }
+  .project-updates-module .list-area .main-info {
+    margin-left: 168px;
+  }
+  .project-updates-module .list-area .main-info .title-h4 {
+    line-height: 20px;
+    padding-bottom: 5px;
+  }
+  .project-updates-module .list-area .main-info .title-h4 a {
+    font-size: 14.88px;
+  }
+  .project-updates-module .list-area .main-info p {
+    font-size: 11.57px;
+    line-height: 20px;
+    padding-bottom: 18px;
+  }
+  .project-updates-module .list-area .main-info .social-ul {
+    margin-bottom: 29px;
+  }
+  .project-updates-module .list-area .main-info .social-ul li {
+    margin-right: 5px;
+  }
+  /* .project-updates-module .right-aside */
+  .project-updates-module .right-aside {
+    width: 252px;
+    position: absolute;
+    top: 38px;
+    right: 39px;
+  }
+  .project-updates-module .right-aside .module-box {
+    min-height: 120px;
+    padding: 12px 0 22px 0;
+    margin: 0 0 26px 0;
+  }
+  .project-updates-module .right-aside .module-box .type-txt {
+    font-size: 14.88px;
+    padding: 5px 0 2px 0;
+  }
+  .project-updates-module .right-aside .module-box .value-txt {
+    font-size: 49.6px;
+    padding: 0;
+  }
+  .project-updates-module .right-aside .module-box .title-h5 {
+    font-size: 13.23px;
+    margin: 10px 14px 0 13px;
+    border-top: 2px solid #c3c3c3;
+    border-bottom: 2px solid #c3c3c3;
+    height: 29px;
+    line-height: 29px;
+  }
+  .project-updates-module .right-aside .module-box ul {
+    padding: 29px 0 17px 0;
+  }
+  .project-updates-module .right-aside .module-box li {
+    font-size: 11.57px;
+    line-height: 27px;
+  }
+  .project-updates-module .right-aside .btn-i-want-to-donate {
+    letter-spacing: 4px;
+    padding-left: 12px;
+    width: 190px;
+    height: 38px;
+    line-height: 38px;
+  }
+  /* .project-updates-module .venue-area */
+  .project-updates-module .venue-area {
+    padding: 34px 0 0 0;
+  }
+  .project-updates-module .main-area .title-venue {
+    width: 142px;
+    padding-left: 12px;
+    margin-bottom: 14px;
+  }
+  .project-updates-module .main-area .venue-map, .project-updates-module .main-area .venue-map img {
+    width: 100%;
+    height: 314px;
+  }
+  .project-updates-module .main-area .venue-bottom {
+    padding: 19px 0 0 0;
+  }
+  .project-updates-module .main-area .venue-bottom .title-h4 {
+    font-size: 14.88px;
+    line-height: 22px;
+    padding-bottom: 5px;
+  }
+  .project-updates-module .main-area .venue-bottom p {
+    line-height: 21px;
+  }
+  .project-updates-module .main-area .venue-bottom p span {
+    font-size: 11.57px;
+  }
+  /* .donors-module */
+  .donors-module .titles.container {
+    padding: 0;
+    min-height: 49px;
+  }
+  .titles.container .title-donors {
+    margin-right: 39px;
+    min-width: 142px;
+    letter-spacing: 7px;
+    padding-left: 12px;
+  }
+  .donors-module .tab-content .row {
+    margin: 4px 27px 0 70px;
+  }
+  .donors-module .tab-content .row .col-md-6 {
+    padding: 36px 0 0 0;
+  }
+  .donors-module .tab-content .head-img {
+    width: 105px;
+  }
+  .donors-module .tab-content .head-img img {
+    width: 82px;
+    height: 82px;
+  }
+  .donors-module .info-box {
+    margin-left: 105px;
+  }
+  .donors-module .info-box .title-h4 {
+    padding: 0 0 4px 0;
+    margin-top: -2px;
+  }
+  .donors-module .info-box .title-h4 a {
+    font-size: 14.88px;
+  }
+  .donors-module .info-box p {
+    font-size: 11.57px;
+    line-height: 23px;
+    padding: 0 15px 0 0;
+    margin-top: -2px;
+  }
+  /* partners page */
+  .partners-contents .container {
+    padding: 35px 0 37px 70px;
+  }
+  .partners-contents .title-partners {
+    font-size: 15px;
+    height: 36px;
+    line-height: 36px;
+    padding-left: 22px;
+    padding-right: 16px;
+    margin-right: 68px;
+    margin-bottom: 25px;
+  }
+  .partners-contents .titles .title-primary {
+    font-size: 40px;
+    line-height: 46px;
+    margin-bottom: 18px;
+  }
+  .partners-contents .titles .title-sub {
+    font-size: 12px;
+    line-height: 24px;
+  }
+  /* .partners-contents .list */
+  .partners-contents .list-wrap {
+    margin-top: 41px;
+  }
+  .partners-contents .list-wrap .item-wrap {
+    min-height: 172px;
+    padding-bottom: 25px;
+    position: relative;
+    margin-bottom: 0;
+  }
+  .partners-contents .list-wrap .item-wrap.large-spacing {
+    margin-bottom: 0;
+  }
+  .partners-contents .left-img {
+    width: 170px;
+    height: 170px;
+    margin-top: 3px;
+    margin-left: -2px;
+  }
+  .partners-contents .content-info {
+    margin-left: 190px;
+    min-height: 132px;
+    overflow: hidden;
+  }
+  .partners-contents .content-info h4 {
+    font-size: 25px;
+    line-height: 30px;
+    margin-bottom: 8px;
+  }
+  .partners-contents .content-info h4 a {
+    font-family: 'Source Sans Pro';
+    font-weight: 700;
+    font-size: 25px;
+    color: #4b4b4b;
+  }
+  .partners-contents .content-info p {
+    font-size: 12px;
+    line-height: 23px;
+    padding-right: 350px;
+    padding-left: 2px;
+  }
+  .partners-contents .btn-wrap {
+    margin: 0 0 0 191px;
+  }
+  .partners-contents .btn-wrap .btn-blue {
+    height: 36px;
+    line-height: 36px;
+    padding-left: 10px;
+    padding-right: 5px;
+  }
+  /* .partners-contents .pager-info */
+  .partners-contents .pager-info {
+    margin-top: 4px;
+  }
+  .partners-contents .pager-info li {
+    float: left;
+    margin-right: 15px;
+  }
+  .partners-contents .pager-info li a {
+    padding: 0 17px;
+    font-size: 13px;
+    line-height: 32px;
+    height: 32px;
+  }
+  /* .sponsoring-organizations-module */
+  .sponsoring-organizations-module {
+    min-height: 320px;
+  }
+  .sponsoring-organizations-module .container {
+    padding: 31px 0 0 0;
+  }
+  .title-sponsoring-organizations {
+    width: 408px;
+    letter-spacing: 7px;
+    padding-left: 10px;
+    margin-bottom: 30px;
+  }
+  /* .sponsoring-organizations-module .carousel-main */
+  .sponsoring-organizations-module .carousel-main {
+    margin-right: 75px;
+    margin-left: 75px;
+  }
+  .sponsoring-organizations-module .logo-ul li {
+    height: 200px;
+  }
+  .sponsoring-organizations-module .logo-the-san-francisco {
+    background-size: 138px auto;
+    width: 138px;
+    height: 137px;
+  }
+  .sponsoring-organizations-module .logo-toyota-togethergreen {
+    background-size: 158px auto;
+    width: 158px;
+    height: 52px;
+  }
+  .sponsoring-organizations-module .logo-sun-shot {
+    background-size: 111px auto;
+    width: 111px;
+    height: 34px;
+  }
+  .sponsoring-organizations-module .logo-patagonia {
+    background-size: 143px auto;
+    width: 143px;
+    height: 45px;
+  }
+  .sponsoring-organizations-module .carousel-control.left, .sponsoring-organizations-module .carousel-control.right {
+    width: 41px;
+    height: 39px;
+    top: 93px;
+  }
+  .sponsoring-organizations-module .carousel-control.left {
+    left: -62px;
+  }
+  .sponsoring-organizations-module .carousel-control.right {
+    right: -62px;
+  }
+  .sponsoring-organizations-module .carousel-control.left .icons, .sponsoring-organizations-module .carousel-control.right .icons {
+    width: 19px;
+    height: 19px;
+    margin: 8px auto 0 auto;
+  }
+  .sponsoring-organizations-module .carousel-control.left .icons {
+    background-position: -233px -13px;
+  }
+  .sponsoring-organizations-module .carousel-control:hover.left .icons {
+    background-position: -272px -13px;
+  }
+  .sponsoring-organizations-module .carousel-control.right .icons {
+    background-position: -291px -13px;
+  }
+  .sponsoring-organizations-module .carousel-control:hover.right .icons {
+    background-position: -310px -13px;
+  }
+  /* solar ambassador program page */
+  .solar-contents .article-detail {
+    padding: 35px 41px 62px 71px;
+  }
+  .solar-contents .article-detail .title-solar {
+    width: 227px;
+    height: 53px;
+    padding-left: 27px;
+    padding-top: 10px;
+    font-size: 15px;
+  }
+  .solar-contents .article-detail .detail-left {
+    padding-right: 331px;
+    padding-top: 46px;
+  }
+  .solar-contents .article-detail .detail-left .title-img {
+    margin-bottom: 33px;
+  }
+  .solar-contents .article-detail .detail-left .btn-group {
+    padding-top: 27px;
+    padding-right: 0;
+    width: auto;
+  }
+  .solar-contents .article-detail .detail-left .btn-group .btn-blue {
+    margin-bottom: 14px;
+  }
+  .solar-contents .article-detail .detail-left .btn-group .btn-application {
+    padding-left: 24px;
+    padding-right: 17px;
+    margin-top: 4px;
+  }
+  .solar-contents .article-detail .detail-left .btn-group .btn-team {
+    padding-left: 21px;
+    padding-right: 19px;
+    margin-bottom: 22px;
+    margin-right: 0;
+  }
+  .solar-contents .article-detail .detail-left .btn-group .btn-project {
+    padding-left: 33px;
+    padding-right: 36px;
+  }
+  /* blog page */
+  .titles.container .title-blog {
+    margin-right: 68px;
+    min-width: 110px;
+    letter-spacing: 8px;
+    padding-left: 12px;
+  }
+  /* .grid-data */
+  .grid-data.container {
+    padding: 0 55px;
+  }
+  /* .form-area */
+  .form-area {
+    padding: 12px 13px 16px 13px;
+    min-height: 47px;
+  }
+  .form-area .width167 {
+    float: left;
+  }
+  .form-area .width167 .btn-default, .form-area .width167.input-search {
+    width: 134px;
+  }
+  /* .input-search */
+  .input-search {
+    padding: 0 24px 2px 18px;
+    height: 30px;
+    line-height: 0;
+  }
+  .input-search input {
+    font-size: 9.92px;
+    letter-spacing: 4px;
+    height: 28px;
+  }
+  .input-search .icon-search {
+    background-position: -26px 0;
+    width: 13px;
+    height: 13px;
+    top: 6px;
+    right: 7px;
+  }
+  .input-search .icon-search:hover {
+    background-position: -65px 0;
+  }
+  /* .grid-area.row */
+  .grid-area.row .col-md-6 {
+    padding-right: 13px;
+    padding-left: 13px;
+  }
+  .grid-area.row .img-main {
+    height: 215px;
+  }
+  .grid-area.row .video {
+    width: 100%;
+    height: 215px;
+  }
+  .grid-area.row .video iframe {
+    width: 100%;
+    height: 215px;
+  }
+  .grid-area.row .btn-play {
+    width: 88px;
+    height: 88px;
+    margin: -44px 0 0 -44px;
+  }
+  .grid-area.row .btn-play .icons {
+    background-size: 442px auto;
+    background-position: 0 -58px;
+    width: 63px;
+    height: 63px;
+    margin: 8px 0 0 0;
+  }
+  .grid-area.row .btn-play:hover .icons, .grid-area.row .btn-play:focus .icons {
+    background-position: -63px -58px;
+  }
+  .grid-area.row .img-main img {
+    height: 215px;
+  }
+  .grid-area.row .carousel-control.left, .grid-area.row .carousel-control.right {
+    width: 41px;
+    height: 39px;
+  }
+  .grid-area.row .carousel-control.left {
+    right: 45px;
+  }
+  .grid-area.row .carousel-control.left .icons, .grid-area.row .carousel-control.right .icons {
+    width: 19px;
+    height: 19px;
+    margin: 8px auto 0 auto;
+  }
+  .grid-area.row .carousel-control.left .icons {
+    background-position: -233px -13px;
+  }
+  .grid-area.row .carousel-control:hover.left .icons {
+    background-position: -272px -13px;
+  }
+  .grid-area.row .carousel-control.right .icons {
+    background-position: -291px -13px;
+  }
+  .grid-area.row .carousel-control:hover.right .icons {
+    background-position: -310px -13px;
+  }
+  .grid-area.row .info-main {
+    padding: 29px 0 30px 0;
+  }
+  .grid-area.row .info-main .title-h2 {
+    font-size: 24.8px;
+    line-height: 30px;
+  }
+  .grid-area.row .info-main .title-h2 a {
+    font-size: 24.8px;
+  }
+  .grid-area.row .info-main .date-txt {
+    font-size: 13.23px;
+    line-height: 20px;
+    padding-bottom: 8px;
+  }
+  .grid-area.row .info-main p {
+    font-size: 11.57px;
+    line-height: 24px;
+    padding: 0 25px 15px 0;
+  }
+  .grid-area.row .info-main .bottom-bar {
+    padding: 14px 0 20px 0;
+  }
+  .grid-area.row .info-main .bottom-bar .btn-read-more {
+    font-size: 11.57px;
+    letter-spacing: 3px;
+    width: 108px;
+    height: 35px;
+    padding: 2px 0 0 2px;
+    line-height: 33px;
+  }
+  .grid-area.row .info-main .bottom-bar .social-ul {
+    margin: 0 20px 0 0;
+  }
+  .grid-area.row .info-main .bottom-bar .social-ul li {
+    margin: 0 5px 0 6px;
+  }
+  /* .loading-bar */
+  .loading-bar {
+    padding: 0 0 58px 0;
+  }
+  .loading-bar .loading-img {
+    background-size: 106px auto;
+    width: 106px;
+    height: 18px;
+  }
+  /* .blog-details-data */
+  .blog-details-data.container {
+    padding: 0 68px;
+    min-height: 150px;
+  }
+  /* .blog-details-data .title-bar */
+  .blog-details-data.container .title-bar {
+    padding: 14px 0 15px 0;
+  }
+  .blog-details-data.container .title-bar .date-txt {
+    font-size: 13.23px;
+    line-height: 24px;
+  }
+  .blog-details-data.container .title-bar .social-ul {
+    top: 38px;
+  }
+  .blog-details-data.container .title-bar .social-ul li {
+    margin-left: 11px;
+  }
+  /* .blog-details-data .info-box */
+  .blog-details-data.container .info-box .img-main, .blog-details-data.container .info-box .img-main img {
+    height: 442px;
+  }
+  .blog-details-data.container .info-box .info-main {
+    padding: 35px 3px 18px 3px;
+  }
+  .blog-details-data.container .info-box .info-main .lefts p {
+    padding-right: 5px;
+  }
+  .blog-details-data.container .info-box .info-main .rights p {
+    padding-left: 12px;
+  }
+  .blog-details-data.container .info-box .info-main .font20 {
+    font-size: 16.53px;
+    line-height: 30px;
+  }
+  .blog-details-data.container .info-box .info-main .font14 {
+    font-size: 11.57px;
+    line-height: 23px;
+  }
+  .blog-details-data.container .info-box .down25 {
+    padding-bottom: 18px;
+  }
+  .blog-details-data.container .info-box .info-main .rights .down25 {
+    padding-bottom: 20px;
+  }
+  /* .related-blog-module */
+  .related-blog-module {
+    padding: 20px 0 7px 0;
+  }
+  .related-blog-module .form-area {
+    min-height: 70px;
+  }
+  .related-blog-module .title-related-blog {
+    width: 217px;
+    top: 13px;
+    right: 68px;
+  }
+  .related-blog-module .carousel-control.left, .related-blog-module .carousel-control.right {
+    width: 41px;
+    height: 39px;
+    margin-top: -65px;
+  }
+  .related-blog-module .carousel-control.left {
+    left: -45px;
+  }
+  .related-blog-module .carousel-control.right {
+    right: -45px;
+  }
+  .related-blog-module .carousel-control.left .icons, .related-blog-module .carousel-control.right .icons {
+    width: 19px;
+    height: 19px;
+    margin-top: 7px;
+  }
+  .related-blog-module .carousel-control.left .icons {
+    background-position: -233px -13px;
+  }
+  .related-blog-module .carousel-control:hover.left .icons {
+    background-position: -272px -13px;
+  }
+  .related-blog-module .carousel-control.right .icons {
+    background-position: -291px -13px;
+  }
+  .related-blog-module .carousel-control:hover.right .icons {
+    background-position: -310px -13px;
+  }
+  .related-blog-module .carousel-inner>.active {
+    min-height: 512px;
+  }
+  /* .comments-module */
+  .comments-module .container {
+    padding: 30px 68px 0 68px;
+  }
+  .comments-module .container .title-comments {
+    width: 167px;
+    letter-spacing: 7px;
+    margin-bottom: 20px;
+    padding-left: 12px;
+  }
+  /* .comments-module .comments-area  .comments-list*/
+  .comments-module .comments-area {
+    min-height: 150px;
+  }
+  .comments-module .comments-area .comments-list {
+    padding: 41px 100px 34px 0;
+  }
+  .comments-module .comments-area .spaceleft {
+    padding-left: 86px;
+  }
+  .comments-module .comments-area .spacetop {
+    padding-top: 18px;
+  }
+  .comments-module .comments-area .comments-list .head-img {
+    width: 108px;
+  }
+  .comments-module .comments-area .comments-list .head-img img {
+    width: 83px;
+    height: 83px;
+  }
+  .comments-module .comments-area .comments-list .info-box {
+    margin-left: 108px;
+  }
+  .comments-module .comments-area .comments-list .info-box .title-h4 {
+    padding: 0 0 11px 0;
+  }
+  .comments-module .comments-area .comments-list .info-box .title-h4 a {
+    font-size: 14.88px;
+  }
+  .comments-module .comments-area .comments-list .info-box p {
+    font-size: 11.57px;
+    line-height: 20px;
+    padding: 0 18px 0 0;
+  }
+  .comments-module .comments-area .comments-list .comments-apply {
+    width: 85px;
+    height: 35px;
+    line-height: 35px;
+    letter-spacing: 4px;
+  }
+  .comments-module .comments-area .comments-list .comments-apply a {
+    font-size: 11.57px;
+    padding-left: 4px;
+  }
+  .comments-module .comments-area .comments-list .comments-apply a:hover {
+    color: #1ab1e6;
+    text-decoration: none;
+  }
+  /* .comments-module .comments-area .quick-reply */
+  .comments-module .comments-area .quick-reply {
+    padding: 31px 0 100px 0;
+  }
+  .comments-module .comments-area .quick-reply .quick-reply-txt {
+    width: 108px;
+  }
+  .comments-module .comments-area .quick-reply .quick-reply-txt .title-h4 {
+    padding: 20px 0 18px 0;
+    font-size: 14.88px;
+  }
+  .comments-module .comments-area .quick-reply .quick-reply-txt p {
+    font-size: 11.57px;
+  }
+  .comments-module .comments-area .quick-reply .quick-reply-txt li {
+    margin-top: 11px;
+    margin-left: -1px;
+  }
+  .comments-module .comments-area .quick-reply .quick-reply-txt li:nth-child(2) {
+    margin-left: 10px;
+  }
+  .comments-module .comments-area .quick-reply .textarea-box {
+    margin-right: 4px;
+    margin-left: 108px;
+    height: 162px;
+    padding: 14px 21px;
+  }
+  .comments-module .comments-area .quick-reply .textarea-box textarea {
+    font-size: 9.92px;
+    height: 100px;
+    line-height: 14px;
+    letter-spacing: 6px;
+  }
+  .comments-module .comments-area .quick-reply .comments-post {
+    width: 83px;
+    height: 35px;
+    line-height: 35px;
+    right: 5px;
+    bottom: 101px;
+    letter-spacing: 3px;
+  }
+  .comments-module .comments-area .quick-reply .comments-post a {
+    font-size: 11.57px;
+    padding: 2px 0 0 3px;
+  }
+  /* .footer */
+  .footer .row {
+    padding: 0 82px 0 95px;
+  }
+  .footer .row .col-menu, .footer .row .col-info {
+    padding: 55px 0 48px 0;
+  }
+  .footer .row .col-menu dt, .footer .row .col-info dt {
+    line-height: 20px;
+  }
+  .footer .row .col-menu dt a, .footer .row .col-info dt a {
+    font-size: 11.57px;
+  }
+  .footer .row .col-menu dd, .footer .row .col-info dd {
+    line-height: 19px;
+  }
+  .footer .row .col-info dt {
+    padding-bottom: 4px;
+  }
+  .footer .row .col-info a {
+    font-size: 9.92px;
+  }
+  .footer .row .col-info p {
+    font-size: 9.92px;
+    text-align: justify;
+    line-height: 20px;
+    padding: 5px 0 0 0;
+  }
+  /* .footer .bottoms */
+  .footer .bottoms {
+    margin: 0 86px 0 99px;
+    min-height: 100px;
+  }
+  .footer .bottoms .logo {
+    background-size: 141px auto;
+    margin: 16px 0 0 -4px;
+    width: 141px;
+    height: 56px;
+  }
+  .footer .bottoms .social-ul {
+    margin: 32px -8px 0 0;
+  }
+  .footer .bottoms .social-ul li {
+    margin: 0 0 0 25px;
+  }
+  .footer .bottoms .social-ul li .icons {
+    width: 19px;
+    height: 19px;
+  }
+  .footer .bottoms .social-ul li .icon-fb {
+    background-position: 0 -13px;
+  }
+  .footer .bottoms .social-ul li .icon-fb:hover {
+    background-position: -20px -13px;
+  }
+  .footer .bottoms .social-ul li .icon-tw {
+    background-position: -38px -13px;
+  }
+  .footer .bottoms .social-ul li .icon-tw:hover {
+    background-position: -58px -13px;
+  }
+  .footer .bottoms .social-ul li .icon-gg {
+    background-position: -76px -13px;
+  }
+  .footer .bottoms .social-ul li .icon-gg:hover {
+    background-position: -96px -13px;
+  }
+  /* .modal-default */
+  .modal.modal-default .modal-dialog {
+    width: 967px;
+    margin: 90px auto;
+  }
+  /* .modal-default .modal-header */
+  .modal.modal-default .modal-header {
+    text-align: center;
+    padding: 0;
+    border-bottom: none;
+  }
+  .modal.modal-default .btn-close {
+    width: 13px;
+    height: 13px;
+    top: 45px;
+    right: 50px;
+  }
+  .modal.modal-default .btn-close:hover {
+    background-position: -13px 0;
+  }
+  /* #modal-how-it-works */
+  #modal-how-it-works .title-how-it-works {
+    width: 229px;
+    margin: 37px auto 0 auto;
+  }
+  #modal-how-it-works .txt-info {
+    font-size: 11.57px;
+    line-height: 23px;
+    padding: 33px 167px;
+  }
+  /* #modal-how-it-works .info-row */
+  #modal-how-it-works .info-row {
+    padding: 25px 80px 7px 80px;
+  }
+  #modal-how-it-works .info-row .video-area .video, #modal-how-it-works .info-row .video-area .video img {
+    width: 414px;
+    height: 269px;
+  }
+  #modal-how-it-works .info-row .video-area .video iframe {
+    width: 414px;
+    height: 269px;
+    border: none;
+  }
+  #modal-how-it-works .info-row .video-area .btn-play {
+    width: 108px;
+    height: 108px;
+    margin: -54px 0 0 -54px;
+  }
+  #modal-how-it-works .info-row .video-area .btn-play .icons {
+    background-position: 0 -71px;
+    width: 78px;
+    height: 78px;
+    margin: 8px 0 0 0;
+  }
+  #modal-how-it-works .info-row .video-area .btn-play:hover .icons, #modal-how-it-works .info-row .video-area .btn-play:focus .icons {
+    background-position: -78px -71px;
+  }
+  #modal-how-it-works .info-row .step-area {
+    margin: 0 436px 0 0;
+    min-height: 269px;
+  }
+  #modal-how-it-works .step-area .module-box {
+    padding: 0 20px 0 0;
+    margin-bottom: 40px;
+  }
+  #modal-how-it-works .step-area .icon-blue-round {
+    width: 58px;
+    height: 58px;
+    margin: 0;
+  }
+  #modal-how-it-works .step-area .icon-blue-round .icons {
+    width: 39px;
+    height: 39px;
+    margin-top: 9px;
+  }
+  #modal-how-it-works .step-area .icon-fundraise .icons {
+    background-position: -0 -32px;
+  }
+  #modal-how-it-works .step-area .icon-invest .icons {
+    background-position: -39px -32px;
+  }
+  #modal-how-it-works .step-area .icon-pay-it-forward .icons {
+    background-position: -78px -32px;
+  }
+  #modal-how-it-works .step-area .info-txt {
+    margin: 0 45px 0 80px;
+  }
+  #modal-how-it-works .step-area .info-txt h4 {
+    font-size: 14.88px;
+    line-height: 20px;
+    padding-bottom: 4px;
+    margin-top: -7px;
+  }
+  #modal-how-it-works .step-area .info-txt p {
+    font-size: 11.57px;
+    line-height: 21px;
+  }
+}
 
 /*fix layout issue when smaller than 992px width*/
+
 @media (max-width: 991px) {
-.icons {
-	background-size: 672px auto;
+  .icons {
+    background-size: 672px auto;
+  }
+  /* btn */
+  .btn-blue {
+    font-size: 14.34px;
+    height: 55px;
+    line-height: 55px;
+    padding: 0 5px;
+  }
+  .btn-icon-gray {
+    width: 74px;
+    height: 60px;
+  }
+  .btn-icon-gray .icons {
+    width: 48px;
+    height: 48px;
+    margin-top: 5px;
+  }
+  .btn-icon-gray .icon-fb {
+    background-position: -288px -40px;
+  }
+  .btn-icon-gray:hover .icon-fb {
+    background-position: -336px -40px;
+  }
+  .btn-icon-gray .icon-tw {
+    background-position: -384px -40px;
+  }
+  .btn-icon-gray:hover .icon-tw {
+    background-position: -432px -40px;
+  }
+  .btn-icon-gray .icon-gg {
+    background-position: -480px -40px;
+  }
+  .btn-icon-gray:hover .icon-gg {
+    background-position: -528px -40px;
+  }
+  /* .dropdown-default */
+  .dropdown-default .btn-default {
+    font-size: 16.67px;
+    letter-spacing: 7px;
+    padding: 0 32px 0 40px;
+    height: 50px;
+    line-height: 47px;
+  }
+  .dropdown-default .btn-default .icon-arrow-down {
+    background-position: -97px 0;
+    top: 16px;
+    right: 17px;
+  }
+  .dropdown-default .btn-default.active .icon-arrow-down, .dropdown-default .btn-default:active .icon-arrow-down, .open.dropdown-default>.dropdown-toggle.btn-default .icon-arrow-down {
+    background-position: -113px 0;
+  }
+  .dropdown-default .dropdown-menu {
+    font-size: 16.46px;
+    min-width: 60px;
+    padding: 5px 0;
+  }
+  .dropdown-default .dropdown-menu>li>a {
+    padding: 0 25px;
+    line-height: 26px;
+  }
+  /* title */
+  .title-white-border, .title-blue-border {
+    font-size: 21.5px;
+    letter-spacing: 7px;
+    height: 44px;
+    line-height: 44px;
+    padding: 0 5px;
+  }
+  .container {
+    width: 750px;
+  }
+  /* .header */
+  .header {
+    margin-top: 10px;
+    height: 185px;
+  }
+  .header .logo {
+    background: url(../images/tablet/tablet-logo-white.png);
+    background-size: 257px auto;
+    margin: 37px 0 0 32px;
+    width: 257px;
+    height: 101px;
+  }
+  .header .btn-donate {
+    min-width: 132px;
+  }
+  .header .rights {
+    padding: 66px 24px 0 0;
+  }
+  .header .txt {
+    font-size: 16.38px;
+    padding: 2px 14px 3px 0;
+    line-height: 26px;
+  }
+  /* .after-scroll-header */
+  .header.after-scroll-header {
+    border-bottom: 1px solid #c6c6c6;
+  }
+  .header.after-scroll-header .logo {
+    background: url(../images/tablet/tablet-logo.png);
+    background-size: 257px auto;
+    width: 257px;
+    height: 101px;
+    margin: 47px 0 0 32px;
+  }
+  .header.after-scroll-header .rights {
+    padding: 77px 24px 0 0;
+  }
+  /* .top-section */
+  .top-section {
+    min-height: 185px;
+  }
+  .top-section .sub-section-bg {
+    background: url(../images/tablet/tablet-sub-section-bg.jpg) no-repeat center top;
+    background-size: 100% 185px;
+  }
+  .top-section.min-height {
+    min-height: 1366px;
+  }
+  .top-section .section-video img {
+    width: 100%;
+    height: 1366px;
+  }
+  .top-section .section-video-area iframe, .top-section .section-video-area video, .top-section .section-video-area .mejs-container, .top-section .section-video-area .me-plugin, .top-section .section-video-area embed, .top-section .section-video-area .mejs-overlay-play {
+    width: 100%!important;
+    height: 1366px!important;
+    border: none;
+  }
+  .top-section.min-height .container {
+    top: 55px;
+  }
+  /* .top-section .carousel */
+  .top-section .carousel {
+    padding-right: 65px;
+    padding-left: 65px;
+  }
+  /* .top-section .carousel .item */
+  .top-section .carousel .item {
+    padding: 272px 0 0 0;
+    min-height: 1124px;
+  }
+  .top-section .carousel .item-info {
+    width: 580px;
+  }
+  .top-section .carousel .item-info .titles {
+    font-size: 49.15px;
+    line-height: 58px;
+  }
+  .top-section .carousel .item-info p {
+    font-size: 20.48px;
+    line-height: 36px;
+    width: 480px;
+    padding: 22px 0 48px 0;
+  }
+  .top-section .carousel .item-info .btn-donate-now {
+    letter-spacing: 4.5px;
+    min-width: 257px;
+    padding-left: 15px;
+  }
+  /* .top-section .carousel-indicators */
+  .top-section .carousel-indicators li {
+    width: 20px;
+    height: 20px;
+    margin: 0 6px 0 5px;
+  }
+  .top-section .icon-arrow-down {
+    background-position: -240px -40px;
+    width: 48px;
+    height: 48px;
+    bottom: -78px;
+  }
+  .top-section .carousel-control.left, .top-section .carousel-control.right {
+    width: 66px;
+    height: 64px;
+    top: auto;
+    bottom: 13px;
+  }
+  .top-section .carousel-control.left {
+    left: 33px;
+  }
+  .top-section .carousel-control.right {
+    right: 33px;
+  }
+  .top-section .carousel-control.left .icons, .top-section .carousel-control.right .icons {
+    width: 24px;
+    height: 24px;
+    margin-top: 18px;
+  }
+  .top-section .carousel-control.left .icons {
+    background-position: -480px -16px;
+  }
+  .top-section .carousel-control:hover.left .icons {
+    background-position: -504px -16px;
+  }
+  .top-section .carousel-control.right .icons {
+    background-position: -576px -16px;
+  }
+  .top-section .carousel-control:hover.right .icons {
+    background-position: -552px -16px;
+  }
+  /* home page */
+  .mobile-mask {
+    display: none;
+  }
+  /* .active-projects-module */
+  .active-projects-module {
+    text-align: center;
+    padding-bottom: 18px;
+  }
+  .active-projects-module .title-active-projects {
+    letter-spacing: 10px;
+    width: 378px;
+    margin: 51px auto;
+  }
+  .active-projects-module .row {
+    margin: 0 64px;
+  }
+  /* .active-projects-module .module-box */
+  .active-projects-module .module-box {
+    margin: 0 0 53px 0;
+  }
+  .active-projects-module .desktop-img {
+    display: none;
+  }
+  .active-projects-module .mobile-img {
+    display: block;
+  }
+  /* .active-projects-module .img-main */
+  .active-projects-module .img-main .txt-table {
+    height: 623px;
+  }
+  .active-projects-module .img-main .txt {
+    font-size: 43.01px;
+    line-height: 62px;
+    padding: 0 130px 46px 130px;
+  }
+  .active-projects-module .img-main .funded-round {
+    width: 240px;
+    height: 250px;
+    padding: 20px;
+    bottom: -125px;
+    margin: 0 0 0 -125px;
+  }
+  .active-projects-module .img-main .funded-round .round-depict {
+    font-size: 30.72px;
+    width: 176px;
+    margin: 8px 0 0 -88px;
+  }
+  .active-projects-module .img-main .funded-round .status-indicator input {
+    font-size: 73.73px !important;
+    margin-top: 29px !important;
+    width: 160px !important;
+    height: 80px !important;
+    margin-left: -185px!important;
+  }
+  .active-projects-module .img-main .funded-round .status-indicator input.smaller {
+    font-size: 64px !important;
+    margin-top: 41px !important;
+    -webkit-transition: font-size 0.25s ease;
+    transition: font-size 0.25s ease;
+  }
+  .active-projects-module.embedded .img-main .funded-round .status-indicator input {
+    margin-top: -170px !important;
+  }
+  .active-projects-module.embedded .img-main .funded-round .status-indicator input.smaller {
+    margin-top: -165px !important;
+    font-size: 60px !important;
+  }
+  .status-indicator {
+    transform: rotateY(180deg);
+    -webkit-transform: rotateY(180deg);
+  }
+  .status-indicator input {
+    transform: rotateY(180deg);
+    -webkit-transform: rotateY(180deg);
+  }
+  .tablet-circle {
+    display: block;
+  }
+  .desktop-circle, .small-circle, .mobile-circle {
+    display: none;
+  }
+  /* .active-projects-module .info-main */
+  .active-projects-module .info-main {
+    padding: 86px 61px 34px 58px;
+  }
+  .active-projects-module .info-main .blue-bar, .active-projects-module .info-main .dark-blue-bar {
+    font-size: 30.72px;
+    height: 96px;
+    line-height: 96px;
+    padding: 0 35px 0 48px;
+    margin-top: 24px;
+  }
+  /* .our-impacts-module */
+  .our-impacts-module .title-our-impacts {
+    letter-spacing: 10px;
+    padding-left: 20px;
+    width: 312px;
+    margin: 42px auto 28px auto;
+  }
+  .our-impacts-module .row {
+    margin: 0 18px 0 16px;
+    padding: 0 0 2px 0;
+    border-bottom: 1px solid #cacaca;
+  }
+  .our-impacts-module .row .col-md-3 {
+    width: 50%;
+    float: left;
+    padding: 0;
+  }
+  .our-impacts-module .module-box {
+    margin-bottom: 48px;
+  }
+  .our-impacts-module .row .col-md-3:nth-child(1) .module-box {
+    float: none;
+    width: 100%;
+    margin-left: 0;
+  }
+  .our-impacts-module .row .col-md-3:nth-child(2) .module-box .icons {
+    margin-left: auto;
+  }
+  .our-impacts-module .row .col-md-3:nth-child(2) .module-box .titles {
+    padding-right: 0;
+  }
+  .our-impacts-module .row .col-md-3:nth-child(3) .module-box .icons {
+    margin-left: auto;
+  }
+  .our-impacts-module .row .col-md-3:nth-child(3) .module-box .titles {
+    letter-spacing: -1.8px;
+    padding-top: 20px;
+    line-height: 40px;
+  }
+  .our-impacts-module .row .col-md-3:nth-child(4) .module-box {
+    float: none;
+    width: 100%;
+  }
+  .our-impacts-module .row .col-md-3:nth-child(4) .module-box .titles {
+    padding-top: 5px;
+    line-height: 50px;
+  }
+  .our-impacts-module .module-box .icons {
+    width: 168px;
+    height: 160px;
+  }
+  .our-impacts-module .module-box .icon-people {
+    background-position: 0 -184px;
+  }
+  .our-impacts-module .module-box .icon-home-ok {
+    background-position: -168px -184px;
+  }
+  .our-impacts-module .module-box .icon-tree {
+    background-position: -336px -190px;
+  }
+  .our-impacts-module .module-box .icon-user {
+    background-position: -504px -178px;
+  }
+  .our-impacts-module .module-box .titles {
+    line-height: 66px;
+  }
+  .our-impacts-module .module-box .font20 {
+    font-size: 20.48px;
+  }
+  .our-impacts-module .module-box .font48 {
+    font-size: 49.15px;
+  }
+  .our-impacts-module .module-box .font72 {
+    font-size: 73.73px;
+  }
+  .our-impacts-module .module-box .txt {
+    font-size: 18.43px;
+    line-height: 22px;
+    padding-top: 0;
+    padding-right: 20%;
+    padding-left: 20%;
+  }
+  /* .how-it-works-module */
+  .how-it-works-module .title-how-it-works {
+    letter-spacing: 10px;
+    padding-left: 20px;
+    width: 312px;
+    margin: 52px auto 0 auto;
+  }
+  /* .how-it-works-module .info-row */
+  .how-it-works-module .info-row {
+    padding: 49px 33px 0 30px;
+  }
+  .how-it-works-module .info-row .video-area.pull-right {
+    float: none !important;
+  }
+  .how-it-works-module .info-row .video-area .video, .how-it-works-module .info-row .video-area .video img, .how-it-works-module .info-row .video-area .video iframe {
+    width: 100%;
+    height: 524px;
+  }
+  .how-it-works-module .info-row .video-area .btn-play {
+    width: 130px;
+    height: 130px;
+    margin: -75px 0 0 -75px;
+  }
+  .how-it-works-module .info-row .video-area .btn-play .icons {
+    background-position: 0 -88px;
+    width: 96px;
+    height: 96px;
+    margin: 13px 0 0 0;
+  }
+  .how-it-works-module .info-row .video-area .btn-play:hover .icons, .how-it-works-module .info-row .video-area .btn-play:focus .icons {
+    background-position: -96px -88px;
+  }
+  .how-it-works-module .info-row .txt-area {
+    margin: 30px;
+    min-height: 0;
+  }
+  .how-it-works-module .info-row .txt-area .txt-table {
+    min-height: 0;
+  }
+  .how-it-works-module .info-row .txt-area .txt-td {
+    line-height: 20px;
+  }
+  .how-it-works-module .info-row .txt-area .txt-td p {
+    font-size: 16.38px;
+    line-height: 32px;
+    text-align: center;
+    letter-spacing: 0;
+  }
+  /* .how-it-works-module .step-row */
+  .how-it-works-module .step-row {
+    text-align: left;
+    margin: 79px 32px 0 32px;
+    min-height: 317px;
+    border-bottom: 1px solid #cacaca;
+  }
+  .how-it-works-module .carousel {
+    min-height: 265px;
+    margin-right: 85px;
+    margin-left: 85px;
+  }
+  .how-it-works-module .row .carousel-control, .how-it-works-module .row .carousel-control .icons, .how-it-works-module .row .carousel-indicators {
+    display: block;
+  }
+  .how-it-works-module .step-row .carousel-inner>.item {
+    float: none;
+    display: none;
+  }
+  .how-it-works-module .step-row .carousel-inner>.active, .how-it-works-module .step-row .carousel-inner>.next, .how-it-works-module .step-row .carousel-inner>.prev {
+    display: block;
+  }
+  .how-it-works-module .step-row .item:nth-child(1), .how-it-works-module .step-row .item:nth-child(2) {
+    width: 100%;
+  }
+  .how-it-works-module .step-row .item:nth-child(3) {
+    width: 100%;
+  }
+  .how-it-works-module .step-row .item:nth-child(3) .info-txt {
+    margin-right: 0;
+  }
+  .how-it-works-module .row .carousel-control.left, .how-it-works-module .row .carousel-control.right {
+    background-color: rgba(41, 41, 41, 0.15);
+    text-shadow: none;
+    background-image: none;
+    box-shadow: none;
+    opacity: 1;
+    width: 67px;
+    height: 63px;
+    border: 2px solid #fff;
+    top: 43px;
+  }
+  .how-it-works-module .row .carousel-control.left {
+    text-align: center;
+    left: -85px;
+  }
+  .how-it-works-module .row .carousel-control.right {
+    text-align: center;
+    right: -85px;
+  }
+  .how-it-works-module .row .carousel-control.left .icons, .how-it-works-module .row .carousel-control.right .icons {
+    width: 24px;
+    height: 24px;
+    top: 0;
+    right: auto;
+    left: auto;
+    position: static;
+    margin: 17px auto 0 auto;
+  }
+  .how-it-works-module .row .carousel-control.left .icons {
+    background-position: -456px -16px;
+  }
+  .how-it-works-module .row .carousel-control:hover.left .icons {
+    background-position: -504px -16px;
+  }
+  .how-it-works-module .row .carousel-control.right .icons {
+    background-position: -528px -16px;
+  }
+  .how-it-works-module .row .carousel-control:hover.right .icons {
+    background-position: -552px -16px;
+  }
+  .how-it-works-module .carousel-indicators li {
+    width: 18px;
+    height: 18px;
+    margin: 0 5px;
+    background-color: rgba(41, 41, 41, 0.5);
+    border: none;
+    border-radius: 100%;
+  }
+  .how-it-works-module .carousel-indicators .active {
+    width: 18px;
+    height: 18px;
+    background-color: rgba(41, 41, 41, 1);
+  }
+  .how-it-works-module .step-row .module-box {
+    padding: 10px 33px 0 33px;
+    min-height: 170px;
+  }
+  .how-it-works-module .step-row .icon-blue-round {
+    width: 132px;
+    height: 132px;
+  }
+  .how-it-works-module .step-row .icon-blue-round .icons {
+    width: 96px;
+    height: 96px;
+    margin-top: 15px;
+  }
+  .how-it-works-module .step-row .icon-fundraise .icons {
+    background-position: -192px -88px;
+  }
+  .how-it-works-module .step-row .icon-invest .icons {
+    background-position: -288px -88px;
+  }
+  .how-it-works-module .step-row .icon-pay-it-forward .icons {
+    background-position: -384px -88px;
+  }
+  .how-it-works-module .step-row .icon-arrow-right {
+    display: none;
+  }
+  .how-it-works-module .step-row .info-txt {
+    margin: 0 0 0 160px;
+  }
+  .how-it-works-module .step-row .info-txt h4 {
+    font-size: 24.58px;
+    line-height: 30px;
+    padding-bottom: 3px;
+    margin-top: 24px;
+  }
+  .how-it-works-module .step-row .info-txt p {
+    font-size: 16.38px;
+    line-height: 33px;
+    letter-spacing: -0.7px;
+  }
+  /* .how-it-works-module */
+  .testimonial-module {
+    padding-bottom: 60px;
+  }
+  .testimonial-module .container {
+    padding: 0;
+  }
+  .testimonial-module .title-testimonial {
+    letter-spacing: 10px;
+    padding-left: 10px;
+    width: 253px;
+    margin: 48px auto 0 auto;
+  }
+  /* .testimonial-module .head-row */
+  .testimonial-module .head-row {
+    margin: 0;
+    padding: 37px 19px 0 19px;
+  }
+  .testimonial-module .head-row ul {
+    display: block;
+  }
+  .testimonial-module .head-row li {
+    display: block;
+    float: left;
+    width: 33.33333333%;
+  }
+  .testimonial-module .head-row li .head-img {
+    display: block;
+    margin: 14px;
+  }
+  .testimonial-module .head-row li .head-img .desktop-head {
+    display: none;
+  }
+  .testimonial-module .head-row li .head-img .mobile-head {
+    display: block;
+  }
+  .testimonial-module .head-row li.mobile-show {
+    display: block;
+  }
+  .testimonial-module .head-row li .head-img .icon-arrow-down {
+    display: none;
+  }
+  /*.testimonial-module .head-row li .head-img:hover,
+        .testimonial-module .head-row li .head-img:focus,*/
+  .testimonial-module .head-row li .head-img.active {
+    border-radius: 10px;
+    margin: 0;
+    margin: 7px;
+    padding: 5px;
+  }
+  /*.testimonial-module .head-row li .head-img:hover .icon-arrow-down,
+          .testimonial-module .head-row li .head-img:focus .icon-arrow-down,*/
+  .testimonial-module .head-row li .head-img.active .icon-arrow-down {
+    display: none;
+  }
+  .testimonial-module .head-row li .head-img img {
+    width: 100%;
+    height: 100%;
+    border-radius: 10px;
+  }
+  /* .testimonial-module .info-area */
+  .testimonial-module .info-area {
+    padding: 35px 60px 0 60px;
+  }
+  .testimonial-module .info-area p {
+    font-size: 16.38px;
+    line-height: 32px;
+    letter-spacing: -0.2px;
+    width: 640px;
+    padding-bottom: 15px;
+  }
+  .testimonial-module .info-area .block {
+    display: block;
+  }
+  .testimonial-module .user-group {
+    padding-top: 14px;
+  }
+  .testimonial-module .user-group .link-blue {
+    font-size: 24.58px;
+  }
+  .testimonial-module .user-group .txt {
+    font-size: 16.38px;
+    padding: 13px 0 40px 0;
+  }
+  .testimonial-module .user-group .btn-blue {
+    font-size: 14.34px;
+    height: 41px;
+    line-height: 41px;
+    padding-top: 2px;
+    min-width: 292px;
+    letter-spacing: 4px;
+  }
+  /* .featured-on-module */
+  .featured-on-module {
+    padding-bottom: 41px;
+  }
+  .featured-on-module .title-featured-on {
+    font-size: 21.5px;
+    letter-spacing: 10px;
+    padding-left: 20px;
+    width: 300px;
+    margin: 43px auto 43px auto;
+  }
+  /* .featured-on-module .carousel-main */
+  .featured-on-module .carousel-main {
+    min-height: 175px;
+  }
+  #featured-on-example-generic {
+    display: none;
+  }
+  #mobile-featured-on-example-generic {
+    display: block;
+  }
+  /* .featured-on-module .carousel-main */
+  .featured-on-module .carousel-main {
+    min-height: 175px;
+    margin-right: 65px;
+    margin-left: 65px;
+  }
+  .featured-on-module .carousel-main .logo-ul li {
+    height: 171px;
+  }
+  .featured-on-module .logo-fast-mpany {
+    background-size: 154px auto;
+    width: 154px;
+    height: 23px;
+  }
+  .featured-on-module .logo-ehe-new-hork-eimes {
+    background-size: 137px auto;
+    width: 137px;
+    height: 113px;
+  }
+  .featured-on-module .logo-shareable {
+    background-size: 144px auto;
+    width: 144px;
+    height: 21px;
+  }
+  .featured-on-module .logo-philanthropy {
+    background-size: 153px auto;
+    width: 153px;
+    height: 28px;
+  }
+  .featured-on-module .logo-clean-technica {
+    background-size: 153px auto;
+    width: 153px;
+    height: 44px;
+  }
+  .featured-on-module .logo-fast-mpany:hover, .featured-on-module .logo-fast-mpany:focus, .featured-on-module .logo-ehe-new-hork-eimes:hover, .featured-on-module .logo-ehe-new-hork-eimes:focus, .featured-on-module .logo-shareable:hover, .featured-on-module .logo-shareable:focus, .featured-on-module .logo-philanthropy:hover, .featured-on-module .logo-philanthropy:focus, .featured-on-module .logo-clean-technica:hover, .featured-on-module .logo-clean-technica:focus {
+    background-position: center bottom;
+  }
+  .featured-on-module .carousel-control.left, .featured-on-module .carousel-control.right {
+    width: 49px;
+    height: 47px;
+    top: 60px;
+  }
+  .featured-on-module .carousel-control.left {
+    left: -69px;
+  }
+  .featured-on-module .carousel-control.right {
+    right: -69px;
+  }
+  .featured-on-module .carousel-control.left .icons, .featured-on-module .carousel-control.right .icons {
+    width: 24px;
+    height: 24px;
+    margin: 10px auto 0 auto;
+  }
+  .featured-on-module .carousel-control.left .icons {
+    background-position: -288px -16px;
+  }
+  .featured-on-module .carousel-control:hover.left .icons {
+    background-position: -336px -16px;
+  }
+  .featured-on-module .carousel-control.right .icons {
+    background-position: -360px -16px;
+  }
+  .featured-on-module .carousel-control:hover.right .icons {
+    background-position: -384px -16px;
+  }
+  /* .newsletter-module */
+  .newsletter-module {
+    height: 448px;
+  }
+  .newsletter-module .small-img {
+    display: none;
+  }
+  .newsletter-module .mobile-img {
+    display: block;
+  }
+  .newsletter-module .img-area img {
+    width: 100%;
+    height: 449px;
+  }
+  .newsletter-module .img-area .mobile-img {
+    min-height: 449px;
+    background: transparent;
+  }
+  .newsletter-module .title-newsletter {
+    letter-spacing: 5px;
+    padding-left: 12px;
+    width: 346px;
+    height: 43px;
+    line-height: 43px;
+    margin: 47px auto 43px auto;
+  }
+  /* .newsletter-module .container */
+  .newsletter-module .container {
+    left: 0;
+    margin: 0;
+    width: 100%;
+  }
+  .newsletter-module .group-main p {
+    font-size: 20.48px;
+    line-height: 25px;
+    padding: 50px 0 37px 0;
+  }
+  .newsletter-module .group-main .group {
+    min-height: 113px;
+    margin: 0 32px;
+    padding: 30px 30px 30px 72px;
+  }
+  .newsletter-module .group-main .group .btn-sign-up {
+    font-size: 14.34px;
+    letter-spacing: 4px;
+    width: 156px;
+    height: 53px;
+    line-height: 53px;
+    border: none;
+  }
+  .newsletter-module .group-main .group .inputs {
+    margin-right: 171px;
+    height: 53px;
+  }
+  .newsletter-module .group-main .group .inputs input {
+    font-size: 20.48px;
+  }
+  /* .contents */
+  .contents {
+    min-height: 185px;
+  }
+  .top150 {
+    margin-top: 185px;
+  }
+  /* .titles */
+  .titles.container {
+    padding: 52px 0 0 0;
+    min-height: 113px;
+  }
+  .titles.container .title-get-involved {
+    margin-right: 30px;
+    min-width: 291px;
+    letter-spacing: 11px;
+    padding-left: 14px;
+  }
+  .title-h1 {
+    font-size: 49.15px;
+    line-height: 60px;
+  }
+  /* sign in page */
+  .contents.sign-in-contents {
+    min-height: 900px;
+    margin-top: 185px;
+  }
+  .sign-in {
+    padding: 50px 39px 75px 72px;
+  }
+  .sign-in .title-sign-in {
+    font-size: 21px;
+    height: 43px;
+    line-height: 43px;
+    padding-left: 27px;
+    padding-right: 26px;
+    letter-spacing: 9px;
+  }
+  /* .sign-in .sign-in-left */
+  .sign-in .sign-in-left {
+    float: none;
+    padding-top: 92px;
+  }
+  .sign-in .sign-in-left h2 {
+    font-size: 48px;
+    line-height: 52px;
+    margin-bottom: 11px;
+  }
+  .sign-in .sign-in-left p {
+    font-size: 16px;
+    line-height: 32px;
+  }
+  .sign-in .sign-in-left .account {
+    margin-top: 32px;
+  }
+  .sign-in .sign-in-left a {
+    font-size: 16px;
+    line-height: 32px;
+  }
+  /* .sign-in .login-area */
+  .sign-in .login-area {
+    padding: 40px 31px 0 3px;
+  }
+  .sign-in .login-area .input-wrap {
+    height: 73px;
+    margin-bottom: 15px;
+  }
+  .sign-in .login-area .input-wrap input {
+    font-size: 16px;
+    line-height: 20px;
+    padding-left: 40px;
+    padding-right: 40px;
+    letter-spacing: 8px;
+  }
+  .sign-in .check-wrap {
+    min-height: 62px;
+    padding: 14px 0 26px 0;
+  }
+  .sign-in .login-area .btn-login {
+    padding-left: 20px;
+    padding-right: 17px;
+    height: 47px;
+    line-height: 47px;
+    letter-spacing: 4px;
+    font-size: 14px;
+  }
+  /* sign up page */
+  .contents.sign-up-contents {
+    margin-top: 185px;
+  }
+  .sign-up {
+    padding: 50px 39px 25px 72px;
+  }
+  .sign-up .title-sign-up {
+    font-size: 21px;
+    height: 43px;
+    line-height: 43px;
+    padding-left: 27px;
+    padding-right: 19px;
+    letter-spacing: 9px;
+  }
+  /* .sign-up .sign-up-left */
+  .sign-up .sign-up-left {
+    float: none;
+    padding-top: 82px;
+  }
+  .sign-up .sign-up-left h2 {
+    font-size: 48px;
+    line-height: 52px;
+    margin-bottom: 11px;
+  }
+  .sign-up .sign-up-left p {
+    font-size: 16px;
+    line-height: 32px;
+  }
+  .sign-up .sign-up-left .account {
+    margin-top: 32px;
+  }
+  .sign-up .sign-up-left a {
+    font-size: 16px;
+    line-height: 32px;
+  }
+  /* .sign-up .reg-area */
+  .sign-up .reg-area {
+    padding: 17px 31px 0 3px;
+  }
+  .sign-up .reg-area .input-wrap {
+    height: 73px;
+    margin-bottom: 15px;
+  }
+  .sign-up .reg-area .input-wrap.less-margin {
+    margin-bottom: 12px;
+  }
+  .sign-up .reg-area .input-wrap.high-margin {
+    margin-bottom: 17px;
+  }
+  .sign-up .reg-area .input-wrap.higher-margin {
+    margin-bottom: 23px;
+  }
+  .sign-up .reg-area .input-wrap input {
+    font-size: 16px;
+    line-height: 20px;
+    padding-left: 40px;
+    padding-right: 40px;
+    letter-spacing: 8px;
+  }
+  .sign-up .reg-area p {
+    font-size: 14px;
+    line-height: 28px;
+    padding-left: 44px;
+    padding-right: 180px;
+    margin-bottom: 21px;
+  }
+  .sign-up .reg-area .btn-signup {
+    padding-left: 31px;
+    padding-right: 26px;
+    height: 47px;
+    line-height: 47px;
+    letter-spacing: 4px;
+  }
+  /* what do page */
+  .contents.what-we-do-contents {
+    margin-top: 185px;
+  }
+  /* .article-detail */
+  .article-detail, .what-we-do-contents .article-detail {
+    padding: 50px 0 75px 72px;
+  }
+  .article-detail .title-do {
+    padding-left: 34px;
+    padding-right: 22px;
+    font-size: 21px;
+    height: 43px;
+    line-height: 43px;
+    letter-spacing: 10px;
+    margin-right: 39px;
+  }
+  .article-detail .detail-left {
+    padding-right: 0;
+    padding-top: 79px;
+  }
+  .article-detail .detail-left .title-img {
+    width: 625px;
+    height: 312px;
+    margin-bottom: 24px;
+  }
+  .article-detail .detail-left h2 {
+    font-size: 48px;
+    line-height: 56px;
+    padding-right: 0px;
+    padding-bottom: 0;
+  }
+  .article-detail .detail-left p {
+    font-size: 16px;
+    line-height: 32px;
+    margin-left: -3px;
+    margin-top: 21px;
+    margin-bottom: 32px;
+    padding-right: 50px;
+  }
+  .article-detail .detail-left .btn-group {
+    padding-top: 14px;
+  }
+  .article-detail .detail-left .btn-group .btn-blue {
+    font-size: 14px;
+    line-height: 43px;
+    height: 43px;
+    letter-spacing: 4px;
+    margin-right: 35px;
+    margin-bottom: 22px;
+  }
+  .article-detail .detail-left .btn-group .btn-leasing {
+    padding-left: 20px;
+    padding-right: 19px;
+    margin-top: 4px;
+  }
+  .article-detail .detail-left .btn-group .btn-communities {
+    padding-left: 12px;
+    padding-right: 10px;
+    margin-bottom: 27px;
+    margin-right: 0;
+  }
+  .article-detail .detail-left .btn-group .btn-services {
+    padding-left: 39px;
+    padding-right: 36px;
+  }
+  /* about us page */
+  .contents.about-us-contents {
+    margin-top: 185px;
+  }
+  .about-us {
+    padding: 50px 0 74px 62px;
+  }
+  .about-us .title-about-us {
+    font-size: 22px;
+    height: 45px;
+    line-height: 45px;
+    padding-left: 24px;
+    padding-right: 19px;
+    margin-right: 30px;
+    letter-spacing: 10px;
+  }
+  .about-us .about-us-left {
+    padding-right: 0;
+    padding-top: 126px;
+  }
+  .about-us .about-us-left h2 {
+    font-size: 43px;
+    line-height: 62px;
+  }
+  .about-us .about-us-left p {
+    font-size: 16px;
+    line-height: 32px;
+    margin-top: 28px;
+    margin-bottom: 51px;
+    padding-right: 270px;
+  }
+  .about-us .about-us-left .btn-works {
+    font-size: 14px;
+    line-height: 55px;
+    height: 55px;
+    letter-spacing: 5px;
+    padding-left: 36px;
+    padding-right: 25px;
+    margin-left: 3px;
+  }
+  /* .mains-tabs */
+  .mains-tabs .container {
+    width: 100%;
+  }
+  .mains-tabs .tab-index .row {
+    padding: 0;
+  }
+  .mains-tabs .tab-index .row .col-lg-3:nth-child(2n+1) {
+    padding-right: 3px;
+  }
+  .mains-tabs .tab-index .row .col-lg-3 a {
+    font-size: 21px;
+    height: 65px;
+    line-height: 65px;
+  }
+  .mains-tabs .tab-content {
+    min-height: 921px;
+  }
+  .mains-tabs .tab-content .tab-why, .mains-tabs .tab-content .tab-how, .mains-tabs .tab-content .tab-funded, .mains-tabs .tab-content .tab-involved {
+    padding-left: 33px;
+    padding-right: 30px;
+  }
+  .mains-tabs .tab-content .img-left {
+    float: none;
+    margin-top: 44px;
+    width: 100%;
+    height: 507px;
+  }
+  .mains-tabs .tab-content .img-left .desktop-img {
+    display: none;
+  }
+  .mains-tabs .tab-content .img-left .small-img {
+    display: block;
+  }
+  .mains-tabs .tab-content .content-right {
+    margin-left: 29px;
+  }
+  .mains-tabs .tab-content .content-right p {
+    font-size: 17px;
+    line-height: 33px;
+  }
+  .mains-tabs .tab-content .tab-why .content-right p {
+    padding-top: 45px;
+    padding-right: 58px;
+  }
+  .mains-tabs .tab-content .tab-how p {
+    font-size: 14px;
+    line-height: 28px;
+  }
+  .mains-tabs .tab-content .tab-how .content-right, .mains-tabs .tab-content .tab-funded .content-right {
+    padding-top: 47px;
+  }
+  .mains-tabs .tab-content .tab-how .content-right p, .mains-tabs .tab-content .tab-funded .content-right p {
+    margin-bottom: 30px;
+    padding-right: 35px;
+  }
+  .mains-tabs .tab-content .tab-funded .content-right {
+    padding-top: 40px;
+  }
+  .mains-tabs .tab-content .tab-funded .content-right p {
+    padding-right: 35px;
+    padding-top: 2px;
+    margin-bottom: 30px;
+  }
+  .mains-tabs .tab-content .tab-involved .content-right {
+    padding-top: 54px;
+    margin-left: 0;
+  }
+  .mains-tabs .tab-content .tab-involved .btn-blue {
+    margin-right: 0;
+    margin-bottom: 25px;
+    font-size: 15px;
+    line-height: 46px;
+    width: 313px;
+    height: 46px;
+    letter-spacing: 4px;
+  }
+  .mains-tabs .tab-content .tab-involved .btn-blue:nth-child(2n) {
+    float: right;
+  }
+  /* get involved page */
+  /* .info-area */
+  .info-area.container {
+    padding: 0 30px 35px 60px;
+  }
+  .info-area.container .title-h1 {
+    padding: 32px 220px 18px 0;
+  }
+  .info-area.container .txt {
+    font-size: 16.38px;
+    line-height: 32px;
+    padding-right: 70px;
+    padding-bottom: 17px;
+  }
+  /* .list-area */
+  .list-area.container {
+    background: #ededed;
+    width: auto;
+    padding: 0 0 40px 0;
+  }
+  /* .list-area .row */
+  .list-area .row {
+    background: #ededed;
+    margin: 0 auto;
+    width: 750px;
+  }
+  /* .list-area  .lefts */
+  .list-area .row .lefts {
+    float: none;
+    width: 100%;
+  }
+  .list-area .desktop-img {
+    display: none;
+  }
+  .list-area .mobile-img {
+    display: block;
+  }
+  /* .list-area .img-main */
+  .list-area .mobile-show.txt-table {
+    position: absolute;
+    bottom: 45px;
+    left: 0;
+    width: 100%;
+    z-index: 99;
+    display: block;
+    z-index: 299;
+  }
+  .list-area .mobile-show.txt-table .txt {
+    font-family: 'Source Sans Pro';
+    font-weight: 700;
+    font-size: 43.01px;
+    color: #fff;
+    text-align: center;
+    display: block;
+    height: 50px;
+    line-height: 50px;
+  }
+  .list-area .img-main .funded-round {
+    width: 170px;
+    height: 170px;
+    padding: 5px;
+    bottom: -145px;
+    margin: 0 0 0 -85px;
+  }
+  .get-involved-contents .funded-round .status-indicator {
+    margin: 5px 0 0 0;
+    position: relative;
+    left: -4px;
+  }
+  .get-involved-contents .funded-round .round-depict {
+    font-size: 19.79px;
+    width: 110px;
+    margin: 6px 0 0 -55px;
+  }
+  .get-involved-contents .funded-round .status-indicator input {
+    font-size: 42.4px !important;
+    margin-top: 34px !important;
+  }
+  .get-involved-contents .funded-round .status-indicator input.smaller {
+    font-size: 32.4px !important;
+    -webkit-transition: font-size 0.25s ease;
+    transition: font-size 0.25s ease;
+  }
+  /* .list-area .info-main */
+  .list-area .info-main {
+    padding-top: 5px;
+  }
+  .list-area .info-main .blue-bar, .list-area .info-main .dark-blue-bar {
+    font-size: 19.79px;
+    height: 47px;
+    line-height: 47px;
+    padding: 0 41px;
+    margin-top: 10px;
+    margin-right: 34px;
+    margin-left: 34px;
+  }
+  /* .list-area  .rights */
+  .list-area .row .rights {
+    margin: 0 62px;
+    padding: 65px 0 50px 0;
+    position: relative;
+  }
+  .list-area .row .rights h2, .list-area .row .rights .time {
+    display: none;
+  }
+  .list-area .row .rights .share-txt {
+    font-family: 'Source Sans Pro';
+    font-weight: 700;
+    font-size: 16.38px;
+    color: #292929;
+    position: absolute;
+    top: 103px;
+    left: 270px;
+    display: block;
+  }
+  .list-area .row .rights p {
+    font-size: 16.38px;
+    line-height: 32px;
+    padding-top: 105px;
+    padding-right: 50px;
+    padding-bottom: 47px;
+  }
+  .list-area .row .rights .bottom-bar {
+    padding-bottom: 85px;
+  }
+  .list-area .row .rights .bottom-bar .btn-read-more {
+    font-size: 14.34px;
+    letter-spacing: 4px;
+    padding-left: 15px;
+    width: 160px;
+    height: 45px;
+    line-height: 45px;
+  }
+  .list-area .row .rights .bottom-bar .social-ul {
+    float: none;
+    position: absolute;
+    top: 65px;
+    left: 0;
+  }
+  .list-area .row .rights .bottom-bar .social-ul li {
+    float: left;
+    margin-left: 0;
+    margin-right: 18px;
+  }
+  /* .past-projects-module */
+  .past-projects-module {
+    background-color: #fff;
+    padding-bottom: 0;
+  }
+  .past-projects-module .title-past-projects {
+    letter-spacing: 10px;
+    padding-left: 12px;
+    width: 355px;
+    margin: 38px auto 54px auto;
+  }
+  /* .past-projects-module .carousel-main */
+  .past-projects-module .carousel-main {
+    min-height: 0;
+    margin-right: 92px;
+    margin-left: 92px;
+  }
+  .past-projects-module .carousel.desktop-show {
+    display: none;
+  }
+  .past-projects-module .carousel.mobile-show {
+    display: block;
+  }
+  /* .past-projects-module .carousel .item */
+  .past-projects-module .carousel .item {
+    padding: 0;
+    min-height: 580px;
+  }
+  .past-projects-module .carousel .module-box {
+    float: none;
+    width: 100%;
+  }
+  .past-projects-module .carousel .spacing {
+    padding: 0 19px 0 20px;
+  }
+  /* .past-projects-module .carousel .img-main */
+  .past-projects-module .img-main .img-gradient {
+    height: 60%;
+    top: 40%;
+  }
+  .past-projects-module .img-main .funded-round {
+    width: 170px;
+    height: 170px;
+    padding: 10px;
+    right: 7px;
+    bottom: -178px;
+    z-index: 99;
+  }
+  /* .past-projects-module .carousel .info-main */
+  .past-projects-module .info-main {
+    padding: 28px 0 50px 0;
+  }
+  .past-projects-module .info-main h2 {
+    line-height: 35px;
+  }
+  .past-projects-module .info-main h2 a {
+    font-size: 30.72px;
+  }
+  .past-projects-module .info-main .time {
+    font-size: 18.43px;
+    padding: 13px 0 23px 0;
+  }
+  .past-projects-module .info-main .bottom-bar {
+    padding-right: 35px;
+  }
+  .past-projects-module .info-main .bottom-bar .btn-read-more {
+    font-size: 14.34px;
+    letter-spacing: 4px;
+    padding-left: 12px;
+    width: 157px;
+    height: 44px;
+    line-height: 44px;
+  }
+  .past-projects-module .carousel-control.left, .past-projects-module .carousel-control.right {
+    width: 49px;
+    height: 47px;
+    top: 223px;
+  }
+  .past-projects-module .carousel-control.left {
+    left: -73px;
+  }
+  .past-projects-module .carousel-control.right {
+    right: -73px;
+  }
+  .past-projects-module .carousel-control.left .icons, .past-projects-module .carousel-control.right .icons {
+    width: 24px;
+    height: 24px;
+    margin: 10px auto 0 auto;
+  }
+  .past-projects-module .carousel-control.left .icons {
+    background-position: -288px -16px;
+  }
+  .past-projects-module .carousel-control:hover.left .icons {
+    background-position: -336px -16px;
+  }
+  .past-projects-module .carousel-control.right .icons {
+    background-position: -360px -16px;
+  }
+  .past-projects-module .carousel-control:hover.right .icons {
+    background-position: -384px -16px;
+  }
+  /* project details page */
+  .details-active-project-module .banners.min-height455 {
+    min-height: 658px;
+  }
+  .desktop-banner {
+    display: none;
+  }
+  .mobile-banner {
+    display: block;
+  }
+  .details-active-project-module .banners img {
+    height: 658px;
+  }
+  /* .details-active-project-module .banner-section */
+  .details-active-project-module .banner-section .container {
+    text-align: center;
+    padding: 51px 0 0 0;
+    min-height: 658px;
+  }
+  .details-active-project-module .banner-section .title-active-project {
+    letter-spacing: 9px;
+    padding-left: 20px;
+    margin: 0 auto;
+    width: 386px;
+    float: none !important;
+  }
+  .details-active-project-module .banner-section .title-h1 {
+    font-size: 43.01px;
+    text-align: center;
+    bottom: 40px;
+    left: 0;
+    width: 100%;
+  }
+  .details-active-project-module .banner-section .funded-round {
+    width: 172px;
+    height: 172px;
+    padding: 8px;
+    margin: 0 0 0 -86px;
+    bottom: -146px;
+  }
+  .details-active-project-module .banner-section .funded-round .round-depict {
+    font-size: 19.79px;
+    text-align: center;
+    width: 170px;
+    margin: 6px 0 0 -85px;
+  }
+  .details-active-project-module .banner-section .funded-round .status-indicator input {
+    font-size: 42.4px !important;
+    margin-top: 40px !important;
+  }
+  .details-active-project-module .banner-section .funded-round .status-indicator input.smaller {
+    font-size: 32.4px !important;
+    -webkit-transition: font-size 0.25s ease;
+    transition: font-size 0.25s ease;
+  }
+  /* .details-active-project-module .info-section */
+  .details-active-project-module .info-section .container {
+    padding: 4px 29px 0 33px;
+  }
+  /* .details-active-project-module .info-main */
+  .details-active-project-module .info-main {
+    padding-bottom: 48px;
+  }
+  .details-active-project-module .info-main .blue-bar, .details-active-project-module .info-main .dark-blue-bar {
+    font-size: 19.79px;
+    height: 47px;
+    line-height: 47px;
+    padding: 0 40px;
+    margin-top: 12px;
+  }
+  /* .details-active-project-module .video-main */
+  .details-active-project-module .video-main {
+    padding: 0 31px 55px 31px;
+    position: relative;
+  }
+  .details-active-project-module .video-area {
+    float: none !important;
+  }
+  .details-active-project-module .video-area .video {
+    background: #000;
+    width: 100%;
+    height: 412px;
+    position: relative;
+  }
+  .details-active-project-module .video-area .video img {
+    width: 100%;
+    height: 412px;
+  }
+  .details-active-project-module .video-area .video iframe {
+    width: 100%;
+    height: 412px;
+    border: none;
+  }
+  .details-active-project-module .video-area .btn-play {
+    width: 130px;
+    height: 130px;
+    margin: -75px 0 0 -75px;
+  }
+  .details-active-project-module .video-area .btn-play .icons {
+    background-position: 0 -88px;
+    width: 96px;
+    height: 96px;
+    margin: 13px 0 0 0;
+  }
+  .details-active-project-module .video-area .btn-play:hover .icons, .details-active-project-module .video-area .btn-play:focus .icons {
+    background-position: -96px -88px;
+  }
+  .details-active-project-module .txt-area {
+    margin: 0;
+    min-height: 0;
+    display: table;
+  }
+  .details-active-project-module .mobile-bottom-bar {
+    display: block;
+    margin: 30px 0 0 0;
+    padding-bottom: 85px;
+  }
+  .details-active-project-module .mobile-bottom-bar .social-ul {
+    float: none;
+  }
+  .details-active-project-module .mobile-bottom-bar .social-ul li {
+    float: left;
+    margin-left: 0;
+    margin-right: 18px;
+  }
+  .details-active-project-module .mobile-bottom-bar .share-txt {
+    font-family: 'Source Sans Pro';
+    font-weight: 700;
+    font-size: 16.38px;
+    color: #292929;
+    float: left;
+    padding: 40px 0 0 0;
+    margin-left: -10px;
+    display: block;
+  }
+  .details-active-project-module .txt-area .txt-td {
+    line-height: 20px;
+  }
+  .details-active-project-module .txt-area .txt-td .font20 {
+    font-size: 20.48px;
+    line-height: 37px;
+    padding: 25px 0 32px 0;
+    color: #292929;
+  }
+  .details-active-project-module .txt-area .txt-td .font14 {
+    font-size: 16.38px;
+    line-height: 32px;
+  }
+  /* .project-updates-module */
+  .project-updates-module .container {
+    padding: 57px 31px 20px 31px;
+  }
+  /* .project-updates-module .main-area */
+  .project-updates-module .main-area {
+    text-align: center;
+    float: none;
+    width: 100%;
+    margin: 0;
+  }
+  .project-updates-module .main-area .title-project-updates {
+    width: 385px;
+    letter-spacing: 9px;
+    padding-left: 20px;
+    margin: 0 auto 37px auto;
+    float: none !important;
+  }
+  /* .project-updates-module .list-area */
+  .project-updates-module .list-area .row {
+    background: none;
+    text-align: left;
+    width: auto;
+    padding: 40px 0 0 0;
+    border-bottom: 5px solid #dcdcdc;
+  }
+  .project-updates-module .list-area .left-date {
+    width: 222px;
+  }
+  .project-updates-module .list-area .left-date .date-txt, .project-updates-module .list-area .left-date .month-txt {
+    padding: 0 50px 0 40px;
+  }
+  .project-updates-module .list-area .left-date .date-txt {
+    font-size: 126.03px;
+    line-height: 110px;
+    margin-top: -8px;
+  }
+  .project-updates-module .list-area .left-date .month-txt {
+    font-size: 24.58px;
+    letter-spacing: 22px;
+  }
+  .project-updates-module .list-area .main-info {
+    margin-left: 222px;
+    position: relative;
+  }
+  .project-updates-module .list-area .main-info .title-h4 {
+    line-height: 30px;
+    padding-bottom: 10px;
+  }
+  .project-updates-module .list-area .main-info .title-h4 a {
+    font-size: 18.43px;
+  }
+  .project-updates-module .list-area .main-info p {
+    font-size: 16.38px;
+    line-height: 32px;
+    padding-bottom: 47px;
+  }
+  .project-updates-module .list-area .main-info .social-ul {
+    margin-bottom: 34px;
+    position: absolute;
+    top: 140px;
+    left: -210px;
+  }
+  .project-updates-module .list-area .main-info .social-ul li {
+    float: left;
+    margin-right: 14px;
+  }
+  .project-updates-module .list-area .main-info .btn-icon-gray {
+    text-align: center;
+    background: rgba(40, 40, 40, 0.15);
+    width: 53px;
+    height: 43px;
+    border: 2px solid #fff;
+    display: inline-block;
+  }
+  .project-updates-module .list-area .main-info .btn-icon-gray .icons {
+    background-size: 672px auto;
+    width: 24px;
+    height: 24px;
+    margin-top: 7px;
+  }
+  .project-updates-module .list-area .main-info .btn-icon-gray .icon-fb {
+    background-position: -144px -16px;
+  }
+  .project-updates-module .list-area .main-info .btn-icon-gray:hover .icon-fb {
+    background-position: -168px -16px;
+  }
+  .project-updates-module .list-area .main-info .btn-icon-gray .icon-tw {
+    background-position: -192px -16px;
+  }
+  .project-updates-module .list-area .main-info .btn-icon-gray:hover .icon-tw {
+    background-position: -216px -16px;
+  }
+  .project-updates-module .list-area .main-info .btn-icon-gray .icon-gg {
+    background-position: -240px -16px;
+  }
+  .project-updates-module .list-area .main-info .btn-icon-gray:hover .icon-gg {
+    background-position: -264px -16px;
+  }
+  /* .project-updates-module .right-aside */
+  .project-updates-module .right-aside {
+    width: 100%;
+    float: none;
+    position: static;
+    top: 0;
+    right: 0;
+    margin-top: 39px;
+  }
+  .project-updates-module .right-aside .module-box {
+    min-height: 226px;
+    padding: 12px 0 32px 0;
+    margin: 0 32px 32px 32px;
+    position: relative;
+  }
+  .project-updates-module .right-aside .module-box .type-txt {
+    font-size: 20.48px;
+    line-height: 30px;
+    padding: 11px 0 13px 0;
+    width: 295px;
+  }
+  .project-updates-module .right-aside .module-box .value-txt {
+    font-size: 73.73px;
+    line-height: 70px;
+    padding: 0 0 20px 0;
+    width: 295px;
+  }
+  .project-updates-module .right-aside .module-box .title-h5 {
+    font-size: 16.38px;
+    text-align: left;
+    border-top: none;
+    border-bottom: 2px solid #c3c3c3;
+    width: 45%;
+    margin: 0;
+    height: 33px;
+    line-height: 33px;
+    position: absolute;
+    top: 18px;
+    right: 45px;
+  }
+  .project-updates-module .right-aside .module-box ul {
+    padding: 34px 0 25px 0;
+    width: 45%;
+    position: absolute;
+    top: 35px;
+    right: 45px;
+  }
+  .project-updates-module .right-aside .module-box .mobile-ul li {
+    float: left;
+    width: 50%;
+  }
+  .project-updates-module .right-aside .module-box li {
+    text-align: left;
+    font-size: 14.34px;
+    line-height: 32px;
+  }
+  .project-updates-module .right-aside .btn-i-want-to-donate {
+    letter-spacing: 5px;
+    padding-left: 12px;
+    width: 223px;
+    height: 45px;
+    line-height: 45px;
+    position: absolute;
+    bottom: 24px;
+    left: 33px;
+  }
+  /* .project-updates-module .venue-area */
+  .project-updates-module .venue-area {
+    display: none;
+  }
+  /* .donors-module */
+  .donors-module .titles.container {
+    text-align: center;
+    padding: 0;
+    min-height: 99px;
+  }
+  .titles.container .title-donors {
+    margin: 0 auto;
+    min-width: 192px;
+    width: 192px;
+    letter-spacing: 9px;
+    padding-left: 12px;
+    float: none !important;
+  }
+  .donors-module .mains-tabs {
+    background: #f4f4f4;
+  }
+  .donors-module .mains-tabs .tab-index .container {
+    padding: 0;
+  }
+  .donors-module .mains-tabs .tab-index .row {
+    margin-top: -2px;
+  }
+  .donors-module .mains-tabs .tab-content {
+    min-height: 708px;
+  }
+  .donors-module .tab-content .row {
+    margin: 4px 19px 40px 19px;
+  }
+  .donors-module .tab-content .row .col-md-6 {
+    padding: 46px 0 0 0;
+  }
+  .donors-module .desktop-img {
+    display: none;
+  }
+  .donors-module .mobile-img {
+    display: block;
+  }
+  .donors-module .tab-content .head-img {
+    width: 156px;
+  }
+  .donors-module .tab-content .head-img img {
+    width: 127px;
+    height: 127px;
+  }
+  .donors-module .info-box {
+    margin-left: 156px;
+  }
+  .donors-module .info-box .title-h4 {
+    padding: 10px 0 9px 0;
+  }
+  .donors-module .info-box .title-h4 a {
+    font-size: 18.43px;
+  }
+  .donors-module .info-box p {
+    font-size: 16.38px;
+    line-height: 35px;
+    padding: 0 45px 0 0;
+  }
+  /* partners page */
+  .partners-contents .container {
+    padding: 50px 0 11px 42px;
+  }
+  .partners-contents .title-partners {
+    font-size: 21px;
+    height: 43px;
+    line-height: 43px;
+    padding-left: 36px;
+    padding-right: 18px;
+    margin-right: 39px;
+    margin-bottom: 40px;
+    letter-spacing: 8px;
+  }
+  .partners-contents .titles .title-primary {
+    font-size: 48px;
+    line-height: 52px;
+    margin-bottom: 10px;
+    padding-left: 32px;
+  }
+  .partners-contents .titles .title-sub {
+    font-size: 16px;
+    line-height: 32px;
+    padding-left: 34px;
+  }
+  /* .partners-contents .list */
+  .partners-contents .list-wrap {
+    margin-top: 33px;
+  }
+  .partners-contents .list-wrap .item-wrap {
+    height: auto;
+    margin-bottom: 30px;
+  }
+  .partners-contents .list-wrap .item-wrap.large-spacing {
+    margin-bottom: 47px;
+  }
+  .partners-contents .left-img {
+    width: 200px;
+    height: 200px;
+    margin-top: 0;
+    margin-left: 3px;
+  }
+  .partners-contents .content-info {
+    margin-left: 217px;
+    height: auto;
+    overflow: auto;
+    min-height: 234px;
+  }
+  .partners-contents .content-info h4 {
+    font-size: 30px;
+    line-height: 36px;
+    margin-bottom: 8px;
+    padding-top: 36px;
+  }
+  .partners-contents .content-info h4 a {
+    font-size: 30px;
+  }
+  .partners-contents .content-info p {
+    font-size: 16px;
+    line-height: 32px;
+    padding-right: 41px;
+    padding-left: 2px;
+  }
+  .partners-contents .btn-wrap {
+    position: absolute;
+    top: 205px;
+    left: -188px;
+  }
+  .partners-contents .btn-wrap .btn-blue {
+    height: 43px;
+    line-height: 43px;
+    padding-left: 48px;
+    padding-right: 44px;
+  }
+  /* .partners-contents .pager-info */
+  .partners-contents .pager-info {
+    margin-top: 23px;
+    margin-right: 43px;
+    float: right;
+  }
+  .partners-contents .pager-info li {
+    float: left;
+    margin-right: 16px;
+  }
+  .partners-contents .pager-info li a {
+    padding: 0 17px;
+    font-size: 16px;
+    line-height: 39px;
+    height: 39px;
+  }
+  /* .sponsoring-organizations-module */
+  .sponsoring-organizations-module {
+    min-height: 450px;
+  }
+  .sponsoring-organizations-module .container {
+    padding: 50px 25px 0 25px;
+  }
+  .sponsoring-organizations-module .title-sponsoring-organizations {
+    font-size: 18px;
+    width: 494px;
+    letter-spacing: 9px;
+    padding-left: 15px;
+    margin-bottom: 69px;
+  }
+  #sponsoring-organizations-example-generic {
+    display: none;
+  }
+  #mobile-sponsoring-organizations-example-generic {
+    display: block;
+  }
+  /* .sponsoring-organizations-module .carousel-main */
+  .sponsoring-organizations-module .logo-ul li {
+    text-align: center;
+    vertical-align: middle;
+    width: 50%;
+    height: 200px;
+    display: table-cell;
+  }
+  .sponsoring-organizations-module .logo {
+    margin-right: auto;
+    margin-left: auto;
+    display: block;
+    overflow: hidden;
+  }
+  .sponsoring-organizations-module .logo-the-san-francisco {
+    background: url(../images/logo-the-san-francisco.png) no-repeat;
+    width: 166px;
+    height: 165px;
+  }
+  .sponsoring-organizations-module .logo-toyota-togethergreen {
+    background: url(../images/logo-toyota-togethergreen.png) no-repeat;
+    width: 193px;
+    height: 63px;
+  }
+  .sponsoring-organizations-module .logo-sun-shot {
+    background: url(../images/logo-sun-shot.png) no-repeat;
+    width: 134px;
+    height: 41px;
+  }
+  .sponsoring-organizations-module .logo-patagonia {
+    background: url(../images/logo-patagonia.png) no-repeat;
+    width: 172px;
+    height: 54px;
+  }
+  .sponsoring-organizations-module .carousel-control.left, .sponsoring-organizations-module .carousel-control.right {
+    background-color: rgba(41, 41, 41, 0.15);
+    text-shadow: none;
+    background-image: none;
+    box-shadow: none;
+    opacity: 1;
+    width: 49px;
+    height: 47px;
+    border: 2px solid #fff;
+    top: 90px;
+  }
+  .sponsoring-organizations-module .carousel-control.left {
+    text-align: center;
+    left: -76px;
+  }
+  .sponsoring-organizations-module .carousel-control.right {
+    text-align: center;
+    right: -76px;
+  }
+  .sponsoring-organizations-module .carousel-control.left .icons, .sponsoring-organizations-module .carousel-control.right .icons {
+    width: 24px;
+    height: 24px;
+    top: 0;
+    right: auto;
+    left: auto;
+    position: static;
+    margin: 10px auto 0 auto;
+  }
+  .sponsoring-organizations-module .carousel-control.left .icons {
+    background-position: -288px -16px;
+  }
+  .sponsoring-organizations-module .carousel-control:hover.left .icons {
+    background-position: -336px -16px;
+  }
+  .sponsoring-organizations-module .carousel-control.right .icons {
+    background-position: -360px -16px;
+  }
+  .sponsoring-organizations-module .carousel-control:hover.right .icons {
+    background-position: -384px -16px;
+  }
+  /* solar ambassador program page */
+  .solar-contents .article-detail {
+    padding: 50px 39px 49px 72px;
+  }
+  .solar-contents .article-detail .title-solar {
+    width: auto;
+    font-size: 21px;
+    height: 43px;
+    line-height: 43px;
+    padding-left: 27px;
+    padding-top: 0;
+    padding-right: 18px;
+  }
+  .solar-contents .article-detail .detail-left {
+    padding-right: 0;
+    padding-top: 85px;
+  }
+  .solar-contents .article-detail .detail-left p {
+    margin-top: 10px;
+    padding-left: 5px;
+  }
+  .solar-contents .article-detail .detail-left .title-img {
+    margin-bottom: 22px;
+  }
+  .solar-contents .article-detail .detail-left .btn-group {
+    padding-top: 0;
+    padding-right: 0;
+    margin-top: -10px;
+  }
+  .solar-contents .article-detail .detail-left .btn-group .btn-blue {
+    margin-bottom: 14px;
+  }
+  .solar-contents .article-detail .detail-left .btn-group .btn-application {
+    padding-left: 24px;
+    padding-right: 17px;
+    margin-top: 4px;
+    margin-right: 35px;
+  }
+  .solar-contents .article-detail .detail-left .btn-group .btn-team {
+    padding-left: 21px;
+    padding-right: 19px;
+    margin-bottom: 22px;
+    margin-right: 0;
+  }
+  .solar-contents .article-detail .detail-left .btn-group .btn-project {
+    padding-left: 33px;
+    padding-right: 36px;
+    margin-right: 0;
+  }
+  /* blog page */
+  .titles.container .title-blog {
+    margin-right: 40px;
+    min-width: 140px;
+    letter-spacing: 9px;
+    padding-left: 14px;
+    margin-top: -2px;
+  }
+  /* .grid-data */
+  .grid-data.container {
+    padding: 0;
+  }
+  /* .form-area */
+  .form-area {
+    padding: 0 0 11px 39px;
+    min-height: 50px;
+  }
+  .form-area .width167 .btn-default, .form-area .width167.input-search {
+    width: 230px;
+  }
+  /* .input-search */
+  .input-search {
+    padding: 0 28px 0 23px;
+    height: 50px;
+    line-height: 50px;
+  }
+  .input-search input {
+    font-size: 16.67px;
+    letter-spacing: 6px;
+    height: 50px;
+    line-height: 20px;
+  }
+  .input-search .icon-search {
+    background-position: -528px -88px;
+    width: 24px;
+    height: 24px;
+    top: 11px;
+    right: 13px;
+  }
+  .input-search .icon-search:hover {
+    background-position: -552px -88px;
+  }
+  /* .grid-area.row */
+  .grid-area.row {
+    min-height: 100px;
+  }
+  .grid-area.row .col-md-6 {
+    padding-right: 0;
+    padding-left: 0;
+  }
+  .grid-area.row .img-main {
+    height: 388px;
+  }
+  .grid-area.row .video {
+    width: 100%;
+    height: 388px;
+  }
+  .grid-area.row .video iframe {
+    width: 100%;
+    height: 388px;
+  }
+  .grid-area.row .btn-play {
+    border: 4px solid #fff;
+    top: 50%;
+    left: 50%;
+    width: 106px;
+    height: 106px;
+    margin: -53px 0 0 -53px;
+  }
+  .grid-area.row .btn-play .icons {
+    background-size: 543px auto;
+    background-position: 0 -71px;
+    width: 78px;
+    height: 78px;
+    margin: 10px 0 0 0;
+  }
+  .grid-area.row .btn-play:hover, .grid-area.row .btn-play:focus {
+    border: 4px solid #1cb0e6;
+  }
+  .grid-area.row .btn-play:hover .icons, .grid-area.row .btn-play:focus .icons {
+    background-position: -78px -71px;
+  }
+  .grid-area.row .img-main img {
+    height: 388px;
+  }
+  .grid-area.row .carousel-control.left, .grid-area.row .carousel-control.right {
+    background-color: rgba(255, 255, 255, 0.5);
+    text-shadow: none;
+    background-image: none;
+    box-shadow: none;
+    opacity: 1;
+    width: 49px;
+    height: 47px;
+    border: 2px solid #fff;
+    top: 50%;
+    bottom: auto;
+    margin-top: -24px;
+  }
+  .grid-area.row .carousel-control.left {
+    left: 24px;
+    right: auto;
+  }
+  .grid-area.row .carousel-control.right {
+    right: 24px;
+  }
+  .grid-area.row .carousel-control.left .icons, .grid-area.row .carousel-control.right .icons {
+    width: 24px;
+    height: 24px;
+    margin-top: 9px;
+  }
+  .grid-area.row .carousel-control.left .icons {
+    background-position: -288px -16px;
+  }
+  .grid-area.row .carousel-control:hover.left .icons {
+    background-position: -336px -16px;
+  }
+  .grid-area.row .carousel-control.right .icons {
+    background-position: -360px -16px;
+  }
+  .grid-area.row .carousel-control:hover.right .icons {
+    background-position: -385px -16px;
+  }
+  .grid-area.row .info-main {
+    padding: 60px 45px 40px 45px;
+  }
+  .grid-area.row .info-main .title-h2 {
+    font-size: 42px;
+    line-height: 45px;
+  }
+  .grid-area.row .info-main .title-h2 a {
+    font-size: 42px;
+  }
+  .grid-area.row .info-main .date-txt {
+    font-size: 18px;
+    line-height: 32px;
+    padding-top: 7px;
+    letter-spacing: 1px;
+    padding-bottom: 14px;
+  }
+  .grid-area.row .info-main p {
+    font-size: 16px;
+    line-height: 32px;
+    padding: 8px 25px 19px 0;
+  }
+  .grid-area.row .info-main .bottom-bar {
+    padding: 24px 5px 57px 5px;
+  }
+  .grid-area.row .info-main .bottom-bar .btn-read-more {
+    font-size: 14px;
+    letter-spacing: 4px;
+    width: 152px;
+    height: 65px;
+    padding: 0 0 0 2px;
+    line-height: 65px;
+  }
+  .grid-area.row .info-main .bottom-bar .social-ul {
+    margin: 3px 0 0 0;
+  }
+  .grid-area.row .info-main .bottom-bar .social-ul li {
+    margin: 0 8px 0 9px;
+  }
+  .grid-area.row .info-main .bottom-bar .btn-icon-gray {
+    width: 79px;
+    height: 65px;
+  }
+  .grid-area.row .info-main .bottom-bar .btn-icon-gray .icons {
+    margin-top: 7px;
+  }
+  /* .loading-bar */
+  .loading-bar {
+    padding: 0 0 45px 0;
+    margin-top: -68px;
+  }
+  .loading-bar .loading-img {
+    background: url(../images/loading.gif) no-repeat;
+    width: 128px;
+    height: 22px;
+    display: block;
+    margin: 0 auto;
+  }
+  /* .blog-details-data */
+  .blog-details-data.container {
+    padding: 0;
+    min-height: 300px;
+  }
+  /* .blog-details-data .title-bar */
+  .blog-details-data.container .title-bar {
+    padding: 10px 70px 17px 70px;
+  }
+  .blog-details-data.container .title-bar .title-h1 {
+    font-size: 48px;
+    line-height: 60px;
+  }
+  .blog-details-data.container .title-bar .date-txt {
+    font-size: 18px;
+    line-height: 32px;
+  }
+  .blog-details-data.container .title-bar .social-ul {
+    min-height: 60px;
+    position: static;
+    top: auto;
+    right: auto;
+    padding: 15px 0 0 0;
+    margin-bottom: 23px;
+  }
+  .blog-details-data.container .title-bar .social-ul li {
+    margin-right: 20px;
+    margin-left: 0;
+  }
+  .blog-details-data.container .title-bar .social-ul li .btn-icon-gray {
+    width: 78px;
+    height: 64px;
+  }
+  .blog-details-data.container .title-bar .social-ul li .btn-icon-gray .icons {
+    margin-top: 7px;
+  }
+  /* .blog-details-data .info-box */
+  .blog-details-data.container .info-box .img-main, .blog-details-data.container .info-box .img-main img {
+    height: 388px;
+  }
+  .blog-details-data.container .info-box .info-main {
+    padding: 37px 0 62px 0;
+    margin: 0 70px;
+  }
+  .blog-details-data.container .info-box .info-main .lefts, .blog-details-data.container .info-box .info-main .rights {
+    width: auto;
+    float: none;
+  }
+  .blog-details-data.container .info-box .info-main .lefts p {
+    padding-right: 0;
+  }
+  .blog-details-data.container .info-box .info-main .rights p {
+    padding-left: 0;
+  }
+  .blog-details-data.container .info-box .info-main .font20 {
+    font-size: 20px;
+    line-height: 36px;
+  }
+  .blog-details-data.container .info-box .info-main .font14 {
+    font-size: 16px;
+    line-height: 32px;
+  }
+  .blog-details-data.container .info-box .info-main .lefts .font14, .blog-details-data.container .info-box .down25 {
+    padding-bottom: 34px;
+  }
+  .blog-details-data.container .info-box .info-main .rights .down25 {
+    padding-bottom: 0;
+  }
+  /* .related-blog-module */
+  .related-blog-module {
+    padding: 26px 0 7px 0;
+  }
+  .related-blog-module .form-area {
+    min-height: 83px;
+    margin-top: 96px;
+  }
+  .related-blog-module .title-related-blog {
+    font-size: 21px;
+    width: 320px;
+    top: 2px;
+    right: 39px;
+  }
+  .related-blog-module .desktop-show {
+    display: none;
+  }
+  .related-blog-module .mobile-show {
+    display: block;
+  }
+  #mobile-related-example-generic {
+    margin: 0 72px;
+  }
+  #mobile-related-example-generic .grid-area.row .info-main {
+    padding: 23px 185px 23px 0;
+    position: relative;
+  }
+  #mobile-related-example-generic .grid-area.row .info-main .title-h2 {
+    font-size: 48px;
+  }
+  #mobile-related-example-generic .grid-area.row .info-main p, #mobile-related-example-generic .grid-area.row .info-main .bottom-bar .social-ul {
+    display: none;
+  }
+  #mobile-related-example-generic .grid-area.row .info-main .bottom-bar {
+    padding: 0;
+    overflow: visible;
+  }
+  #mobile-related-example-generic .grid-area.row .info-main .bottom-bar .btn-read-more {
+    position: absolute;
+    top: 34px;
+    right: 0;
+    width: 158px;
+    height: 55px;
+    line-height: 55px;
+    z-index: 99;
+  }
+  .related-blog-module .carousel-control.left, .related-blog-module .carousel-control.right {
+    width: 49px;
+    height: 47px;
+    top: 180px;
+    margin-top: 0;
+  }
+  .related-blog-module .carousel-control.left {
+    left: -55px;
+  }
+  .related-blog-module .carousel-control.right {
+    right: -55px;
+  }
+  .related-blog-module .carousel-control.left .icons, .related-blog-module .carousel-control.right .icons {
+    width: 24px;
+    height: 24px;
+    margin-top: 9px;
+  }
+  .related-blog-module .carousel-control.left .icons {
+    background-position: -288px -16px;
+  }
+  .related-blog-module .carousel-control:hover.left .icons {
+    background-position: -336px -16px;
+  }
+  .related-blog-module .carousel-control.right .icons {
+    background-position: -360px -16px;
+  }
+  .related-blog-module .carousel-control:hover.right .icons {
+    background-position: -384px -16px;
+  }
+  .related-blog-module .carousel-inner>.active {
+    min-height: 590px;
+  }
+  /* .comments-module */
+  .comments-module .container {
+    padding: 37px 38px 0 38px;
+  }
+  .comments-module .container .title-comments {
+    width: 221px;
+    letter-spacing: 10px;
+    padding-left: 12px;
+    margin-bottom: 6px;
+  }
+  /* .comments-module .comments-area  .comments-list*/
+  .comments-module .comments-area {
+    min-height: 200px;
+    padding-top: 20px;
+  }
+  .comments-module .comments-area .comments-list {
+    padding: 63px 0 34px 0;
+  }
+  .comments-module .comments-area .spaceleft {
+    padding-left: 0;
+  }
+  .comments-module .comments-area .spacetop {
+    padding-top: 26px;
+  }
+  .comments-module .comments-area .comments-list .head-img {
+    float: left;
+    width: 125px;
+  }
+  .comments-module .comments-area .comments-list .head-img img {
+    width: 99px;
+    height: 99px;
+    margin-left: 5px;
+  }
+  .comments-module .comments-area .comments-list .info-box {
+    margin-left: 130px;
+  }
+  .comments-module .comments-area .comments-list .info-box .title-h4 {
+    padding: 3px 0 6px 0;
+  }
+  .comments-module .comments-area .comments-list .info-box .title-h4 a {
+    font-size: 20px;
+  }
+  .comments-module .comments-area .comments-list .info-box p {
+    font-size: 16px;
+    line-height: 32px;
+    padding: 0 28px 30px 0;
+  }
+  .comments-module .comments-area .comments-list .comments-apply {
+    width: 156px;
+    height: 42px;
+    line-height: 42px;
+    letter-spacing: 6px;
+  }
+  .comments-module .comments-area .comments-list .comments-apply a {
+    font-size: 14px;
+    padding-left: 5px;
+  }
+  /* .comments-module .comments-area .quick-reply */
+  .comments-module .comments-area .quick-reply {
+    padding: 32px 0 33px 0;
+  }
+  .comments-module .btn-icon-gray {
+    width: 54px;
+    height: 44px;
+  }
+  .comments-module .btn-icon-gray .icons {
+    width: 24px;
+    height: 24px;
+    margin-top: 9px;
+  }
+  .comments-module .btn-icon-gray .icon-fb {
+    background-position: -144px -16px;
+  }
+  .comments-module .btn-icon-gray:hover .icon-fb {
+    background-position: -168px -16px;
+  }
+  .comments-module .btn-icon-gray .icon-tw {
+    background-position: -192px -16px;
+  }
+  .comments-module .btn-icon-gray:hover .icon-tw {
+    background-position: -216px -16px;
+  }
+  .comments-module .btn-icon-gray .icon-gg {
+    background-position: -240px -16px;
+  }
+  .comments-module .btn-icon-gray:hover .icon-gg {
+    background-position: -264px -16px;
+  }
+  .comments-module .comments-area .quick-reply .quick-reply-txt {
+    width: 135px;
+  }
+  .comments-module .comments-area .quick-reply .quick-reply-txt .title-h4 {
+    padding: 18px 0 22px 0;
+    font-size: 20px;
+  }
+  .comments-module .comments-area .quick-reply .quick-reply-txt p {
+    font-size: 16px;
+  }
+  .comments-module .comments-area .quick-reply .quick-reply-txt li {
+    margin-top: 11px;
+    margin-left: -1px;
+  }
+  .comments-module .comments-area .quick-reply .quick-reply-txt li:nth-child(2) {
+    margin-left: 13px;
+  }
+  .comments-module .comments-area .quick-reply .textarea-box {
+    margin-right: 4px;
+    margin-left: 135px;
+    height: 252px;
+    padding: 21px 29px;
+  }
+  .comments-module .comments-area .quick-reply .textarea-box textarea {
+    font-size: 16px;
+    height: 170px;
+    line-height: 14px;
+    letter-spacing: 6px;
+  }
+  .comments-module .comments-area .quick-reply .comments-post {
+    width: 137px;
+    height: 43px;
+    line-height: 43px;
+    right: 6px;
+    bottom: 35px;
+    letter-spacing: 4px;
+  }
+  .comments-module .comments-area .quick-reply .comments-post a {
+    font-size: 14px;
+    padding: 2px 0 0 3px;
+  }
+  /* .footer */
+  .footer .row {
+    padding: 0 23px 0 65px;
+  }
+  .footer .row .col-info {
+    float: left;
+    padding: 45px 0 18px 0;
+  }
+  .footer .row .col-menu dt, .footer .row .col-info dt {
+    line-height: 25px;
+    padding: 20px 0;
+  }
+  .footer .row .col-menu dt a, .footer .row .col-info dt a {
+    font-size: 21.5px;
+  }
+  .footer .row .col-menu dd, .footer .row .col-info dd {
+    line-height: 29px;
+  }
+  /* .footer .col-menu */
+  .footer .row .col-menu {
+    width: 100%;
+    float: none;
+    padding: 45px 0 10px 0;
+  }
+  .footer .row .col-menu dt {
+    padding-bottom: 0;
+  }
+  /* .footer .col-info */
+  .footer .row .col-info {
+    width: 33.3333333%;
+  }
+  .footer .row .col-info:nth-child(2) {
+    width: 34%;
+  }
+  .footer .row .col-info:nth-child(3) {
+    width: 38%;
+  }
+  .footer .row .col-info:nth-child(4) {
+    width: 28%;
+  }
+  .footer .row .col-info:nth-child(5) {
+    width: 100%;
+    padding: 0 0 32px 0;
+  }
+  .footer .row .col-info:nth-child(5) dt a {
+    font-size: 16.38px;
+    color: #6f6f6f;
+  }
+  .footer .row .col-info dt {
+    padding-bottom: 7px;
+  }
+  .footer .row .col-info a {
+    font-size: 16.38px;
+  }
+  .footer .row .col-info p {
+    font-size: 14.34px;
+    line-height: 24px;
+    padding: 0;
+  }
+  /* .footer .bottoms */
+  .footer .bottoms {
+    margin: 0;
+    min-height: 225px;
+  }
+  .footer .bottoms .lefts, .footer .bottoms .rights {
+    float: none !important;
+  }
+  .footer .bottoms .logo {
+    background-size: 171px auto;
+    margin: 38px auto 0 auto;
+    width: 171px;
+    height: 68px;
+  }
+  .footer .bottoms .social-ul {
+    margin: 48px auto 0 auto;
+    width: 170px;
+    height: 24px;
+  }
+  .footer .bottoms .social-ul li {
+    float: left;
+    margin: 0 14px;
+  }
+  .footer .bottoms .social-ul li .icons {
+    background-size: 672px auto;
+    width: 24px;
+    height: 24px;
+  }
+  .footer .bottoms .social-ul li .icon-fb {
+    background-position: 0 -16px;
+  }
+  .footer .bottoms .social-ul li .icon-fb:hover {
+    background-position: -24px -16px;
+  }
+  .footer .bottoms .social-ul li .icon-tw {
+    background-position: -48px -16px;
+  }
+  .footer .bottoms .social-ul li .icon-tw:hover {
+    background-position: -72px -16px;
+  }
+  .footer .bottoms .social-ul li .icon-gg {
+    background-position: -96px -16px;
+  }
+  .footer .bottoms .social-ul li .icon-gg:hover {
+    background-position: -120px -16px;
+  }
+  /* .modal-default */
+  .modal.modal-default .modal-dialog {
+    width: 706px;
+    margin: 209px auto;
+  }
+  /* .modal-default .modal-header */
+  .modal.modal-default .btn-close {
+    background-position: -480px -88px;
+    width: 48px;
+    height: 48px;
+    top: 37px;
+    right: 24px;
+  }
+  .modal.modal-default .btn-close:hover {
+    background-position: -480px -136px;
+  }
+  /* .modal-default .modal-body */
+  .modal.modal-default .modal-body {
+    padding: 0;
+    min-height: 100px;
+  }
+  /* #modal-how-it-works */
+  #modal-how-it-works .title-how-it-works {
+    width: 283px;
+    letter-spacing: 9px;
+    padding-left: 12px;
+    margin: 38px auto 0 auto;
+  }
+  #modal-how-it-works .txt-info {
+    font-size: 16.38px;
+    line-height: 33px;
+    padding: 540px 68px 35px 68px;
+  }
+  /* #modal-how-it-works .info-row */
+  #modal-how-it-works .info-row {
+    padding: 25px 30px 7px 30px;
+    position: absolute;
+    top: 20px;
+    left: 0;
+  }
+  #modal-how-it-works .info-row .video-area .video, #modal-how-it-works .info-row .video-area .video img {
+    width: 640px;
+    height: 458px;
+  }
+  #modal-how-it-works .info-row .video-area .video iframe {
+    width: 640px;
+    height: 458px;
+    border: none;
+  }
+  #modal-how-it-works .info-row .video-area .btn-play {
+    text-align: center;
+    border: 5px solid #fff;
+    border-radius: 100%;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 130px;
+    height: 130px;
+    margin: -75px 0 0 -75px;
+  }
+  #modal-how-it-works .info-row .video-area .btn-play .icons {
+    background-position: 0 -88px;
+    width: 96px;
+    height: 96px;
+    margin: 13px 0 0 0;
+  }
+  #modal-how-it-works .info-row .video-area .btn-play:hover, #modal-how-it-works .info-row .video-area .btn-play:focus {
+    border: 5px solid #1cb0e6;
+  }
+  #modal-how-it-works .info-row .video-area .btn-play:hover .icons, #modal-how-it-works .info-row .video-area .btn-play:focus .icons {
+    background-position: -96px -88px;
+  }
+  #modal-how-it-works .info-row .step-area {
+    display: none;
+  }
 }
-/* btn */
-.btn-blue {
-	font-size: 14.34px;
-	height: 55px;
-	line-height: 55px;
-	padding: 0 5px;
-}
-.btn-icon-gray {
-	width: 74px;
-	height: 60px;
-}
-	.btn-icon-gray .icons {
-		width: 48px;
-		height: 48px;
-		margin-top: 5px;
-	}
-		.btn-icon-gray .icon-fb {
-			background-position: -288px -40px;
-		}
-			.btn-icon-gray:hover .icon-fb {
-				background-position: -336px -40px;
-			}
-		.btn-icon-gray .icon-tw {
-			background-position: -384px -40px;
-		}
-			.btn-icon-gray:hover .icon-tw {
-				background-position: -432px -40px;
-			}
-		.btn-icon-gray .icon-gg {
-			background-position: -480px -40px;
-		}
-			.btn-icon-gray:hover .icon-gg {
-				background-position: -528px -40px;
-			}
-
-
-
-	/* .dropdown-default */
-	.dropdown-default .btn-default {
-		font-size: 16.67px;
-		letter-spacing: 7px;
-		padding: 0 32px 0 40px;
-		height: 50px;
-		line-height: 47px;
-	}
-		.dropdown-default .btn-default .icon-arrow-down {
-			background-position: -97px 0;
-			top: 16px;
-			right: 17px;
-		}
-			.dropdown-default .btn-default.active .icon-arrow-down,
-			.dropdown-default .btn-default:active .icon-arrow-down,
-			.open.dropdown-default>.dropdown-toggle.btn-default .icon-arrow-down {
-				background-position: -113px 0;
-			}
-		.dropdown-default .dropdown-menu {
-			font-size: 16.46px;
-			min-width: 60px;
-			padding: 5px 0;
-		}
-			.dropdown-default .dropdown-menu>li>a {
-				padding: 0 25px;
-				line-height: 26px;
-			}
-
-
-
-/* title */
-.title-white-border,
-.title-blue-border {
-	font-size: 21.5px;
-	letter-spacing: 7px;
-	height: 44px;
-	line-height: 44px;
-	padding: 0 5px;
-}
-
-.container {
-	width: 750px;
-}
-
-
-/* .header */
-.header {
-	margin-top: 10px;
-	height: 185px;
-}
-		.header .logo {
-			background: url(../images/tablet/tablet-logo-white.png);
-			background-size: 257px auto;
-			margin: 37px 0 0 32px;
-			width: 257px;
-			height: 101px;
-		}
-		.header .btn-donate {
-			min-width: 132px;
-		}
-		.header .rights {
-			padding: 66px 24px 0 0;
-		}
-			.header .txt {
-				font-size: 16.38px;
-				padding: 2px 14px 3px 0;
-				line-height: 26px;
-			}
-	/* .after-scroll-header */
-	.header.after-scroll-header {
-		border-bottom: 1px solid #c6c6c6;
-	}
-		.header.after-scroll-header .logo {
-			background: url(../images/tablet/tablet-logo.png);
-			background-size: 257px auto;
-			width: 257px;
-			height: 101px;
-			margin: 47px 0 0 32px;
-		}
-		.header.after-scroll-header .rights {
-			padding: 77px 24px 0 0;
-		}
-
-
-/* .top-section */
-.top-section {
-	min-height: 185px;
-}
-	.top-section .sub-section-bg {
-		background: url(../images/tablet/tablet-sub-section-bg.jpg) no-repeat center top;
-		background-size: 100% 185px;
-	}
-		.top-section.min-height {
-			min-height: 1366px;
-		}
-			.top-section .section-video img {
-				width: 100%;
-				height: 1366px;
-			}
-			.top-section .section-video-area iframe,
-			.top-section .section-video-area video,
-			.top-section .section-video-area .mejs-container,
-			.top-section .section-video-area .me-plugin,
-			.top-section .section-video-area embed,
-			.top-section .section-video-area .mejs-overlay-play {
-				width: 100%!important;
-				height: 1366px!important;
-				border: none;
-			}
-	.top-section.min-height .container {
-		top: 55px;
-	}
-	/* .top-section .carousel */
-	.top-section .carousel {
-		padding-right: 65px;
-		padding-left: 65px;
-	}
-		/* .top-section .carousel .item */
-		.top-section .carousel .item {
-			padding: 272px 0 0 0;
-			min-height: 1124px;
-		}
-			.top-section .carousel .item-info {
-				width: 580px;
-			}
-				.top-section .carousel .item-info .titles {
-					font-size: 49.15px;
-					line-height: 58px;
-				}
-				.top-section .carousel .item-info p {
-					font-size: 20.48px;
-					line-height: 36px;
-					width: 480px;
-					padding: 22px 0 48px 0;
-				}
-				.top-section .carousel .item-info .btn-donate-now {
-					letter-spacing: 4.5px;
-					min-width: 257px;
-					padding-left: 15px;
-				}
-		/* .top-section .carousel-indicators */
-		.top-section .carousel-indicators li {
-			width: 20px;
-			height: 20px;
-			margin: 0 6px 0 5px;
-		}
-			.top-section .icon-arrow-down {
-				background-position: -240px -40px;
-				width: 48px;
-				height: 48px;
-				bottom: -78px;
-			}
-			.top-section .carousel-control.left,
-			.top-section .carousel-control.right {
-				width: 66px;
-				height: 64px;
-				top: auto;
-				bottom: 13px;
-			}
-				.top-section .carousel-control.left {
-					left: 33px;
-				}
-				.top-section .carousel-control.right {
-					right: 33px;
-				}
-					.top-section .carousel-control.left .icons,
-					.top-section .carousel-control.right .icons {
-						width: 24px;
-						height: 24px;
-						margin-top: 18px;
-					}
-						.top-section .carousel-control.left .icons {
-							background-position: -480px -16px;
-						}
-							.top-section .carousel-control:hover.left .icons {
-								background-position: -504px -16px;
-							}
-						.top-section .carousel-control.right .icons {
-							background-position: -576px -16px;
-						}
-							.top-section .carousel-control:hover.right .icons {
-								background-position: -552px -16px;
-							}
-
-
-
-/* home page */
-.mobile-mask {
-	display: none;
-}
-	/* .active-projects-module */
-	.active-projects-module {
-		text-align: center;
-		padding-bottom: 18px;
-	}
-		.active-projects-module .title-active-projects {
-			letter-spacing: 10px;
-			width: 378px;
-			margin: 51px auto;
-		}
-		.active-projects-module .row {
-			margin: 0 64px;
-		}
-				/* .active-projects-module .module-box */
-				.active-projects-module .module-box {
-					margin: 0 0 53px 0;
-				}
-					.active-projects-module .desktop-img {
-						display: none;
-					}
-					.active-projects-module .mobile-img {
-						display: block;
-					}
-					/* .active-projects-module .img-main */
-					.active-projects-module .img-main .txt-table {
-						height: 623px;
-					}
-						.active-projects-module .img-main .txt {
-							font-size: 43.01px;
-							line-height: 62px;
-							padding: 0 130px 46px 130px;
-						}
-						.active-projects-module .img-main .funded-round {
-							width: 240px;
-							height: 250px;
-							padding: 20px;
-							bottom: -125px;
-							margin: 0 0 0 -125px;
-						}
-							.active-projects-module .img-main .funded-round .round-depict {
-								font-size: 30.72px;
-								width: 176px;
-								margin: 8px 0 0 -88px;
-							}
-							.active-projects-module .img-main .funded-round .status-indicator input {
-								font-size: 73.73px !important;
-								margin-top: 29px !important;
-								width: 160px !important;
-								height: 80px !important;
-								margin-left: -185px!important;
-							}
-							.active-projects-module .img-main .funded-round .status-indicator input.smaller {
-								font-size: 64px !important;
-								margin-top: 41px !important;
-								-webkit-transition: font-size 0.25s ease;
-								transition: font-size 0.25s ease;
-							}
-								.active-projects-module.embedded .img-main .funded-round .status-indicator input {
-									margin-top: -170px !important;
-								}
-								.active-projects-module.embedded .img-main .funded-round .status-indicator input.smaller {
-									margin-top: -165px !important;
-									font-size: 60px !important;
-								}
-						.status-indicator {
-							transform: rotateY(180deg);
-							-webkit-transform: rotateY(180deg);
-						}
-						.status-indicator input {
-							transform: rotateY(180deg);
-							-webkit-transform: rotateY(180deg);
-						}
-						.tablet-circle {
-							display: block;
-						}
-						.desktop-circle,
-						.small-circle,
-						.mobile-circle {
-							display: none;
-						}
-
-
-					/* .active-projects-module .info-main */
-					.active-projects-module .info-main {
-						padding: 86px 61px 34px 58px;
-					}
-						.active-projects-module .info-main .blue-bar,
-						.active-projects-module .info-main .dark-blue-bar {
-							font-size: 30.72px;
-							height: 96px;
-							line-height: 96px;
-							padding: 0 35px 0 48px;
-							margin-top: 24px;
-						}
-
-		/* .our-impacts-module */
-		.our-impacts-module .title-our-impacts {
-			letter-spacing: 10px;
-			padding-left: 20px;
-			width: 312px;
-			margin: 42px auto 28px auto;
-		}
-		.our-impacts-module .row {
-			margin: 0 18px 0 16px;
-			padding: 0 0 2px 0;
-			border-bottom: 1px solid #cacaca;
-		}
-			.our-impacts-module .row .col-md-3 {
-				width: 50%;
-				float: left;
-				padding: 0;
-			}
-			.our-impacts-module .module-box {
-				margin-bottom: 48px;
-			}
-				.our-impacts-module .row .col-md-3:nth-child(1) .module-box {
-					float: none;
-					width: 100%;
-					margin-left: 0;
-				}
-					.our-impacts-module .row .col-md-3:nth-child(2) .module-box .icons {
-						margin-left: auto;
-					}
-					.our-impacts-module .row .col-md-3:nth-child(2) .module-box .titles {
-						padding-right: 0;
-					}
-					.our-impacts-module .row .col-md-3:nth-child(3) .module-box .icons {
-						margin-left: auto;
-					}
-					.our-impacts-module .row .col-md-3:nth-child(3) .module-box .titles {
-						letter-spacing: -1.8px;
-						padding-top: 20px;
-						line-height: 40px;
-					}
-				.our-impacts-module .row .col-md-3:nth-child(4) .module-box {
-					float: none;
-					width: 100%;
-				}
-					.our-impacts-module .row .col-md-3:nth-child(4) .module-box .titles {
-						padding-top: 5px;
-						line-height: 50px;
-					}
-			.our-impacts-module .module-box .icons {
-				width: 168px;
-				height: 160px;
-			}
-				.our-impacts-module .module-box .icon-people {
-					background-position: 0 -184px;
-				}
-				.our-impacts-module .module-box .icon-home-ok {
-					background-position: -168px -184px;
-				}
-				.our-impacts-module .module-box .icon-tree {
-					background-position: -336px -190px;
-				}
-				.our-impacts-module .module-box .icon-user {
-					background-position: -504px -178px;
-				}
-					.our-impacts-module .module-box .titles {
-						line-height: 66px;
-					}
-						.our-impacts-module .module-box .font20 {
-							font-size: 20.48px;
-						}
-						.our-impacts-module .module-box .font48 {
-							font-size: 49.15px;
-						}
-						.our-impacts-module .module-box .font72 {
-							font-size: 73.73px;
-						}
-					.our-impacts-module .module-box .txt {
-						font-size: 18.43px;
-						line-height: 22px;
-						padding-top: 0;
-						padding-right: 20%;
-						padding-left: 20%;
-					}
-
-	/* .how-it-works-module */
-	.how-it-works-module .title-how-it-works {
-		letter-spacing: 10px;
-		padding-left: 20px;
-		width: 312px;
-		margin: 52px auto 0 auto;
-	}
-		/* .how-it-works-module .info-row */
-		.how-it-works-module .info-row {
-			padding: 49px 33px 0 30px;
-		}
-			.how-it-works-module .info-row .video-area.pull-right {
-				float: none !important;
-			}
-			.how-it-works-module .info-row .video-area .video,
-			.how-it-works-module .info-row .video-area .video img,
-			.how-it-works-module .info-row .video-area .video iframe {
-				width: 100%;
-				height: 524px;
-			}
-				.how-it-works-module .info-row .video-area .btn-play {
-					width: 130px;
-					height: 130px;
-					margin: -75px 0 0 -75px;
-				}
-					.how-it-works-module .info-row .video-area .btn-play .icons {
-						background-position: 0 -88px;
-						width: 96px;
-						height: 96px;
-						margin: 13px 0 0 0;
-					}
-						.how-it-works-module .info-row .video-area .btn-play:hover .icons,
-						.how-it-works-module .info-row .video-area .btn-play:focus .icons {
-							background-position: -96px -88px;
-						}
-			.how-it-works-module .info-row .txt-area {
-				margin: 30px;
-				min-height: 0;
-			}
-			.how-it-works-module .info-row .txt-area .txt-table {
-				min-height: 0;
-			}
-				.how-it-works-module .info-row .txt-area .txt-td {
-					line-height: 20px;
-				}
-				.how-it-works-module .info-row .txt-area .txt-td p {
-					font-size: 16.38px;
-					line-height: 32px;
-					text-align: center;
-					letter-spacing: 0;
-				}
-		/* .how-it-works-module .step-row */
-		.how-it-works-module .step-row {
-			text-align: left;
-			margin: 79px 32px 0 32px;
-			min-height: 317px;
-			border-bottom: 1px solid #cacaca;
-		}
-			.how-it-works-module .carousel {
-				min-height: 265px;
-				margin-right: 85px;
-				margin-left: 85px;
-			}
-				.how-it-works-module .row .carousel-control,
-				.how-it-works-module .row .carousel-control .icons,
-				.how-it-works-module .row .carousel-indicators {
-					display: block;
-				}
-					.how-it-works-module .step-row .carousel-inner>.item {
-						float: none;
-						display: none;
-					}
-					.how-it-works-module .step-row .carousel-inner>.active,
-					.how-it-works-module .step-row .carousel-inner>.next,
-					.how-it-works-module .step-row .carousel-inner>.prev {
-						display: block;
-					}
-						.how-it-works-module .step-row .item:nth-child(1),
-						.how-it-works-module .step-row .item:nth-child(2) {
-							width: 100%;
-						}
-						.how-it-works-module .step-row .item:nth-child(3) {
-							width: 100%;
-						}
-							.how-it-works-module .step-row .item:nth-child(3) .info-txt {
-								margin-right: 0;
-							}
-					.how-it-works-module .row .carousel-control.left,
-					.how-it-works-module .row .carousel-control.right {
-						background-color: rgba(41,41,41,0.15);
-						text-shadow: none;
-						background-image: none;
-						box-shadow: none;
-						opacity: 1;
-						width: 67px;
-						height: 63px;
-						border: 2px solid #fff;
-						top: 43px;
-					}
-						.how-it-works-module .row .carousel-control.left {
-							text-align: center;
-							left: -85px;
-						}
-						.how-it-works-module .row .carousel-control.right {
-							text-align: center;
-							right: -85px;
-						}
-							.how-it-works-module .row .carousel-control.left .icons,
-							.how-it-works-module .row .carousel-control.right .icons {
-								width: 24px;
-								height: 24px;
-								top: 0;
-								right: auto;
-								left: auto;
-								position: static;
-								margin: 17px auto 0 auto;
-							}
-								.how-it-works-module .row .carousel-control.left .icons {
-									background-position: -456px -16px;
-								}
-									.how-it-works-module .row .carousel-control:hover.left .icons {
-										background-position: -504px -16px;
-									}
-								.how-it-works-module .row .carousel-control.right .icons {
-									background-position: -528px -16px;
-								}
-									.how-it-works-module .row .carousel-control:hover.right .icons {
-										background-position: -552px -16px;
-									}
-						.how-it-works-module .carousel-indicators li {
-							width: 18px;
-							height: 18px;
-							margin: 0 5px;
-							background-color: rgba(41,41,41,0.5);
-							border: none;
-							border-radius: 100%;
-						}
-							.how-it-works-module .carousel-indicators .active {
-								width: 18px;
-								height: 18px;
-								background-color: rgba(41,41,41,1);
-							}
-								.how-it-works-module .step-row .module-box {
-									padding: 10px 33px 0 33px;
-									min-height: 170px;
-								}
-									.how-it-works-module .step-row .icon-blue-round {
-										width: 132px;
-										height: 132px;
-									}
-										.how-it-works-module .step-row .icon-blue-round .icons {
-											width: 96px;
-											height: 96px;
-											margin-top: 15px;
-										}
-											.how-it-works-module .step-row .icon-fundraise .icons {
-												background-position: -192px -88px;
-											}
-											.how-it-works-module .step-row .icon-invest .icons {
-												background-position: -288px -88px;
-											}
-											.how-it-works-module .step-row .icon-pay-it-forward .icons {
-												background-position: -384px -88px;
-											}
-									.how-it-works-module .step-row .icon-arrow-right {
-										display: none;
-									}
-									.how-it-works-module .step-row .info-txt {
-										margin: 0 0 0 160px;
-									}
-										.how-it-works-module .step-row .info-txt h4 {
-											font-size: 24.58px;
-											line-height: 30px;
-											padding-bottom: 3px;
-											margin-top: 24px;
-										}
-										.how-it-works-module .step-row .info-txt p {
-											font-size: 16.38px;
-											line-height: 33px;
-											letter-spacing: -0.7px;
-										}
-
-	/* .how-it-works-module */
-	.testimonial-module {
-		padding-bottom: 60px;
-	}
-		.testimonial-module .container {
-			padding: 0;
-		}
-		.testimonial-module .title-testimonial {
-			letter-spacing: 10px;
-			padding-left: 10px;
-			width: 253px;
-			margin: 48px auto 0 auto;
-		}
-			/* .testimonial-module .head-row */
-			.testimonial-module .head-row {
-				margin: 0;
-				padding: 37px 19px 0 19px;
-			}
-				.testimonial-module .head-row ul {
-					display: block;
-				}
-				.testimonial-module .head-row li {
-					display: block;
-					float: left;
-					width: 33.33333333%;
-				}
-				.testimonial-module .head-row li .head-img {
-					display: block;
-					margin: 14px;
-				}
-					.testimonial-module .head-row li .head-img .desktop-head {
-						display: none;
-					}
-					.testimonial-module .head-row li .head-img .mobile-head {
-						display: block;
-					}
-					.testimonial-module .head-row li.mobile-show {
-						display: block;
-					}
-					.testimonial-module .head-row li .head-img .icon-arrow-down {
-						display: none;
-					}
-				/*.testimonial-module .head-row li .head-img:hover,
-				.testimonial-module .head-row li .head-img:focus,*/
-				.testimonial-module .head-row li .head-img.active {
-					border-radius: 10px;
-					margin: 0;
-					margin: 7px;
-					padding: 5px;
-				}
-					/*.testimonial-module .head-row li .head-img:hover .icon-arrow-down,
-					.testimonial-module .head-row li .head-img:focus .icon-arrow-down,*/
-					.testimonial-module .head-row li .head-img.active .icon-arrow-down {
-						display: none;
-					}
-					.testimonial-module .head-row li .head-img img {
-						width: 100%;
-						height: 100%;
-						border-radius: 10px;
-					}
-			/* .testimonial-module .info-area */
-			.testimonial-module .info-area {
-				padding: 35px 60px 0 60px;
-			}
-				.testimonial-module .info-area p {
-					font-size: 16.38px;
-					line-height: 32px;
-					letter-spacing: -0.2px;
-					width: 640px;
-					padding-bottom: 15px;
-				}
-					.testimonial-module .info-area .block {
-						display: block;
-					}
-					    .testimonial-module .user-group {
-							padding-top: 14px;
-						}
-							.testimonial-module .user-group .link-blue {
-								font-size: 24.58px;
-							}
-							.testimonial-module .user-group .txt {
-								font-size: 16.38px;
-								padding: 13px 0 40px 0;
-							}
-							.testimonial-module .user-group .btn-blue {
-								font-size: 14.34px;
-								height: 41px;
-								line-height: 41px;
-								padding-top: 2px;
-								min-width: 292px;
-								letter-spacing: 4px;
-							}
-
-	/* .featured-on-module */
-	.featured-on-module {
-		padding-bottom: 41px;
-	}
-		.featured-on-module .title-featured-on {
-			font-size: 21.5px;
-			letter-spacing: 10px;
-			padding-left: 20px;
-			width: 300px;
-			margin: 43px auto 43px auto;
-		}
-			/* .featured-on-module .carousel-main */
-			.featured-on-module .carousel-main {
-				min-height: 175px;
-			}
-			#featured-on-example-generic {
-				display: none;
-			}
-			#mobile-featured-on-example-generic {
-				display: block;
-			}
-				/* .featured-on-module .carousel-main */
-				.featured-on-module .carousel-main {
-					min-height: 175px;
-					margin-right: 65px;
-					margin-left: 65px;
-				}
-					.featured-on-module .carousel-main .logo-ul li {
-						height: 171px;
-					}
-						.featured-on-module .logo-fast-mpany {
-							background-size: 154px auto;
-							width: 154px;
-							height: 23px;
-						}
-						.featured-on-module .logo-ehe-new-hork-eimes {
-							background-size: 137px auto;
-							width: 137px;
-							height: 113px;
-						}
-						.featured-on-module .logo-shareable {
-							background-size: 144px auto;
-							width: 144px;
-							height: 21px;
-						}
-						.featured-on-module .logo-philanthropy {
-							background-size: 153px auto;
-							width: 153px;
-							height: 28px;
-						}
-						.featured-on-module .logo-clean-technica {
-							background-size: 153px auto;
-							width: 153px;
-							height: 44px;
-						}
-							.featured-on-module .logo-fast-mpany:hover,
-							.featured-on-module .logo-fast-mpany:focus,
-							.featured-on-module .logo-ehe-new-hork-eimes:hover,
-							.featured-on-module .logo-ehe-new-hork-eimes:focus,
-							.featured-on-module .logo-shareable:hover,
-							.featured-on-module .logo-shareable:focus,
-							.featured-on-module .logo-philanthropy:hover,
-							.featured-on-module .logo-philanthropy:focus,
-							.featured-on-module .logo-clean-technica:hover,
-							.featured-on-module .logo-clean-technica:focus {
-								background-position: center bottom;
-							}
-			.featured-on-module .carousel-control.left,
-			.featured-on-module .carousel-control.right {
-				width: 49px;
-				height: 47px;
-				top: 60px;
-			}
-				.featured-on-module .carousel-control.left {
-					left: -69px;
-				}
-				.featured-on-module .carousel-control.right {
-					right: -69px;
-				}
-					.featured-on-module .carousel-control.left .icons,
-					.featured-on-module .carousel-control.right .icons {
-						width: 24px;
-						height: 24px;
-						margin: 10px auto 0 auto;
-					}
-						.featured-on-module .carousel-control.left .icons {
-							background-position: -288px -16px;
-						}
-							.featured-on-module .carousel-control:hover.left .icons {
-								background-position: -336px -16px;
-							}
-						.featured-on-module .carousel-control.right .icons {
-							background-position: -360px -16px;
-						}
-							.featured-on-module .carousel-control:hover.right .icons {
-								background-position: -384px -16px;
-							}
-
-
-
-	/* .newsletter-module */
-	.newsletter-module {
-		height: 448px;
-	}
-	.newsletter-module .small-img {
-		display: none;
-	}
-	.newsletter-module .mobile-img {
-		display: block;
-	}
-	.newsletter-module .img-area img {
-		width: 100%;
-		height: 449px;
-	}
-	.newsletter-module .img-area .mobile-img {
-		min-height: 449px;
-		background: transparent;
-	}
-		.newsletter-module .title-newsletter {
-			letter-spacing: 5px;
-			padding-left: 12px;
-			width: 346px;
-			height: 43px;
-			line-height: 43px;
-			margin: 47px auto 43px auto;
-		}
-			/* .newsletter-module .container */
-			.newsletter-module .container {
-				left: 0;
-				margin: 0;
-				width: 100%;
-			}
-				.newsletter-module .group-main p {
-					font-size: 20.48px;
-					line-height: 25px;
-					padding: 50px 0 37px 0;
-				}
-				.newsletter-module .group-main .group {
-					min-height: 113px;
-					margin: 0 32px;
-					padding: 30px 30px 30px 72px;
-				}
-					.newsletter-module .group-main .group .btn-sign-up {
-						font-size: 14.34px;
-						letter-spacing: 4px;
-						width: 156px;
-						height: 53px;
-						line-height: 53px;
-                        border: none;
-					}
-					.newsletter-module .group-main .group .inputs {
-						margin-right: 171px;
-						height: 53px;
-					}
-						.newsletter-module .group-main .group .inputs input {
-							font-size: 20.48px;
-						}
-
-
-
-/* .contents */
-.contents {
-	min-height: 185px;
-}
-	.top150 {
-		margin-top: 185px;
-	}
-
-	/* .titles */
-	.titles.container {
-		padding: 52px 0 0 0;
-		min-height: 113px;
-	}
-		.titles.container .title-get-involved {
-			margin-right: 30px;
-			min-width: 291px;
-			letter-spacing: 11px;
-			padding-left: 14px;
-		}
-		.title-h1 {
-			font-size: 49.15px;
-			line-height: 60px;
-		}
-
-
-	/* sign in page */
-	.contents.sign-in-contents {
-		min-height: 900px;
-		margin-top: 185px;
-	}
-	.sign-in {
-		padding: 50px 39px 75px 72px;
-	}
-		.sign-in .title-sign-in {
-			font-size: 21px;
-			height: 43px;
-			line-height: 43px;
-			padding-left: 27px;
-			padding-right: 26px;
-			letter-spacing: 9px;
-		}
-		/* .sign-in .sign-in-left */
-		.sign-in .sign-in-left {
-			float: none;
-			padding-top: 92px;
-		}
-			.sign-in .sign-in-left h2 {
-				font-size: 48px;
-				line-height: 52px;
-				margin-bottom: 11px;
-			}
-			.sign-in .sign-in-left p {
-				font-size: 16px;
-				line-height: 32px;
-			}
-			.sign-in .sign-in-left .account {
-				margin-top: 32px;
-			}
-			.sign-in .sign-in-left a {
-				font-size: 16px;
-				line-height: 32px;
-			}
-			/* .sign-in .login-area */
-			.sign-in .login-area {
-				padding: 40px 31px 0 3px;
-			}
-				.sign-in .login-area .input-wrap {
-					height: 73px;
-					margin-bottom: 15px;
-				}
-					.sign-in .login-area .input-wrap input {
-						font-size: 16px;
-						line-height: 20px;
-						padding-left: 40px;
-						padding-right: 40px;
-						letter-spacing: 8px;
-					}
-				.sign-in .check-wrap {
-					min-height: 62px;
-					padding: 14px 0 26px 0;
-				}
-				.sign-in .login-area .btn-login {
-					padding-left: 20px;
-					padding-right: 17px;
-					height: 47px;
-					line-height: 47px;
-					letter-spacing: 4px;
-					font-size: 14px;
-				}
-
-
-	/* sign up page */
-	.contents.sign-up-contents {
-		margin-top: 185px;
-	}
-	.sign-up {
-		padding: 50px 39px 25px 72px;
-	}
-		.sign-up .title-sign-up {
-			font-size: 21px;
-			height: 43px;
-			line-height: 43px;
-			padding-left: 27px;
-			padding-right: 19px;
-			letter-spacing: 9px;
-		}
-		/* .sign-up .sign-up-left */
-		.sign-up .sign-up-left {
-			float: none;
-			padding-top: 82px;
-		}
-			.sign-up .sign-up-left h2 {
-				font-size: 48px;
-				line-height: 52px;
-				margin-bottom: 11px;
-			}
-			.sign-up .sign-up-left p {
-				font-size: 16px;
-				line-height: 32px;
-			}
-			.sign-up .sign-up-left .account {
-				margin-top: 32px;
-			}
-			.sign-up .sign-up-left a {
-				font-size: 16px;
-				line-height: 32px;
-			}
-			/* .sign-up .reg-area */
-			.sign-up .reg-area {
-				padding: 17px 31px 0 3px;
-			}
-				.sign-up .reg-area .input-wrap {
-					height: 73px;
-					margin-bottom: 15px;
-				}
-				.sign-up .reg-area .input-wrap.less-margin {
-					margin-bottom: 12px;
-				}
-				.sign-up .reg-area .input-wrap.high-margin {
-					margin-bottom: 17px;
-				}
-				.sign-up .reg-area .input-wrap.higher-margin {
-					margin-bottom: 23px;
-				}
-					.sign-up .reg-area .input-wrap input {
-						font-size: 16px;
-						line-height: 20px;
-						padding-left: 40px;
-						padding-right: 40px;
-						letter-spacing: 8px;
-					}
-				.sign-up .reg-area p {
-					font-size: 14px;
-					line-height: 28px;
-					padding-left: 44px;
-					padding-right: 180px;
-					margin-bottom: 21px;
-				}
-				.sign-up .reg-area .btn-signup {
-					padding-left: 31px;
-					padding-right: 26px;
-					height: 47px;
-					line-height: 47px;
-					letter-spacing: 4px;
-				}
-
-
-	/* what do page */
-	.contents.what-we-do-contents {
-		margin-top: 185px;
-	}
-		/* .article-detail */
-		.article-detail,
-		.what-we-do-contents .article-detail {
-			padding: 50px 0 75px 72px;
-		}
-			.article-detail .title-do {
-				padding-left: 34px;
-				padding-right: 22px;
-				font-size: 21px;
-				height: 43px;
-				line-height: 43px;
-				letter-spacing: 10px;
-				margin-right: 39px;
-			}
-			.article-detail .detail-left {
-				padding-right: 0;
-				padding-top: 79px;
-			}
-			.article-detail .detail-left .title-img {
-				width: 625px;
-				height: 312px;
-				margin-bottom: 24px;
-			}
-			.article-detail .detail-left h2 {
-				font-size: 48px;
-				line-height: 56px;
-				padding-right: 0px;
-				padding-bottom: 0;
-			}
-			.article-detail .detail-left p {
-				font-size: 16px;
-				line-height: 32px;
-				margin-left: -3px;
-				margin-top: 21px;
-				margin-bottom: 32px;
-				padding-right: 50px;
-			}
-			.article-detail .detail-left .btn-group {
-				padding-top: 14px;
-			}
-				.article-detail .detail-left .btn-group .btn-blue {
-					font-size: 14px;
-					line-height: 43px;
-					height: 43px;
-					letter-spacing: 4px;
-					margin-right: 35px;
-					margin-bottom: 22px;
-				}
-				.article-detail .detail-left .btn-group .btn-leasing {
-					padding-left: 20px;
-					padding-right: 19px;
-					margin-top: 4px;
-				}
-				.article-detail .detail-left .btn-group .btn-communities {
-					padding-left: 12px;
-					padding-right: 10px;
-					margin-bottom: 27px;
-					margin-right: 0;
-				}
-				.article-detail .detail-left .btn-group .btn-services {
-					padding-left: 39px;
-					padding-right: 36px;
-				}
-
-
-	/* about us page */
-	.contents.about-us-contents {
-		margin-top: 185px;
-	}
-	.about-us {
-		padding: 50px 0 74px 62px;
-	}
-		.about-us .title-about-us {
-    		font-size: 22px;
-			height: 45px;
-			line-height: 45px;
-			padding-left: 24px;
-			padding-right: 19px;
-			margin-right: 30px;
-			letter-spacing: 10px;
-		}
-		.about-us .about-us-left {
-			padding-right: 0;
-			padding-top: 126px;
-		}
-		.about-us .about-us-left h2 {
-			font-size: 43px;
-			line-height: 62px;
-		}
-		.about-us .about-us-left p {
-			font-size: 16px;
-			line-height: 32px;
-			margin-top: 28px;
-			margin-bottom: 51px;
-			padding-right: 270px;
-		}
-		.about-us .about-us-left .btn-works {
-			font-size: 14px;
-			line-height: 55px;
-			height: 55px;
-			letter-spacing: 5px;
-			padding-left: 36px;
-			padding-right: 25px;
-			margin-left: 3px;
-		}
-		/* .mains-tabs */
-		.mains-tabs .container {
-			width: 100%;
-		}
-		.mains-tabs .tab-index .row {
-			padding: 0;
-		}
-		.mains-tabs .tab-index .row .col-lg-3:nth-child(2n+1) {
-			padding-right: 3px;
-		}
-			.mains-tabs .tab-index .row .col-lg-3 a {
-				font-size: 21px;
-				height: 65px;
-				line-height: 65px;
-			}
-		.mains-tabs .tab-content {
-			min-height: 921px;
-		}
-		.mains-tabs .tab-content .tab-why,
-		.mains-tabs .tab-content .tab-how,
-		.mains-tabs .tab-content .tab-funded,
-		.mains-tabs .tab-content .tab-involved {
-			padding-left: 33px;
-			padding-right: 30px;
-		}
-			.mains-tabs .tab-content .img-left {
-				float: none;
-				margin-top: 44px;
-				width: 100%;
-				height: 507px;
-			}
-				.mains-tabs .tab-content .img-left .desktop-img {
-					display: none;
-				}
-				.mains-tabs .tab-content .img-left .small-img {
-					display: block;
-				}
-			.mains-tabs .tab-content .content-right {
-				margin-left: 29px;
-			}
-				.mains-tabs .tab-content .content-right p {
-					font-size: 17px;
-					line-height: 33px;
-				}
-				.mains-tabs .tab-content .tab-why .content-right p {
-					padding-top: 45px;
-					padding-right: 58px;
-				}
-				.mains-tabs .tab-content .tab-how p {
-					font-size: 14px;
-					line-height: 28px;
-				}
-				.mains-tabs .tab-content .tab-how .content-right,
-				.mains-tabs .tab-content .tab-funded .content-right  {
-					padding-top: 47px;
-				}
-					.mains-tabs .tab-content .tab-how .content-right p,
-					.mains-tabs .tab-content .tab-funded .content-right p {
-						margin-bottom: 30px;
-						padding-right: 35px;
-					}
-				.mains-tabs .tab-content .tab-funded .content-right  {
-					padding-top: 40px;
-				}
-					.mains-tabs .tab-content .tab-funded .content-right p {
-						padding-right: 35px;
-						padding-top: 2px;
-						margin-bottom: 30px;
-					}
-				.mains-tabs .tab-content .tab-involved .content-right {
-					padding-top: 54px;
-					margin-left: 0;
-				}
-					.mains-tabs .tab-content .tab-involved .btn-blue {
-						margin-right: 0;
-						margin-bottom: 25px;
-						font-size: 15px;
-						line-height: 46px;
-						width: 313px;
-						height: 46px;
-						letter-spacing: 4px;
-					}
-					.mains-tabs .tab-content .tab-involved .btn-blue:nth-child(2n) {
-						float: right;
-					}
-
-
-	/* get involved page */
-
-		/* .info-area */
-		.info-area.container {
-			padding: 0 30px 35px 60px;
-		}
-			.info-area.container .title-h1 {
-				padding: 32px 220px 18px 0;
-			}
-			.info-area.container .txt {
-				font-size: 16.38px;
-				line-height: 32px;
-				padding-right: 70px;
-				padding-bottom: 17px;
-			}
-
-		/* .list-area */
-		.list-area.container {
-			background: #ededed;
-			width: auto;
-			padding: 0 0 40px 0;
-		}
-			/* .list-area .row */
-			.list-area .row {
-				background: #ededed;
-				margin: 0 auto;
-				width: 750px;
-			}
-				/* .list-area  .lefts */
-				.list-area .row .lefts {
-					float: none;
-					width: 100%;
-				}
-					.list-area .desktop-img {
-						display: none;
-					}
-					.list-area .mobile-img {
-						display: block;
-					}
-					/* .list-area .img-main */
-					.list-area .mobile-show.txt-table {
-						position: absolute;
-						bottom: 45px;
-						left: 0;
-						width: 100%;
-						z-index: 99;
-						display: block;
-						z-index: 299;
-					}
-						.list-area .mobile-show.txt-table .txt {
-							font-family: 'Source Sans Pro'; font-weight: 700;
-							font-size: 43.01px;
-							color: #fff;
-							text-align: center;
-							display: block;
-							height: 50px;
-							line-height: 50px;
-						}
-					.list-area .img-main .funded-round {
-						width: 170px;
-						height: 170px;
-						padding: 5px;
-						bottom: -145px;
-						margin: 0 0 0 -85px;
-					}
-						.get-involved-contents .funded-round .status-indicator {
-							margin: 5px 0 0 0;
-							position: relative;
-							left: -4px;
-						}
-						.get-involved-contents .funded-round .round-depict {
-							font-size: 19.79px;
-							width: 110px;
-							margin: 6px 0 0 -55px;
-						}
-						.get-involved-contents .funded-round .status-indicator input {
-							font-size: 42.4px !important;
-							margin-top: 34px !important;
-						}
-							.get-involved-contents .funded-round .status-indicator input.smaller {
-								font-size: 32.4px !important;
-								-webkit-transition: font-size 0.25s ease;
-								transition: font-size 0.25s ease;
-							}
-					/* .list-area .info-main */
-					.list-area .info-main {
-						padding-top: 5px;
-					}
-						.list-area .info-main .blue-bar,
-						.list-area .info-main .dark-blue-bar {
-							font-size: 19.79px;
-							height: 47px;
-							line-height: 47px;
-							padding: 0 41px;
-							margin-top: 10px;
-							margin-right: 34px;
-							margin-left: 34px;
-						}
-				/* .list-area  .rights */
-				.list-area .row .rights {
-					margin: 0 62px;
-					padding: 65px 0 50px 0;
-					position: relative;
-				}
-					.list-area .row .rights h2,
-					.list-area .row .rights .time {
-						display: none;
-					}
-					.list-area .row .rights .share-txt {
-						font-family: 'Source Sans Pro'; font-weight: 700;
-						font-size: 16.38px;
-						color: #292929;
-						position: absolute;
-						top: 103px;
-						left: 270px;
-						display: block;
-					}
-					.list-area .row .rights p {
-						font-size: 16.38px;
-						line-height: 32px;
-						padding-top: 105px;
-						padding-right: 50px;
-						padding-bottom: 47px;
-					}
-					.list-area .row .rights .bottom-bar {
-						padding-bottom: 85px;
-					}
-						.list-area .row .rights .bottom-bar .btn-read-more {
-							font-size: 14.34px;
-							letter-spacing: 4px;
-							padding-left: 15px;
-							width: 160px;
-							height: 45px;
-							line-height: 45px;
-						}
-						.list-area .row .rights .bottom-bar .social-ul {
-							float: none;
-							position: absolute;
-							top: 65px;
-							left: 0;
-						}
-							.list-area .row .rights .bottom-bar .social-ul li {
-								float: left;
-								margin-left: 0;
-								margin-right: 18px;
-							}
-
-		/* .past-projects-module */
-		.past-projects-module {
-			background-color: #fff;
-			padding-bottom: 0;
-		}
-				.past-projects-module .title-past-projects {
-					letter-spacing: 10px;
-					padding-left: 12px;
-					width: 355px;
-					margin: 38px auto 54px auto;
-				}
-					/* .past-projects-module .carousel-main */
-					.past-projects-module .carousel-main {
-						min-height: 0;
-						margin-right: 92px;
-						margin-left: 92px;
-					}
-						.past-projects-module .carousel.desktop-show {
-							display: none;
-						}
-						.past-projects-module .carousel.mobile-show {
-							display: block;
-						}
-						/* .past-projects-module .carousel .item */
-						.past-projects-module .carousel .item {
-							padding: 0;
-							min-height: 580px;
-						}
-							.past-projects-module .carousel .module-box {
-								float: none;
-								width: 100%;
-							}
-								.past-projects-module .carousel .spacing {
-									padding: 0 19px 0 20px;
-								}
-									/* .past-projects-module .carousel .img-main */
-									.past-projects-module .img-main .img-gradient {
-										height: 60%;
-										top: 40%;
-									}
-									.past-projects-module .img-main .funded-round {
-										width: 170px;
-										height: 170px;
-										padding: 10px;
-										right: 7px;
-										bottom: -178px;
-										z-index: 99;
-									}
-									/* .past-projects-module .carousel .info-main */
-									.past-projects-module .info-main {
-										padding: 28px 0 50px 0;
-									}
-										.past-projects-module .info-main h2 {
-											line-height: 35px;
-										}
-											.past-projects-module .info-main h2 a {
-												font-size: 30.72px;
-											}
-										.past-projects-module .info-main .time {
-											font-size: 18.43px;
-											padding: 13px 0 23px 0;
-										}
-										.past-projects-module .info-main .bottom-bar {
-											padding-right: 35px;
-										}
-											.past-projects-module .info-main .bottom-bar .btn-read-more {
-												font-size: 14.34px;
-												letter-spacing: 4px;
-												padding-left: 12px;
-												width: 157px;
-												height: 44px;
-												line-height: 44px;
-											}
-									.past-projects-module .carousel-control.left,
-									.past-projects-module .carousel-control.right {
-										width: 49px;
-										height: 47px;
-										top: 223px;
-									}
-										.past-projects-module .carousel-control.left {
-											left: -73px;
-										}
-										.past-projects-module .carousel-control.right {
-											right: -73px;
-										}
-											.past-projects-module .carousel-control.left .icons,
-											.past-projects-module .carousel-control.right .icons {
-												width: 24px;
-												height: 24px;
-												margin: 10px auto 0 auto;
-											}
-												.past-projects-module .carousel-control.left .icons {
-													background-position: -288px -16px;
-												}
-													.past-projects-module .carousel-control:hover.left .icons {
-														background-position: -336px -16px;
-													}
-												.past-projects-module .carousel-control.right .icons {
-													background-position: -360px -16px;
-												}
-													.past-projects-module .carousel-control:hover.right .icons {
-														background-position: -384px -16px;
-													}
-
-
-	/* project details page */
-	.details-active-project-module .banners.min-height455 {
-		min-height: 658px;
-	}
-		.desktop-banner {
-			display: none;
-		}
-		.mobile-banner {
-			display: block;
-		}
-		.details-active-project-module .banners img {
-			height: 658px;
-		}
-				/* .details-active-project-module .banner-section */
-				.details-active-project-module .banner-section .container {
-					text-align: center;
-					padding: 51px 0 0 0;
-					min-height: 658px;
-				}
-					.details-active-project-module .banner-section .title-active-project {
-						letter-spacing: 9px;
-						padding-left: 20px;
-						margin: 0 auto;
-						width: 386px;
-						float: none !important;
-					}
-					.details-active-project-module .banner-section .title-h1 {
-						font-size: 43.01px;
-						text-align: center;
-						bottom: 40px;
-						left: 0;
-						width: 100%;
-					}
-					.details-active-project-module .banner-section .funded-round {
-						width: 172px;
-						height: 172px;
-						padding: 8px;
-						margin: 0 0 0 -86px;
-						bottom: -146px;
-					}
-						.details-active-project-module .banner-section .funded-round .round-depict {
-							font-size: 19.79px;
-							text-align: center;
-							width: 170px;
-							margin: 6px 0 0 -85px;
-						}
-						.details-active-project-module .banner-section .funded-round .status-indicator input {
-							font-size: 42.4px !important;
-							margin-top: 40px !important;
-						}
-							.details-active-project-module .banner-section .funded-round .status-indicator input.smaller {
-								font-size: 32.4px !important;
-								-webkit-transition: font-size 0.25s ease;
-								transition: font-size 0.25s ease;
-							}
-				/* .details-active-project-module .info-section */
-				.details-active-project-module .info-section .container {
-					padding: 4px 29px 0 33px;
-				}
-					/* .details-active-project-module .info-main */
-					.details-active-project-module .info-main {
-						padding-bottom: 48px;
-					}
-						.details-active-project-module .info-main .blue-bar,
-						.details-active-project-module .info-main .dark-blue-bar {
-							font-size: 19.79px;
-							height: 47px;
-							line-height: 47px;
-							padding: 0 40px;
-							margin-top: 12px;
-						}
-					/* .details-active-project-module .video-main */
-					.details-active-project-module .video-main {
-						padding: 0 31px 55px 31px;
-						position: relative;
-					}
-						.details-active-project-module .video-area {
-							float: none !important;
-						}
-						.details-active-project-module .video-area .video {
-							background: #000;
-							width: 100%;
-							height: 412px;
-							position: relative;
-						}
-							.details-active-project-module .video-area .video img {
-								width: 100%;
-								height: 412px;
-							}
-							.details-active-project-module .video-area .video iframe {
-								width: 100%;
-								height: 412px;
-								border: none;
-							}
-							.details-active-project-module .video-area .btn-play {
-								width: 130px;
-								height: 130px;
-								margin: -75px 0 0 -75px;
-							}
-								.details-active-project-module .video-area .btn-play .icons {
-									background-position: 0 -88px;
-									width: 96px;
-									height: 96px;
-									margin: 13px 0 0 0;
-								}
-									.details-active-project-module .video-area .btn-play:hover .icons,
-									.details-active-project-module .video-area .btn-play:focus .icons {
-										background-position: -96px -88px;
-									}
-						.details-active-project-module .txt-area {
-							margin: 0;
-							min-height: 0;
-							display: table;
-						}
-							.details-active-project-module .mobile-bottom-bar {
-								display: block;
-								margin: 30px 0 0 0;
-								padding-bottom: 85px;
-							}
-								.details-active-project-module .mobile-bottom-bar .social-ul {
-									float: none;
-								}
-									.details-active-project-module .mobile-bottom-bar .social-ul li {
-										float: left;
-										margin-left: 0;
-										margin-right: 18px;
-									}
-									.details-active-project-module .mobile-bottom-bar .share-txt {
-										font-family: 'Source Sans Pro'; font-weight: 700;
-										font-size: 16.38px;
-										color: #292929;
-										float: left;
-										padding: 40px 0 0 0;
-										margin-left: -10px;
-										display: block;
-									}
-
-							.details-active-project-module .txt-area .txt-td {
-								line-height: 20px;
-							}
-								.details-active-project-module .txt-area .txt-td .font20 {
-									font-size: 20.48px;
-									line-height: 37px;
-									padding: 25px 0 32px 0;
-									color: #292929;
-								}
-								.details-active-project-module .txt-area .txt-td .font14 {
-									font-size: 16.38px;
-									line-height: 32px;
-								}
-
-			/* .project-updates-module */
-			.project-updates-module .container {
-				padding: 57px 31px 20px 31px;
-			}
-				/* .project-updates-module .main-area */
-				.project-updates-module .main-area {
-					text-align: center;
-					float: none;
-					width: 100%;
-					margin: 0;
-				}
-					.project-updates-module .main-area .title-project-updates {
-						width: 385px;
-						letter-spacing: 9px;
-						padding-left: 20px;
-						margin: 0 auto 37px auto;
-						float: none !important;
-					}
-					 /* .project-updates-module .list-area */
-					 .project-updates-module .list-area .row {
-						 background: none;
-						 text-align: left;
-						 width: auto;
-						 padding: 40px 0 0 0;
-						 border-bottom: 5px solid #dcdcdc;
-					 }
-						.project-updates-module .list-area .left-date {
-							 width: 222px;
-						}
-							 .project-updates-module .list-area .left-date .date-txt,
-							 .project-updates-module .list-area .left-date .month-txt {
-								 padding: 0 50px 0 40px;
-							 }
-								 .project-updates-module .list-area .left-date .date-txt {
-									 font-size: 126.03px;
-									 line-height: 110px;
-									 margin-top: -8px;
-								 }
-								 .project-updates-module .list-area .left-date .month-txt {
-									 font-size: 24.58px;
-									 letter-spacing: 22px;
-								 }
-						.project-updates-module .list-area .main-info {
-							 margin-left: 222px;
-							 position: relative;
-						}
-							.project-updates-module .list-area .main-info .title-h4 {
-								 line-height: 30px;
-								 padding-bottom: 10px;
-							}
-								 .project-updates-module .list-area .main-info .title-h4 a {
-									 font-size: 18.43px;
-								 }
-							.project-updates-module .list-area .main-info p {
-								 font-size: 16.38px;
-								 line-height: 32px;
-								 padding-bottom: 47px;
-							}
-							.project-updates-module .list-area .main-info .social-ul {
-								 margin-bottom: 34px;
-								 position: absolute;
-								 top: 140px;
-								 left: -210px;
-							 }
-								 .project-updates-module .list-area .main-info .social-ul li {
-									 float: left;
-									 margin-right: 14px;
-								 }
-									.project-updates-module .list-area .main-info .btn-icon-gray {
-										text-align: center;
-										background: rgba(40,40,40,0.15);
-										width: 53px;
-										height: 43px;
-										border: 2px solid #fff;
-										display: inline-block;
-									}
-										.project-updates-module .list-area .main-info .btn-icon-gray .icons {
-											background-size: 672px auto;
-											width: 24px;
-											height: 24px;
-											margin-top: 7px;
-										}
-											.project-updates-module .list-area .main-info .btn-icon-gray .icon-fb {
-												background-position: -144px -16px;
-											}
-												.project-updates-module .list-area .main-info .btn-icon-gray:hover .icon-fb {
-													background-position: -168px -16px;
-												}
-											.project-updates-module .list-area .main-info .btn-icon-gray .icon-tw {
-												background-position: -192px -16px;
-											}
-												.project-updates-module .list-area .main-info .btn-icon-gray:hover .icon-tw {
-													background-position: -216px -16px;
-												}
-											.project-updates-module .list-area .main-info .btn-icon-gray .icon-gg {
-												background-position: -240px -16px;
-											}
-												.project-updates-module .list-area .main-info .btn-icon-gray:hover .icon-gg {
-													background-position: -264px -16px;
-												}
-
-				/* .project-updates-module .right-aside */
-				.project-updates-module .right-aside {
-					width: 100%;
-					float: none;
-					position: static;
-					top: 0;
-					right: 0;
-					margin-top: 39px;
-				}
-					.project-updates-module .right-aside .module-box {
-						min-height: 226px;
-						padding: 12px 0 32px 0;
-						margin: 0 32px 32px 32px;
-						position: relative;
-					}
-						.project-updates-module .right-aside .module-box .type-txt {
-							font-size: 20.48px;
-							line-height: 30px;
-							padding: 11px 0 13px 0;
-							width: 295px;
-						}
-						.project-updates-module .right-aside .module-box .value-txt {
-							font-size: 73.73px;
-							line-height: 70px;
-							padding: 0 0 20px 0;
-							width: 295px;
-						}
-						.project-updates-module .right-aside .module-box .title-h5 {
-							font-size: 16.38px;
-							text-align: left;
-							border-top: none;
-							border-bottom: 2px solid #c3c3c3;
-							width: 45%;
-							margin: 0;
-							height: 33px;
-							line-height: 33px;
-							position: absolute;
-							top: 18px;
-							right: 45px;
-						}
-						.project-updates-module .right-aside .module-box ul {
-							padding: 34px 0 25px 0;
-							width: 45%;
-							position: absolute;
-							top: 35px;
-							right: 45px;
-						}
-							.project-updates-module .right-aside .module-box .mobile-ul li {
-								float: left;
-								width: 50%;
-							}
-							.project-updates-module .right-aside .module-box li {
-								text-align: left;
-								font-size: 14.34px;
-								line-height: 32px;
-							}
-						.project-updates-module .right-aside .btn-i-want-to-donate {
-							letter-spacing: 5px;
-							padding-left: 12px;
-							width: 223px;
-							height: 45px;
-							line-height: 45px;
-							position: absolute;
-							bottom: 24px;
-							left: 33px;
-						}
-					 /* .project-updates-module .venue-area */
-					 .project-updates-module .venue-area {
-						 display: none;
-					 }
-
-			/* .donors-module */
-			.donors-module .titles.container {
-				text-align: center;
-				padding: 0;
-				min-height: 99px;
-			}
-				.titles.container .title-donors {
-					margin: 0 auto;
-					min-width: 192px;
-					width: 192px;
-					letter-spacing: 9px;
-					padding-left: 12px;
-					float: none !important;
-				}
-			.donors-module .mains-tabs {
-				background: #f4f4f4;
-			}
-			.donors-module .mains-tabs .tab-index .container {
-				padding: 0;
-			}
-			.donors-module .mains-tabs .tab-index .row {
-				margin-top: -2px;
-			}
-			.donors-module .mains-tabs .tab-content {
-				min-height: 708px;
-			}
-			.donors-module .tab-content .row {
-				margin: 4px 19px 40px 19px;
-			}
-				.donors-module .tab-content .row .col-md-6 {
-					padding: 46px 0 0 0;
-				}
-					.donors-module .desktop-img {
-						display: none;
-					}
-					.donors-module .mobile-img {
-						display: block;
-					}
-					.donors-module .tab-content .head-img {
-						width: 156px;
-					}
-						.donors-module .tab-content .head-img img {
-							width: 127px;
-							height: 127px;
-						}
-					.donors-module .info-box {
-						margin-left: 156px;
-					}
-					.donors-module .info-box .title-h4 {
-						padding: 10px 0 9px 0;
-					}
-						.donors-module .info-box .title-h4 a {
-							font-size: 18.43px;
-						}
-					.donors-module .info-box p {
-						font-size: 16.38px;
-						line-height: 35px;
-						padding: 0 45px 0 0;
-					}
-
-
-	/* partners page */
-	.partners-contents .container {
-		padding: 50px 0 11px 42px;
-	}
-	.partners-contents .title-partners {
-		font-size: 21px;
-		height: 43px;
-		line-height: 43px;
-		padding-left: 36px;
-		padding-right: 18px;
-		margin-right: 39px;
-		margin-bottom: 40px;
-		letter-spacing: 8px;
-	}
-		.partners-contents .titles .title-primary {
-			font-size: 48px;
-			line-height: 52px;
-			margin-bottom: 10px;
-			padding-left: 32px;
-		}
-		.partners-contents .titles .title-sub {
-			font-size: 16px;
-			line-height: 32px;
-			padding-left: 34px;
-		}
-		/* .partners-contents .list */
-		.partners-contents .list-wrap {
-			margin-top: 33px;
-		}
-			.partners-contents .list-wrap .item-wrap {
-				height: auto;
-				margin-bottom: 30px;
-			}
-			.partners-contents .list-wrap .item-wrap.large-spacing {
-				margin-bottom: 47px;
-			}
-			.partners-contents .left-img {
-				width: 200px;
-				height: 200px;
-				margin-top: 0;
-				margin-left: 3px;
-			}
-			.partners-contents .content-info {
-				margin-left: 217px;
-				height: auto;
-				overflow: auto;
-				min-height: 234px;
-			}
-				.partners-contents .content-info h4 {
-					font-size: 30px;
-					line-height: 36px;
-					margin-bottom: 8px;
-					padding-top: 36px;
-				}
-				.partners-contents .content-info h4 a {
-    					font-size: 30px;
-				}
-				.partners-contents .content-info p {
-					font-size: 16px;
-					line-height: 32px;
-					padding-right: 41px;
-					padding-left: 2px;
-				}
-			.partners-contents .btn-wrap {
-				position: absolute;
-				top: 205px;
-				left: -188px;
-			}
-				.partners-contents .btn-wrap .btn-blue {
-					height: 43px;
-					line-height: 43px;
-					padding-left: 48px;
-					padding-right: 44px;
-				}
-			/* .partners-contents .pager-info */
-			.partners-contents .pager-info {
-				margin-top: 23px;
-				margin-right: 43px;
-				float: right;
-			}
-				.partners-contents .pager-info li {
-					float: left;
-					margin-right: 16px;
-				}
-					.partners-contents .pager-info li a {
-						padding: 0 17px;
-						font-size: 16px;
-						line-height: 39px;
-						height: 39px;
-					}
-
-		/* .sponsoring-organizations-module */
-		.sponsoring-organizations-module {
-			min-height: 450px;
-		}
-		.sponsoring-organizations-module .container {
-			padding: 50px 25px 0 25px;
-		}
-			.sponsoring-organizations-module .title-sponsoring-organizations {
-				font-size: 18px;
-				width: 494px;
-				letter-spacing: 9px;
-				padding-left: 15px;
-				margin-bottom: 69px;
-			}
-			#sponsoring-organizations-example-generic {
-				display: none;
-			}
-			#mobile-sponsoring-organizations-example-generic {
-				display: block;
-			}
-					/* .sponsoring-organizations-module .carousel-main */
-					.sponsoring-organizations-module .logo-ul li {
-						text-align: center;
-						vertical-align: middle;
-						width: 50%;
-						height: 200px;
-						display: table-cell;
-					}
-						.sponsoring-organizations-module .logo {
-							margin-right: auto;
-							margin-left: auto;
-							display: block;
-							overflow: hidden;
-						}
-							.sponsoring-organizations-module .logo-the-san-francisco {
-								background: url(../images/logo-the-san-francisco.png) no-repeat;
-								width: 166px;
-								height: 165px;
-							}
-							.sponsoring-organizations-module .logo-toyota-togethergreen {
-								background: url(../images/logo-toyota-togethergreen.png) no-repeat;
-								width: 193px;
-								height: 63px;
-							}
-							.sponsoring-organizations-module .logo-sun-shot {
-								background: url(../images/logo-sun-shot.png) no-repeat;
-								width: 134px;
-								height: 41px;
-							}
-							.sponsoring-organizations-module .logo-patagonia {
-								background: url(../images/logo-patagonia.png) no-repeat;
-								width: 172px;
-								height: 54px;
-							}
-				.sponsoring-organizations-module .carousel-control.left,
-				.sponsoring-organizations-module .carousel-control.right {
-					background-color: rgba(41,41,41,0.15);
-					text-shadow: none;
-					background-image: none;
-					box-shadow: none;
-					opacity: 1;
-					width: 49px;
-					height: 47px;
-					border: 2px solid #fff;
-					top: 90px;
-				}
-					.sponsoring-organizations-module .carousel-control.left {
-						text-align: center;
-						left: -76px;
-					}
-					.sponsoring-organizations-module .carousel-control.right {
-						text-align: center;
-						right: -76px;
-					}
-						.sponsoring-organizations-module .carousel-control.left .icons,
-						.sponsoring-organizations-module .carousel-control.right .icons {
-							width: 24px;
-							height: 24px;
-							top: 0;
-							right: auto;
-							left: auto;
-							position: static;
-							margin: 10px auto 0 auto;
-						}
-							.sponsoring-organizations-module .carousel-control.left .icons {
-								background-position: -288px -16px;
-							}
-								.sponsoring-organizations-module .carousel-control:hover.left .icons {
-									background-position: -336px -16px;
-								}
-							.sponsoring-organizations-module .carousel-control.right .icons {
-								background-position: -360px -16px;
-							}
-								.sponsoring-organizations-module .carousel-control:hover.right .icons {
-									background-position: -384px -16px;
-								}
-
-
-
-
-	/* solar ambassador program page */
-	.solar-contents .article-detail {
-		padding: 50px 39px 49px 72px;
-	}
-	.solar-contents .article-detail .title-solar {
-		width: auto;
-		font-size: 21px;
-		height: 43px;
-		line-height: 43px;
-		padding-left: 27px;
-		padding-top: 0;
-		padding-right: 18px;
-	}
-		.solar-contents .article-detail .detail-left {
-			padding-right: 0;
-			padding-top: 85px;
-		}
-		.solar-contents .article-detail .detail-left p {
-			margin-top: 10px;
-			padding-left: 5px;
-		}
-		.solar-contents .article-detail .detail-left .title-img {
-			margin-bottom: 22px;
-		}
-		.solar-contents .article-detail .detail-left .btn-group {
-			padding-top: 0;
-			padding-right: 0;
-			margin-top: -10px;
-		}
-		.solar-contents .article-detail .detail-left .btn-group .btn-blue {
-			margin-bottom: 14px;
-		}
-			.solar-contents .article-detail .detail-left .btn-group .btn-application {
-				padding-left: 24px;
-				padding-right: 17px;
-				margin-top: 4px;
-				margin-right: 35px;
-			}
-			.solar-contents .article-detail .detail-left .btn-group .btn-team {
-				padding-left: 21px;
-				padding-right: 19px;
-				margin-bottom: 22px;
-				margin-right: 0;
-			}
-			.solar-contents .article-detail .detail-left .btn-group .btn-project {
-				padding-left: 33px;
-				padding-right: 36px;
-				margin-right: 0;
-			}
-
-
-
-
-	/* blog page */
-	.titles.container .title-blog {
-		margin-right: 40px;
-		min-width: 140px;
-		letter-spacing: 9px;
-		padding-left: 14px;
-		margin-top: -2px;
-	}
-
-	/* .grid-data */
-	.grid-data.container {
-		padding: 0;
-	}
-		/* .form-area */
-		.form-area {
-			padding: 0 0 11px 39px;
-			min-height: 50px;
-		}
-				.form-area .width167 .btn-default,
-				.form-area .width167.input-search {
-					width: 230px;
-				}
-				/* .input-search */
-				.input-search {
-					padding: 0 28px 0 23px;
-					height: 50px;
-					line-height: 50px;
-				}
-					.input-search input {
-						font-size: 16.67px;
-						letter-spacing: 6px;
-						height: 50px;
-						line-height: 20px;
-					}
-					.input-search .icon-search {
-						background-position: -528px -88px;
-						width: 24px;
-						height: 24px;
-						top: 11px;
-						right: 13px;
-					}
-						.input-search .icon-search:hover {
-							background-position: -552px -88px;
-					}
-			/* .grid-area.row */
-			.grid-area.row {
-				min-height: 100px;
-			}
-				.grid-area.row .col-md-6 {
-					padding-right: 0;
-					padding-left: 0;
-				}
-				.grid-area.row .img-main {
-					height: 388px;
-				}
-					.grid-area.row .video {
-						width: 100%;
-						height: 388px;
-					}
-					.grid-area.row .video iframe {
-						width: 100%;
-						height: 388px;
-					}
-						.grid-area.row .btn-play {
-							border: 4px solid #fff;
-							top: 50%;
-							left: 50%;
-							width: 106px;
-							height: 106px;
-							margin: -53px 0 0 -53px;
-						}
-							.grid-area.row .btn-play .icons {
-								background-size: 543px auto;
-								background-position: 0 -71px;
-								width: 78px;
-								height: 78px;
-								margin: 10px 0 0 0;
-							}
-								.grid-area.row .btn-play:hover,
-								.grid-area.row .btn-play:focus {
-									border: 4px solid #1cb0e6;
-								}
-								.grid-area.row .btn-play:hover .icons,
-								.grid-area.row .btn-play:focus .icons {
-									background-position: -78px -71px;
-								}
-					.grid-area.row .img-main img {
-						height: 388px;
-					}
-						.grid-area.row .carousel-control.left,
-						.grid-area.row .carousel-control.right {
-							background-color: rgba(255,255,255,0.5);
-							text-shadow: none;
-							background-image: none;
-							box-shadow: none;
-							opacity: 1;
-							width: 49px;
-							height: 47px;
-							border: 2px solid #fff;
-							top: 50%;
-							bottom: auto;
-							margin-top: -24px;
-						}
-							.grid-area.row .carousel-control.left {
-								left: 24px;
-								right: auto;
-							}
-							.grid-area.row .carousel-control.right {
-								right: 24px;
-							}
-								.grid-area.row .carousel-control.left .icons,
-								.grid-area.row .carousel-control.right .icons {
-									width: 24px;
-									height: 24px;
-									margin-top: 9px;
-								}
-									.grid-area.row .carousel-control.left .icons {
-										background-position: -288px -16px;
-									}
-										.grid-area.row .carousel-control:hover.left .icons {
-											background-position: -336px -16px;
-										}
-									.grid-area.row .carousel-control.right .icons {
-										background-position: -360px -16px;
-									}
-										.grid-area.row .carousel-control:hover.right .icons {
-											background-position: -385px -16px;
-										}
-				.grid-area.row .info-main {
-					padding: 60px 45px 40px 45px;
-				}
-					.grid-area.row .info-main .title-h2 {
-						font-size: 42px;
-						line-height: 45px;
-					}
-					.grid-area.row .info-main .title-h2 a {
-						font-size: 42px;
-					}
-					.grid-area.row .info-main .date-txt {
-						font-size: 18px;
-						line-height: 32px;
-						padding-top: 7px;
-						letter-spacing: 1px;
-						padding-bottom: 14px;
-					}
-					.grid-area.row .info-main p {
-						font-size: 16px;
-						line-height: 32px;
-						padding: 8px 25px 19px 0;
-					}
-					.grid-area.row .info-main .bottom-bar {
-						padding: 24px 5px 57px 5px;
-					}
-						.grid-area.row .info-main .bottom-bar .btn-read-more {
-							font-size: 14px;
-							letter-spacing: 4px;
-							width: 152px;
-							height: 65px;
-							padding: 0 0 0 2px;
-							line-height: 65px;
-						}
-						.grid-area.row .info-main .bottom-bar .social-ul {
-							margin: 3px 0 0 0;
-						}
-							.grid-area.row .info-main .bottom-bar .social-ul li {
-								margin: 0 8px 0 9px;
-							}
-							.grid-area.row .info-main .bottom-bar .btn-icon-gray {
-								width: 79px;
-								height: 65px;
-							}
-							.grid-area.row .info-main .bottom-bar .btn-icon-gray .icons {
-								margin-top: 7px;
-							}
-
-
-		/* .loading-bar */
-		.loading-bar {
-			padding: 0 0 45px 0;
-			margin-top: -68px;
-		}
-			.loading-bar .loading-img {
-				background: url(../images/loading.gif) no-repeat;
-				width: 128px;
-				height: 22px;
-				display: block;
-				margin: 0 auto;
-			}
-			/* .blog-details-data */
-			.blog-details-data.container {
-				padding: 0;
-				min-height: 300px;
-			}
-				/* .blog-details-data .title-bar */
-				.blog-details-data.container .title-bar {
-					padding: 10px 70px 17px 70px;
-				}
-					.blog-details-data.container .title-bar .title-h1 {
-						font-size: 48px;
-						line-height: 60px;
-					}
-					.blog-details-data.container .title-bar .date-txt {
-						font-size: 18px;
-						line-height: 32px;
-					}
-						.blog-details-data.container .title-bar .social-ul {
-							min-height: 60px;
-							position: static;
-							top: auto;
-							right: auto;
-							padding: 15px 0 0 0;
-							margin-bottom: 23px;
-						}
-							.blog-details-data.container .title-bar .social-ul li {
-								margin-right: 20px;
-								margin-left: 0;
-							}
-							.blog-details-data.container .title-bar .social-ul li .btn-icon-gray {
-								width: 78px;
-								height: 64px;
-							}
-								.blog-details-data.container .title-bar .social-ul li .btn-icon-gray .icons {
-									margin-top: 7px;
-								}
-				/* .blog-details-data .info-box */
-				.blog-details-data.container .info-box .img-main,
-				.blog-details-data.container .info-box .img-main img {
-					height: 388px;
-				}
-					.blog-details-data.container .info-box .info-main {
-						padding: 37px 0 62px 0;
-						margin: 0 70px;
-					}
-					.blog-details-data.container .info-box .info-main .lefts,
-					.blog-details-data.container .info-box .info-main .rights {
-						width: auto;
-						float: none;
-					}
-					.blog-details-data.container .info-box .info-main .lefts p {
-						padding-right: 0;
-					}
-					.blog-details-data.container .info-box .info-main .rights p {
-						padding-left: 0;
-					}
-						.blog-details-data.container .info-box .info-main .font20 {
-							font-size: 20px;
-							line-height: 36px;
-						}
-						.blog-details-data.container .info-box .info-main .font14 {
-							font-size: 16px;
-							line-height: 32px;
-						}
-						.blog-details-data.container .info-box .info-main .lefts .font14,
-						.blog-details-data.container .info-box .down25 {
-							padding-bottom: 34px;
-						}
-						.blog-details-data.container .info-box .info-main .rights .down25 {
-							padding-bottom: 0;
-						}
-
-			/* .related-blog-module */
-			.related-blog-module {
-				padding: 26px 0 7px 0;
-			}
-				.related-blog-module .form-area {
-					min-height: 83px;
-					margin-top: 96px;
-				}
-				.related-blog-module .title-related-blog {
-					font-size: 21px;
-					width: 320px;
-					top: 2px;
-					right: 39px;
-				}
-				.related-blog-module .desktop-show {
-					display: none;
-				}
-				.related-blog-module .mobile-show {
-					display: block;
-				}
-				#mobile-related-example-generic {
-					margin: 0 72px;
-				}
-					#mobile-related-example-generic .grid-area.row .info-main {
-						padding: 23px 185px 23px 0;
-						position: relative;
-					}
-						#mobile-related-example-generic .grid-area.row .info-main .title-h2 {
-							font-size: 48px;
-						}
-					#mobile-related-example-generic .grid-area.row .info-main p,
-					#mobile-related-example-generic .grid-area.row .info-main .bottom-bar .social-ul {
-						display: none;
-					}
-					#mobile-related-example-generic .grid-area.row .info-main .bottom-bar {
-						padding: 0;
-						overflow: visible;
-					}
-						#mobile-related-example-generic .grid-area.row .info-main .bottom-bar .btn-read-more {
-							position: absolute;
-							top: 34px;
-							right: 0;
-							width: 158px;
-							height: 55px;
-							line-height: 55px;
-							z-index: 99;
-						}
-				.related-blog-module .carousel-control.left,
-				.related-blog-module .carousel-control.right {
-					width: 49px;
-					height: 47px;
-					top: 180px;
-					margin-top: 0;
-				}
-					.related-blog-module .carousel-control.left {
-						left: -55px;
-					}
-					.related-blog-module .carousel-control.right {
-						right: -55px;
-					}
-						.related-blog-module .carousel-control.left .icons,
-						.related-blog-module .carousel-control.right .icons {
-							width: 24px;
-							height: 24px;
-							margin-top: 9px;
-						}
-							.related-blog-module .carousel-control.left .icons {
-								background-position: -288px -16px;
-							}
-								.related-blog-module .carousel-control:hover.left .icons {
-									background-position: -336px -16px;
-								}
-							.related-blog-module .carousel-control.right .icons {
-								background-position: -360px -16px;
-							}
-								.related-blog-module .carousel-control:hover.right .icons {
-									background-position: -384px -16px;
-								}
-					.related-blog-module .carousel-inner>.active {
-						min-height: 590px;
-					}
-
-			/* .comments-module */
-			.comments-module .container {
-				padding: 37px 38px 0 38px;
-			}
-				.comments-module .container .title-comments {
-					width: 221px;
-					letter-spacing: 10px;
-					padding-left: 12px;
-					margin-bottom: 6px;
-				}
-				/* .comments-module .comments-area  .comments-list*/
-				.comments-module .comments-area {
-					min-height: 200px;
-					padding-top: 20px;
-				}
-					.comments-module .comments-area .comments-list {
-						padding: 63px 0 34px 0;
-					}
-					.comments-module .comments-area .spaceleft {
-						padding-left: 0;
-					}
-					.comments-module .comments-area .spacetop {
-						padding-top: 26px;
-					}
-						.comments-module .comments-area .comments-list .head-img {
-							float: left;
-							width: 125px;
-						}
-							.comments-module .comments-area .comments-list .head-img img {
-								width: 99px;
-								height: 99px;
-								margin-left: 5px;
-							}
-						.comments-module .comments-area .comments-list .info-box {
-							margin-left: 130px;
-						}
-							.comments-module .comments-area .comments-list .info-box .title-h4 {
-								padding: 3px 0 6px 0;
-							}
-								.comments-module .comments-area .comments-list .info-box .title-h4 a {
-								    font-size: 20px;
-								}
-							.comments-module .comments-area .comments-list .info-box p {
-								    font-size: 16px;
-								    line-height: 32px;
-								    padding: 0 28px 30px 0;
-							}
-						.comments-module .comments-area .comments-list .comments-apply {
-							width: 156px;
-							height: 42px;
-							line-height: 42px;
-							letter-spacing: 6px;
-						}
-							.comments-module .comments-area .comments-list .comments-apply a {
-								font-size: 14px;
-								padding-left: 5px;
-
-							}
-				/* .comments-module .comments-area .quick-reply */
-				.comments-module .comments-area .quick-reply {
-					padding: 32px 0 33px 0;
-				}
-					.comments-module .btn-icon-gray {
-						width: 54px;
-						height: 44px;
-					}
-						.comments-module .btn-icon-gray .icons {
-							width: 24px;
-							height: 24px;
-							margin-top: 9px;
-						}
-							.comments-module .btn-icon-gray .icon-fb {
-								background-position: -144px -16px;
-							}
-								.comments-module .btn-icon-gray:hover .icon-fb {
-									background-position: -168px -16px;
-								}
-							.comments-module .btn-icon-gray .icon-tw {
-								background-position: -192px -16px;
-							}
-								.comments-module .btn-icon-gray:hover .icon-tw {
-									background-position: -216px -16px;
-								}
-							.comments-module .btn-icon-gray .icon-gg {
-								background-position: -240px -16px;
-							}
-								.comments-module .btn-icon-gray:hover .icon-gg {
-									background-position: -264px -16px;
-								}
-					.comments-module .comments-area .quick-reply .quick-reply-txt {
-						width: 135px;
-					}
-						.comments-module .comments-area .quick-reply .quick-reply-txt .title-h4 {
-							padding: 18px 0 22px 0;
-						    font-size: 20px;
-						}
-						.comments-module .comments-area .quick-reply .quick-reply-txt p {
-							font-size: 16px;
-						}
-							.comments-module .comments-area .quick-reply .quick-reply-txt li {
-								margin-top: 11px;
-								margin-left: -1px;
-							}
-							.comments-module .comments-area .quick-reply .quick-reply-txt li:nth-child(2) {
-								margin-left: 13px;
-							}
-					.comments-module .comments-area .quick-reply .textarea-box {
-						margin-right: 4px;
-						margin-left: 135px;
-						height: 252px;
-						padding: 21px 29px;
-					}
-						.comments-module .comments-area .quick-reply .textarea-box textarea {
-							font-size: 16px;
-							height: 170px;
-							line-height: 14px;
-							letter-spacing: 6px;
-						}
-					.comments-module .comments-area .quick-reply .comments-post {
-						width: 137px;
-						height: 43px;
-						line-height: 43px;
-						right: 6px;
-						bottom: 35px;
-						letter-spacing: 4px;
-					}
-						.comments-module .comments-area .quick-reply .comments-post a {
-							font-size: 14px;
-							padding: 2px 0 0 3px;
-						}
-
-
-
-/* .footer */
-.footer .row {
-	padding: 0 23px 0 65px;
-}
-	.footer .row .col-info {
-		float: left;
-		padding: 45px 0 18px 0;
-	}
-		.footer .row .col-menu dt,
-		.footer .row .col-info dt {
-			line-height: 25px;
-			padding: 20px 0;
-		}
-			.footer .row .col-menu dt a,
-			.footer .row .col-info dt a {
-				font-size: 21.5px;
-			}
-		.footer .row .col-menu dd,
-		.footer .row .col-info dd {
-			line-height: 29px;
-		}
-	/* .footer .col-menu */
-	.footer .row .col-menu {
-		width: 100%;
-		float: none;
-		padding: 45px 0 10px 0;
-	}
-		.footer .row .col-menu dt {
-			padding-bottom: 0;
-		}
-	/* .footer .col-info */
-	.footer .row .col-info {
-		width: 33.3333333%;
-	}
-	.footer .row .col-info:nth-child(2) {
-		width: 34%;
-	}
-	.footer .row .col-info:nth-child(3) {
-		width: 38%;
-	}
-	.footer .row .col-info:nth-child(4) {
-		width: 28%;
-	}
-	.footer .row .col-info:nth-child(5) {
-		width: 100%;
-		padding: 0 0 32px 0;
-	}
-	.footer .row .col-info:nth-child(5) dt a {
-		font-size: 16.38px;
-		color: #6f6f6f;
-	}
-		.footer .row .col-info dt {
-			padding-bottom: 7px;
-		}
-			.footer .row .col-info a {
-				font-size: 16.38px;
-			}
-			.footer .row .col-info p {
-				font-size: 14.34px;
-				line-height: 24px;
-				padding: 0;
-			}
-	/* .footer .bottoms */
-	.footer .bottoms {
-		margin: 0;
-		min-height: 225px;
-	}
-		.footer .bottoms .lefts,
-		.footer .bottoms .rights {
-			float: none !important;
-		}
-		.footer .bottoms .logo {
-			background-size: 171px auto;
-			margin: 38px auto 0 auto;
-			width: 171px;
-			height: 68px;
-		}
-		.footer .bottoms .social-ul {
-			margin: 48px auto 0 auto;
-			width: 170px;
-			height: 24px;
-		}
-			.footer .bottoms .social-ul li {
-				float: left;
-				margin: 0 14px;
-			}
-				.footer .bottoms .social-ul li .icons {
-					background-size: 672px auto;
-					width: 24px;
-					height: 24px;
-				}
-					.footer .bottoms .social-ul li .icon-fb {
-						background-position: 0 -16px;
-					}
-						.footer .bottoms .social-ul li .icon-fb:hover {
-							background-position: -24px -16px;
-						}
-					.footer .bottoms .social-ul li .icon-tw {
-						background-position: -48px -16px;
-					}
-						.footer .bottoms .social-ul li .icon-tw:hover {
-							background-position: -72px -16px;
-						}
-					.footer .bottoms .social-ul li .icon-gg {
-						background-position: -96px -16px;
-					}
-						.footer .bottoms .social-ul li .icon-gg:hover {
-							background-position: -120px -16px;
-						}
-
-
-
-/* .modal-default */
-.modal.modal-default .modal-dialog {
-	width: 706px;
-	margin: 209px auto;
-}
-	/* .modal-default .modal-header */
-	.modal.modal-default .btn-close {
-		background-position: -480px -88px;
-		width: 48px;
-		height: 48px;
-		top: 37px;
-		right: 24px;
-	}
-		.modal.modal-default .btn-close:hover {
-			background-position: -480px -136px;
-		}
-	/* .modal-default .modal-body */
-	.modal.modal-default .modal-body {
-		padding: 0;
-		min-height: 100px;
-	}
-
-	/* #modal-how-it-works */
-	#modal-how-it-works .title-how-it-works {
-		width: 283px;
-		letter-spacing: 9px;
-		padding-left: 12px;
-		margin: 38px auto 0 auto;
-	}
-		#modal-how-it-works .txt-info {
-			font-size: 16.38px;
-			line-height: 33px;
-			padding: 540px 68px 35px 68px;
-		}
-		/* #modal-how-it-works .info-row */
-		#modal-how-it-works .info-row {
-			padding: 25px 30px 7px 30px;
-			position: absolute;
-			top: 20px;
-			left: 0;
-		}
-			#modal-how-it-works .info-row .video-area .video,
-			#modal-how-it-works .info-row .video-area .video img {
-				width: 640px;
-				height: 458px;
-			}
-			#modal-how-it-works .info-row .video-area .video iframe {
-				width: 640px;
-				height: 458px;
-				border: none;
-			}
-				#modal-how-it-works .info-row .video-area .btn-play {
-					text-align: center;
-					border: 5px solid #fff;
-					border-radius: 100%;
-					position: absolute;
-					top: 50%;
-					left: 50%;
-					width: 130px;
-					height: 130px;
-					margin: -75px 0 0 -75px;
-				}
-					#modal-how-it-works .info-row .video-area .btn-play .icons {
-						background-position: 0 -88px;
-						width: 96px;
-						height: 96px;
-						margin: 13px 0 0 0;
-					}
-						#modal-how-it-works .info-row .video-area .btn-play:hover,
-						#modal-how-it-works .info-row .video-area .btn-play:focus {
-							border: 5px solid #1cb0e6;
-						}
-						#modal-how-it-works .info-row .video-area .btn-play:hover .icons,
-						#modal-how-it-works .info-row .video-area .btn-play:focus .icons {
-							background-position: -96px -88px;
-						}
-			#modal-how-it-works .info-row .step-area {
-				display: none;
-			}
-}
-
-
-
 
 /*fix layout issue when smaller than 768px width*/
+
 @media (max-width: 767px) {
-body {
-	min-width: 374px;
+  body {
+    min-width: 374px;
+  }
+  .icons {
+    background: url(../images/mobile/mobile-icon-sprites.png) no-repeat;
+    background-size: 336px auto;
+  }
+  /* btn */
+  .btn-blue {
+    font-size: 7px;
+    height: 26.5px;
+    line-height: 26.5px;
+    padding: 0 3px;
+  }
+  .btn-icon-gray {
+    border: 1px solid #fff;
+    width: 32px;
+    height: 31px;
+  }
+  .btn-icon-gray .icons {
+    width: 24px;
+    height: 24px;
+    margin-top: 2.5px;
+  }
+  .btn-icon-gray .icon-fb {
+    background-position: -144px -20px;
+  }
+  .btn-icon-gray:hover .icon-fb {
+    background-position: -168px -20px;
+  }
+  .btn-icon-gray .icon-tw {
+    background-position: -192px -20px;
+  }
+  .btn-icon-gray:hover .icon-tw {
+    background-position: -216px -20px;
+  }
+  .btn-icon-gray .icon-gg {
+    background-position: -240px -20px;
+  }
+  .btn-icon-gray:hover .icon-gg {
+    background-position: -264px -20px;
+  }
+  .title-blue-border {
+    border: 1px solid #14b1e7;
+  }
+  .title-white-border {
+    border: 1px solid #fff;
+  }
+  /* .dropdown-default */
+  .dropdown-default .btn-default {
+    font-size: 8.335px;
+    letter-spacing: 3.5px;
+    padding: 0 16px 0 20px;
+    height: 25px;
+    line-height: 23px;
+  }
+  .dropdown-default .btn-default .icon-arrow-down {
+    background-position: -48px 0;
+    top: 7px;
+    right: 8.5px;
+    width: 8px;
+    height: 8px;
+  }
+  .dropdown-default .btn-default.active .icon-arrow-down, .dropdown-default .btn-default:active .icon-arrow-down, .open.dropdown-default>.dropdown-toggle.btn-default .icon-arrow-down {
+    background-position: -56.5px 0;
+  }
+  .dropdown-default .dropdown-menu {
+    font-size: 8.23px;
+    min-width: 30px;
+    padding: 2.5px 0;
+  }
+  .dropdown-default .dropdown-menu>li>a {
+    padding: 0 12.5px;
+    line-height: 13px;
+  }
+  /* title */
+  .title-white-border, .title-blue-border {
+    font-size: 10.5px;
+    letter-spacing: 3.5px;
+    height: 21.5px;
+    line-height: 21.5px;
+    padding: 0 2.5px;
+  }
+  .container {
+    width: auto;
+  }
+  /* .header */
+  .header {
+    margin-top: 5px;
+    height: 92.5px;
+  }
+  .header .logo {
+    background-repeat: no-repeat;
+    background-size: 129px auto;
+    margin: 18.5px 0 0 16px;
+    width: 129px;
+    height: 51px;
+  }
+  .header .btn-donate {
+    min-width: 66px;
+  }
+  .header .rights {
+    padding: 33px 24px 0 0;
+  }
+  .header .txt {
+    font-size: 8px;
+    padding: 0 10px 3px 0;
+    line-height: 13px;
+  }
+  /* .after-scroll-header */
+  .header.after-scroll-header {
+    border-bottom: 1px solid #c6c6c6;
+  }
+  .header.after-scroll-header .logo {
+    background: url(../images/mobile/mobile-logo.png) no-repeat;
+    background-size: 129px auto;
+    width: 129px;
+    height: 51px;
+    margin: 18.5px 0 0 16px;
+  }
+  .header.after-scroll-header .rights {
+    padding: 33px 24px 0 0;
+  }
+  /* .top-section */
+  .top-section {
+    min-height: 92.5px;
+  }
+  .top-section .sub-section-bg {
+    background-size: 100% 92.5px;
+  }
+  .top-section.min-height {
+    min-height: 667px;
+  }
+  .top-section .section-video-area iframe, .top-section .section-video-area video, .top-section .section-video-area .mejs-container, .top-section .section-video-area .me-plugin, .top-section .section-video-area embed, .top-section .section-video-area .mejs-overlay-play {
+    height: 667px!important;
+  }
+  .top-section .section-video img {
+    width: 100%;
+    height: 667px;
+  }
+  .top-section .section-video-area iframe, .top-section .section-video-area video, .top-section .section-video-area .mejs-container, .top-section .section-video-area .me-plugin, .top-section .section-video-area embed, .top-section .section-video-area .mejs-overlay-play {
+    width: 100%!important;
+    height: 667px!important;
+    border: none;
+  }
+  /* .top-section .carousel */
+  .top-section .carousel {
+    top: 75px;
+    padding-right: 20px;
+    padding-left: 20px;
+  }
+  /* .top-section .carousel .item */
+  .top-section .carousel .item {
+    padding: 75px 0 0 0;
+    min-height: 507px;
+  }
+  .top-section .carousel .item-info {
+    width: 290px;
+  }
+  .top-section .carousel .item-info .titles {
+    font-size: 24px;
+    line-height: 29px;
+  }
+  .top-section .carousel .item-info p {
+    font-size: 10px;
+    line-height: 18px;
+    width: 240px;
+    padding: 11px 0 22px 0;
+  }
+  .top-section .carousel .item-info .btn-donate-now {
+    letter-spacing: 2px;
+    min-width: 125px;
+    padding-left: 7.5px;
+  }
+  /* .top-section .carousel-indicators */
+  .top-section .carousel-indicators {
+    bottom: 15px;
+  }
+  .top-section .carousel-indicators li {
+    width: 10px;
+    height: 10px;
+    margin: 0 3px 0 2.5px;
+  }
+  .top-section .icon-arrow-down {
+    background-position: -120px -20px;
+    width: 24px;
+    height: 24px;
+    bottom: -23px;
+    margin: 0 0 0 -12px;
+  }
+  .top-section .carousel-control.left, .top-section .carousel-control.right {
+    border: 1px solid #fff;
+    width: 33px;
+    height: 32px;
+    bottom: 21px;
+  }
+  .top-section .carousel-control.left {
+    left: 16px;
+  }
+  .top-section .carousel-control.right {
+    right: 16px;
+  }
+  .top-section .carousel-control.left .icons, .top-section .carousel-control.right .icons {
+    width: 12px;
+    height: 12px;
+    margin-top: 9px;
+  }
+  .top-section .carousel-control.left .icons {
+    background-position: -240px -8px;
+  }
+  .top-section .carousel-control:hover.left .icons {
+    background-position: -252px -8px;
+  }
+  .top-section .carousel-control.right .icons {
+    background-position: -288px -8px;
+  }
+  .top-section .carousel-control:hover.right .icons {
+    background-position: -276px -8px;
+  }
+  /* home page */
+  /* .active-projects-module */
+  .active-projects-module {
+    padding-bottom: 18px;
+  }
+  .active-projects-module .title-active-projects {
+    letter-spacing: 5px;
+    width: 185px;
+    padding-left: 6px;
+    margin: 25px auto;
+  }
+  .active-projects-module .row {
+    margin: 0 32px;
+  }
+  /* .active-projects-module .module-box */
+  .active-projects-module .module-box {
+    margin: 0 0 26px 0;
+  }
+  /* .active-projects-module .img-main */
+  .active-projects-module .img-main .txt-table {
+    height: 312px;
+  }
+  .active-projects-module .img-main .txt {
+    font-size: 21px;
+    line-height: 31px;
+    padding: 0 65px 23px 65px;
+  }
+  .active-projects-module .img-main .img-link img {
+    height: 312px;
+  }
+  .active-projects-module .img-main .funded-round {
+    width: 120px;
+    height: 125px;
+    padding: 10px;
+    bottom: -50px;
+    margin: 0 0 0 -60px;
+  }
+  .active-projects-module .img-main .funded-round .round-depict {
+    text-align: center;
+    font-size: 15px;
+    width: 125px;
+    margin: 6px 0 0 -60px;
+  }
+  .active-projects-module .img-main .funded-round .status-indicator input {
+    font-size: 36px !important;
+    margin-top: 3px !important;
+    width: 80px !important;
+    height: 80px !important;
+    margin-left: -92px!important;
+  }
+  .active-projects-module .img-main .funded-round .status-indicator input.smaller {
+    font-size: 32px !important;
+    margin-top: 3px !important;
+    -webkit-transition: font-size 0.25s ease;
+    transition: font-size 0.25s ease;
+  }
+  .active-projects-module.embedded .img-main .funded-round .status-indicator input {
+    margin-top: -102.5px !important;
+    margin-left: 8px !important;
+  }
+  .active-projects-module.embedded .img-main .funded-round .status-indicator input.smaller {
+    margin-top: -102.5px !important;
+    margin-left: 10px !important;
+    font-size: 30px !important;
+  }
+  .mobile-circle {
+    display: block;
+  }
+  .desktop-circle, .small-circle, .tablet-circle {
+    display: none;
+  }
+  /* .active-projects-module .info-main */
+  .active-projects-module .info-main {
+    padding: 38px 29px 27px 30px;
+  }
+  .active-projects-module .info-main .blue-bar, .active-projects-module .info-main .dark-blue-bar {
+    font-size: 15px;
+    height: 46px;
+    line-height: 46px;
+    padding: 0 24px 0 24px;
+    margin-top: 12px;
+  }
+  /* .our-impacts-module */
+  .our-impacts-module .title-our-impacts {
+    letter-spacing: 5px;
+    padding-left: 15px;
+    width: 156px;
+    margin: 21px auto 14px auto;
+  }
+  .our-impacts-module .row {
+    margin: 0 9px 0 8px;
+    padding: 0 0 1px 0;
+  }
+  .our-impacts-module .module-box {
+    margin-bottom: 24px;
+  }
+  .our-impacts-module .row .col-md-3:nth-child(3) .module-box .titles {
+    letter-spacing: -0.9px;
+    padding-top: 10px;
+    line-height: 20px;
+  }
+  .our-impacts-module .row .col-md-3:nth-child(4) .module-box .titles {
+    padding-top: 2px;
+    line-height: 25px;
+  }
+  .our-impacts-module .module-box .icons {
+    width: 84px;
+    height: 80px;
+  }
+  .our-impacts-module .module-box .icon-people {
+    background-position: 0 -92px;
+  }
+  .our-impacts-module .module-box .icon-home-ok {
+    background-position: -78px -92px;
+  }
+  .our-impacts-module .module-box .icon-tree {
+    background-position: -177px -85px;
+    width: 78px;
+  }
+  .our-impacts-module .module-box .icon-user {
+    background-position: -252px -89px;
+  }
+  .our-impacts-module .module-box .titles {
+    line-height: 33px;
+  }
+  .our-impacts-module .module-box .font20 {
+    font-size: 9px;
+  }
+  .our-impacts-module .module-box .font48 {
+    font-size: 24px;
+  }
+  .our-impacts-module .module-box .font72 {
+    font-size: 36px;
+  }
+  .our-impacts-module .module-box .txt {
+    font-size: 9px;
+    line-height: 11px;
+    padding-right: 10%;
+    padding-left: 10%;
+  }
+  .our-impacts-module .module-box .txt .position {
+    min-width: 4px;
+  }
+  .our-impacts-module .module-box .txt .position .font10 {
+    font-size: 5px;
+    top: -5px;
+    left: 1.5px;
+  }
+  /* .how-it-works-module */
+  .how-it-works-module .title-how-it-works {
+    letter-spacing: 5px;
+    padding-left: 8px;
+    width: 156px;
+    margin: 26px auto 0 auto;
+  }
+  /* .how-it-works-module .info-row */
+  .how-it-works-module .info-row {
+    padding: 23px 15px 0 16px;
+  }
+  .how-it-works-module .info-row .video-area .video, .how-it-works-module .info-row .video-area .video img, .how-it-works-module .info-row .video-area .video iframe {
+    height: 262px;
+  }
+  .how-it-works-module .info-row .video-area .btn-play {
+    width: 66px;
+    height: 66px;
+    margin: -33px 0 0 -33px;
+  }
+  .how-it-works-module .info-row .video-area .btn-play .icons {
+    background-position: 0 -44px;
+    width: 48px;
+    height: 48px;
+    margin: 7px 0 0 0;
+  }
+  .how-it-works-module .info-row .video-area .btn-play:hover .icons, .how-it-works-module .info-row .video-area .btn-play:focus .icons {
+    background-position: -48px -44px;
+  }
+  .how-it-works-module .info-row .txt-area {
+    margin: 15px;
+  }
+  .how-it-works-module .info-row .txt-area .txt-td {
+    line-height: 10px;
+  }
+  .how-it-works-module .info-row .txt-area .txt-td p {
+    font-size: 8px;
+    line-height: 16px;
+  }
+  /* .how-it-works-module .step-row */
+  .how-it-works-module .step-row {
+    margin: 38px 16px 0 16px;
+    min-height: 155px;
+  }
+  .how-it-works-module .carousel {
+    min-height: 132px;
+    margin-right: 42px;
+    margin-left: 42px;
+  }
+  .how-it-works-module .row .carousel-control.left, .how-it-works-module .row .carousel-control.right {
+    width: 34px;
+    height: 32px;
+    border: 1px solid #fff;
+    top: 22px;
+  }
+  .how-it-works-module .row .carousel-control.left {
+    left: -42px;
+  }
+  .how-it-works-module .row .carousel-control.right {
+    right: -42px;
+  }
+  .how-it-works-module .row .carousel-control.left .icons, .how-it-works-module .row .carousel-control.right .icons {
+    width: 12px;
+    height: 12px;
+    margin: 8px auto 0 auto;
+  }
+  .how-it-works-module .row .carousel-control.left .icons {
+    background-position: -228px -8px;
+  }
+  .how-it-works-module .row .carousel-control:hover.left .icons {
+    background-position: -252px -8px;
+  }
+  .how-it-works-module .row .carousel-control.right .icons {
+    background-position: -264px -8px;
+  }
+  .how-it-works-module .row .carousel-control:hover.right .icons {
+    background-position: -276px -8px;
+  }
+  .how-it-works-module .carousel-indicators li {
+    width: 9px;
+    height: 9px;
+    margin: 0 2.5px;
+  }
+  .how-it-works-module .carousel-indicators .active {
+    width: 9px;
+    height: 9px;
+  }
+  .how-it-works-module .step-row .module-box {
+    padding: 5px 16px 0 16px;
+    min-height: 85px;
+  }
+  .how-it-works-module .step-row .icon-blue-round {
+    width: 66px;
+    height: 66px;
+  }
+  .how-it-works-module .step-row .icon-blue-round .icons {
+    width: 48px;
+    height: 48px;
+    margin-top: 7px;
+  }
+  .how-it-works-module .step-row .icon-fundraise .icons {
+    background-position: -96px -44px;
+  }
+  .how-it-works-module .step-row .icon-invest .icons {
+    background-position: -144px -44px;
+  }
+  .how-it-works-module .step-row .icon-pay-it-forward .icons {
+    background-position: -192px -44px;
+  }
+  .how-it-works-module .step-row .info-txt {
+    margin: 0 0 0 80px;
+  }
+  .how-it-works-module .step-row .info-txt h4 {
+    font-size: 12px;
+    line-height: 15px;
+    padding-bottom: 1px;
+    margin-top: 12px;
+  }
+  .how-it-works-module .step-row .info-txt p {
+    font-size: 8px;
+    line-height: 16px;
+    letter-spacing: -0.3px;
+  }
+  /* .how-it-works-module */
+  .testimonial-module {
+    padding-bottom: 30px;
+  }
+  .testimonial-module .title-testimonial {
+    letter-spacing: 4px;
+    padding-left: 5px;
+    width: 126px;
+    margin: 24px auto 0 auto;
+  }
+  /* .testimonial-module .head-row */
+  .testimonial-module .head-row {
+    padding: 18px 9px 0 9px;
+  }
+  .testimonial-module .head-row li .head-img {
+    margin: 7px;
+  }
+  .testimonial-module .head-row li .head-img.active {
+    border-radius: 5px;
+    margin: 3.5px;
+    padding: 2.5px;
+  }
+  .testimonial-module .head-row li .head-img img {
+    border-radius: 5px;
+  }
+  /* .testimonial-module .info-area */
+  .testimonial-module .info-area {
+    padding: 17px 30px 0 30px;
+  }
+  .testimonial-module .info-area p {
+    font-size: 8px;
+    line-height: 16px;
+    letter-spacing: -0.1px;
+    width: 320px;
+    padding-bottom: 7px;
+  }
+  .testimonial-module .user-group {
+    padding-top: 7px;
+  }
+  .testimonial-module .user-group .link-blue {
+    font-size: 12px;
+  }
+  .testimonial-module .user-group .txt {
+    font-size: 8px;
+    padding: 0 0 12px 0;
+  }
+  .testimonial-module .user-group .btn-blue {
+    font-size: 7px;
+    height: 20px;
+    line-height: 20px;
+    padding-top: 1px;
+    min-width: 146px;
+    letter-spacing: 2px;
+  }
+  /* .featured-on-module */
+  .featured-on-module {
+    padding-bottom: 20px;
+  }
+  .featured-on-module .title-featured-on {
+    font-size: 10px;
+    letter-spacing: 5px;
+    padding-left: 10px;
+    width: 150px;
+    margin: 21px auto 21px auto;
+  }
+  /* .featured-on-module .carousel-main */
+  .featured-on-module .carousel-main {
+    min-height: 88px;
+  }
+  /* .featured-on-module .carousel-main */
+  .featured-on-module .carousel-main {
+    min-height: 88px;
+    margin-right: 32px;
+    margin-left: 32px;
+  }
+  .featured-on-module .carousel-main .logo-ul li {
+    height: 85px;
+  }
+  .featured-on-module .logo-fast-mpany {
+    background-size: 77px auto;
+    width: 77px;
+    height: 11.5px;
+  }
+  .featured-on-module .logo-ehe-new-hork-eimes {
+    background-size: 68.5px auto;
+    width: 68.5px;
+    height: 56.5px;
+  }
+  .featured-on-module .logo-shareable {
+    background-size: 72px auto;
+    width: 72px;
+    height: 10.5px;
+  }
+  .featured-on-module .logo-philanthropy {
+    background-size: 76.5px auto;
+    width: 76.5px;
+    height: 14px;
+  }
+  .featured-on-module .logo-clean-technica {
+    background-size: 76.5px auto;
+    width: 76.5px;
+    height: 22px;
+  }
+  .featured-on-module .carousel-control.left, .featured-on-module .carousel-control.right {
+    border: 1px solid #fff;
+    width: 24px;
+    height: 24px;
+    top: 30px;
+  }
+  .featured-on-module .carousel-control.left {
+    left: -34px;
+  }
+  .featured-on-module .carousel-control.right {
+    right: -34px;
+  }
+  .featured-on-module .carousel-control.left .icons, .featured-on-module .carousel-control.right .icons {
+    width: 12px;
+    height: 12px;
+    margin: 0 auto 3px 0;
+  }
+  .featured-on-module .carousel-control.left .icons {
+    background-position: -144px -8px;
+  }
+  .featured-on-module .carousel-control:hover.left .icons {
+    background-position: -168px -8px;
+  }
+  .featured-on-module .carousel-control.right .icons {
+    background-position: -180px -8px;
+  }
+  .featured-on-module .carousel-control:hover.right .icons {
+    background-position: -192px -8px;
+  }
+  /* .newsletter-module */
+  .newsletter-module {
+    height: 224px;
+  }
+  .newsletter-module .img-area img {
+    height: 225px;
+  }
+  .newsletter-module .img-area .mobile-img {
+    min-height: 225px;
+  }
+  .newsletter-module .title-newsletter {
+    letter-spacing: 2.5px;
+    padding-left: 6px;
+    width: 173px;
+    height: 22px;
+    line-height: 22px;
+    margin: 24px auto;
+  }
+  /* .newsletter-module .container */
+  .newsletter-module .group-main p {
+    font-size: 10px;
+    line-height: 12px;
+    padding: 25px 0 19px 0;
+  }
+  .newsletter-module .group-main .group {
+    min-height: 56px;
+    margin: 0 16px;
+    padding: 15px 15px 15px 36px;
+  }
+  .newsletter-module .group-main .group .btn-sign-up {
+    font-size: 7px;
+    letter-spacing: 2px;
+    width: 78px;
+    height: 26px;
+    line-height: 26px;
+    border: none;
+  }
+  .newsletter-module .group-main .group .inputs {
+    margin-right: 85px;
+    height: 26px;
+  }
+  .newsletter-module .group-main .group .inputs input {
+    font-size: 10px;
+    height: 26px;
+    line-height: 26px;
+  }
+  /* .contents */
+  .contents {
+    min-height: 92px;
+  }
+  .top150 {
+    margin-top: 92px;
+  }
+  /* .titles */
+  .titles.container {
+    padding: 26px 0 0 0;
+    min-height: 56.5px;
+  }
+  .titles.container .title-get-involved {
+    margin-right: 15px;
+    min-width: 145px;
+    letter-spacing: 5px;
+    padding-left: 7px;
+  }
+  .title-h1 {
+    font-size: 24px;
+    line-height: 30px;
+  }
+  /* sign in page */
+  .contents.sign-in-contents {
+    min-height: 450px;
+    margin-top: 91px;
+  }
+  .sign-in {
+    padding: 26px 15px 38px 31px;
+  }
+  .sign-in .title-blue-border {
+    border-width: 1px;
+  }
+  .sign-in .title-sign-in {
+    font-size: 11px;
+    height: 22px;
+    line-height: 22px;
+    padding-left: 13px;
+    padding-right: 10px;
+    letter-spacing: 5px;
+  }
+  /* .sign-in .sign-in-left */
+  .sign-in .sign-in-left {
+    float: none;
+    padding-top: 46px;
+  }
+  .sign-in .sign-in-left h2 {
+    font-size: 24px;
+    line-height: 26px;
+    margin-bottom: 7px;
+  }
+  .sign-in .sign-in-left p {
+    font-size: 8px;
+    line-height: 16px;
+    padding-left: 0;
+  }
+  .sign-in .sign-in-left .account {
+    margin-top: 16px;
+  }
+  .sign-in .sign-in-left .account p {
+    line-height: 10px;
+  }
+  .sign-in .sign-in-left .account a {
+    font-size: 8px;
+    line-height: 10px;
+    padding-left: 0;
+  }
+  /* .sign-in .login-area */
+  .sign-in .login-area {
+    padding: 20px 15px 0 0;
+  }
+  .sign-in .login-area .input-wrap {
+    height: 37px;
+    margin-bottom: 7px;
+  }
+  .sign-in .login-area .input-wrap input {
+    font-size: 8px;
+    line-height: 10px;
+    padding-left: 20px;
+    padding-right: 20px;
+    letter-spacing: 5px;
+  }
+  .sign-in .check-wrap {
+    min-height: 35px;
+    padding: 2px 0 14px 0;
+  }
+  .sign-in .login-area .btn-login {
+    padding-left: 11px;
+    padding-right: 5px;
+    height: 23px;
+    line-height: 23px;
+    letter-spacing: 2px;
+    font-size: 7px;
+  }
+  /* sign up page */
+  .contents.sign-up-contents {
+    margin-top: 91px;
+    min-height: 289px;
+  }
+  .sign-up {
+    padding: 26px 15px 12px 28px;
+  }
+  .sign-up .title-blue-border {
+    border-width: 1px;
+  }
+  .sign-up .title-sign-up {
+    font-size: 11px;
+    height: 22px;
+    line-height: 22px;
+    padding-left: 13px;
+    padding-right: 6px;
+    letter-spacing: 5px;
+  }
+  /* .sign-up .sign-up-left */
+  .sign-up .sign-up-left {
+    float: none;
+    padding-top: 41px;
+    padding-left: 2px;
+  }
+  .sign-up .sign-up-left h2 {
+    font-size: 24px;
+    line-height: 26px;
+    margin-bottom: 6px;
+  }
+  .sign-up .sign-up-left p {
+    font-size: 8px;
+    line-height: 16px;
+    padding-left: 0;
+  }
+  .sign-up .sign-up-left .account {
+    margin-top: 16px;
+  }
+  .sign-up .sign-up-left a {
+    font-size: 8px;
+    line-height: 16px;
+  }
+  /* .sign-up .reg-area */
+  .sign-up .reg-area {
+    padding: 14px 15px 0 3px;
+  }
+  .sign-up .reg-area .input-wrap {
+    height: 37px;
+    margin-bottom: 7px;
+  }
+  .sign-up .reg-area .input-wrap.less-margin {
+    margin-bottom: 6px;
+  }
+  .sign-up .reg-area .input-wrap.high-margin {
+    margin-bottom: 7px;
+  }
+  .sign-up .reg-area .input-wrap.higher-margin {
+    margin-bottom: 12px;
+  }
+  .sign-up .reg-area .input-wrap input {
+    font-size: 8px;
+    line-height: 10px;
+    padding-left: 20px;
+    padding-right: 20px;
+    letter-spacing: 5px;
+  }
+  .sign-up .check-wrap {
+    min-height: 15px;
+    padding: 1px 0 0 0;
+  }
+  .sign-up .reg-area p {
+    font-size: 7px;
+    line-height: 14px;
+    padding-left: 22px;
+    padding-right: 90px;
+    margin-bottom: 11px;
+  }
+  .sign-up .reg-area .btn-signup {
+    padding-left: 15px;
+    padding-right: 13px;
+    height: 24px;
+    line-height: 24px;
+    letter-spacing: 2px;
+  }
+  /* what do page */
+  .contents.what-we-do-contents {
+    min-height: 500px;
+    margin-top: 91px;
+  }
+  /* .article-detail */
+  .article-detail, .what-we-do-contents .article-detail {
+    padding: 26px 15px 26px 32px;
+  }
+  .article-detail .title-blue-border {
+    border-width: 1px;
+  }
+  .article-detail .title-do {
+    padding-left: 18px;
+    padding-right: 15px;
+    font-size: 11px;
+    height: 22px;
+    line-height: 22px;
+    letter-spacing: 4px;
+    margin-right: 0px;
+  }
+  .article-detail .detail-left {
+    padding-top: 40px;
+  }
+  .article-detail .detail-left .title-img {
+    width: 100%;
+    height: 156px;
+    margin-bottom: 12px;
+  }
+  .article-detail .detail-left h2 {
+    font-size: 24px;
+    line-height: 28px;
+  }
+  .article-detail .detail-left p {
+    font-size: 8px;
+    line-height: 16px;
+    margin-left: -3px;
+    margin-top: 11px;
+    margin-bottom: 16px;
+    padding-right: 31px;
+  }
+  .article-detail .detail-left .btn-group {
+    padding-top: 7px;
+    padding-right: 0;
+  }
+  .article-detail .detail-left .btn-group .btn-blue {
+    font-size: 7px;
+    line-height: 22px;
+    height: 22px;
+    letter-spacing: 2px;
+    margin-right: 8px;
+    margin-bottom: 11px;
+  }
+  .article-detail .detail-left .btn-group .btn-leasing {
+    padding-left: 9px;
+    padding-right: 9px;
+    margin-right: 18px;
+    margin-top: 2px;
+  }
+  .article-detail .detail-left .btn-group .btn-communities {
+    padding-left: 7px;
+    padding-right: 9px;
+    margin-bottom: 14px;
+    margin-right: 0;
+  }
+  .article-detail .detail-left .btn-group .btn-services {
+    padding-left: 19px;
+    padding-right: 17px;
+    clear: both;
+  }
+  /* about us page */
+  .contents.about-us-contents {
+    margin-top: 91px;
+  }
+  .about-us {
+    padding: 26px 0 36px 30px;
+  }
+  .about-us .title-blue-border {
+    border-width: 1px;
+  }
+  .about-us .title-about-us {
+    font-size: 11px;
+    height: 22px;
+    line-height: 22px;
+    padding-left: 13px;
+    padding-right: 15px;
+    margin-right: 15px;
+    letter-spacing: 4px;
+  }
+  .about-us .about-us-left {
+    padding-right: 10px;
+    padding-top: 61px;
+  }
+  .about-us .about-us-left h2 {
+    font-size: 21px;
+    line-height: 31px;
+  }
+  .about-us .about-us-left p {
+    font-size: 8px;
+    line-height: 16px;
+    margin-top: 12px;
+    margin-bottom: 24px;
+    padding-right: 135px;
+  }
+  .about-us .about-us-left .btn-works {
+    font-size: 7px;
+    line-height: 27px;
+    height: 27px;
+    letter-spacing: 2px;
+    padding-left: 18px;
+    padding-right: 17px;
+    margin-left: 2px;
+  }
+  /* .mains-tabs */
+  .mains-tabs .container {
+    width: 100%;
+  }
+  .mains-tabs .tab-index .row {
+    padding: 0;
+  }
+  .mains-tabs .tab-index .row .col-lg-3 {
+    width: 50%;
+    float: left;
+  }
+  .mains-tabs .tab-index .row .col-lg-3:nth-child(2n+1) {
+    padding-right: 2px;
+  }
+  .mains-tabs .tab-index .row .col-lg-3 a {
+    font-size: 11px;
+    height: 30px;
+    line-height: 30px;
+    border-width: 2px;
+  }
+  .mains-tabs .tab-index .row .col-lg-3 a:hover {
+    border-width: 2px;
+  }
+  .mains-tabs .tab-index .row .col-lg-3 a.active {
+    border-width: 2px;
+  }
+  .mains-tabs .tab-content {
+    min-height: 450px;
+  }
+  .mains-tabs .tab-content .tab-why, .mains-tabs .tab-content .tab-how, .mains-tabs .tab-content .tab-funded, .mains-tabs .tab-content .tab-involved {
+    padding-left: 16px;
+    padding-right: 15px;
+  }
+  .mains-tabs .tab-content .img-left {
+    float: none;
+    margin-top: 23px;
+    width: 100%;
+    height: 248px;
+  }
+  .mains-tabs .tab-content .content-right {
+    margin-left: 14px;
+  }
+  .mains-tabs .tab-content .content-right p {
+    font-size: 8px;
+    line-height: 17px;
+  }
+  .mains-tabs .tab-content .tab-why .content-right p {
+    padding-top: 21px;
+    padding-right: 28px;
+  }
+  .mains-tabs .tab-content .tab-how p {
+    font-size: 7px;
+    line-height: 14px;
+  }
+  .mains-tabs .tab-content .tab-how .content-right, .mains-tabs .tab-content .tab-funded .content-right {
+    padding-top: 22px;
+  }
+  .mains-tabs .tab-content .tab-how .content-right p, .mains-tabs .tab-content .tab-funded .content-right p {
+    margin-bottom: 14px;
+    padding-right: 16px;
+  }
+  .mains-tabs .tab-content .tab-funded .content-right {
+    padding-top: 18px;
+  }
+  .mains-tabs .tab-content .tab-funded .content-right p {
+    padding-right: 19px;
+    padding-top: 2px;
+    margin-bottom: 10px;
+  }
+  .mains-tabs .tab-content .tab-involved .content-right {
+    padding-top: 26px;
+    margin-left: 0;
+  }
+  .mains-tabs .tab-content .tab-involved .btn-blue {
+    margin-right: 0;
+    margin-bottom: 13px;
+    font-size: 7px;
+    line-height: 22px;
+    width: 153px;
+    height: 22px;
+    letter-spacing: 3px;
+  }
+  .mains-tabs .tab-content .tab-involved .btn-blue:nth-child(2n) {
+    float: right;
+  }
+  /* get involved page */
+  /* .info-area */
+  .info-area.container {
+    padding: 0 15px 18px 30px;
+  }
+  .info-area.container .title-h1 {
+    padding: 16px 110px 9px 0;
+  }
+  .info-area.container .txt {
+    font-size: 8px;
+    line-height: 16px;
+    padding-right: 35px;
+    padding-bottom: 8px;
+  }
+  /* .list-area */
+  .list-area.container {
+    padding: 0 0 20px 0;
+  }
+  /* .list-area .row */
+  .list-area .row {
+    width: 375px;
+  }
+  /* .list-area .img-main */
+  .list-area .mobile-show.txt-table {
+    bottom: 23px;
+  }
+  .list-area .mobile-show.txt-table .txt {
+    font-size: 21px;
+    height: 25px;
+    line-height: 25px;
+  }
+  .list-area .img-main .funded-round {
+    width: 85px;
+    height: 85px;
+    padding: 3px;
+    bottom: -72px;
+    margin: 0 0 0 -42px;
+  }
+  .get-involved-contents .funded-round .status-indicator {
+    margin: 2px 0 0 0;
+    left: -2px;
+  }
+  .get-involved-contents .funded-round .round-depict {
+    font-size: 9px;
+    width: 55px;
+    margin: 3px 0 0 -27px;
+  }
+  .get-involved-contents .funded-round .status-indicator input {
+    font-size: 21px !important;
+    margin-top: 17px !important;
+  }
+  .get-involved-contents .past-projects-module .funded-round .round-depict {
+    margin: 6px 0 0 -27px;
+  }
+  .get-involved-contents .past-projects-module .funded-round .status-indicator input {
+    font-size: 21px !important;
+    margin-top: -65px !important;
+    margin-left: -25px !important;
+  }
+  .get-involved-contents .past-projects-module .funded-round .status-indicator input.smaller {}
+  /* .list-area .info-main */
+  .list-area .info-main {
+    padding-top: 2px;
+  }
+  .list-area .info-main .blue-bar, .list-area .info-main .dark-blue-bar {
+    font-size: 9px;
+    height: 23px;
+    line-height: 23px;
+    padding: 0 20px;
+    margin-top: 5px;
+    margin-right: 17px;
+    margin-left: 17px;
+  }
+  /* .list-area  .rights */
+  .list-area .row .rights {
+    margin: 0 31px;
+    padding: 46px 0 20px 0;
+  }
+  .list-area .row .rights .btn-icon-gray {
+    width: 35px;
+    height: 30px;
+  }
+  .list-area .row .rights .share-txt {
+    font-size: 8px;
+    top: 51px;
+    left: 128px;
+  }
+  .list-area .row .rights p {
+    font-size: 8px;
+    line-height: 16px;
+    padding-top: 37px;
+    padding-right: 12px;
+    padding-bottom: 22px;
+  }
+  .list-area .row .rights .bottom-bar {
+    padding-bottom: 24px;
+  }
+  .list-area .row .rights .bottom-bar .btn-read-more {
+    font-size: 7px;
+    letter-spacing: 2px;
+    padding-left: 7px;
+    width: 78px;
+    height: 22px;
+    line-height: 22px;
+  }
+  .list-area .row .rights .bottom-bar .social-ul {
+    top: 29px;
+  }
+  .list-area .row .rights .bottom-bar .social-ul li {
+    margin-right: 9px;
+  }
+  /* .past-projects-module */
+  .past-projects-module .title-past-projects {
+    letter-spacing: 5px;
+    padding-left: 6px;
+    width: 174px;
+    margin: 19px auto 27px auto;
+  }
+  /* .past-projects-module .carousel-main */
+  .past-projects-module .carousel-main {
+    margin-right: 40px;
+    margin-left: 40px;
+  }
+  /* .past-projects-module .carousel .item */
+  .past-projects-module .carousel .item {
+    min-height: 290px;
+  }
+  .past-projects-module .carousel .spacing {
+    padding: 0 9px 0 10px;
+  }
+  /* .past-projects-module .carousel .img-main */
+  .past-projects-module .img-main .img-gradient {
+    height: 60%;
+    top: 40%;
+  }
+  .past-projects-module .img-main .funded-round {
+    width: 85px;
+    height: 85px;
+    padding: 5px;
+    right: 3px;
+    bottom: -89px;
+  }
+  /* .past-projects-module .carousel .info-main */
+  .past-projects-module .info-main {
+    padding: 14px 0 25px 0;
+  }
+  .past-projects-module .info-main h2 {
+    line-height: 17px;
+  }
+  .past-projects-module .info-main h2 a {
+    font-size: 15px;
+  }
+  .past-projects-module .info-main .time {
+    font-size: 9px;
+    padding: 6px 0 11px 0;
+  }
+  .past-projects-module .info-main .bottom-bar {
+    padding-right: 17px;
+  }
+  .past-projects-module .info-main .bottom-bar .btn-read-more {
+    font-size: 7px;
+    letter-spacing: 2px;
+    padding-left: 6px;
+    width: 78px;
+    height: 22px;
+    line-height: 22px;
+  }
+  .past-projects-module .img-main .img-link img {
+    height: 185px;
+  }
+  .past-projects-module .carousel-control.left, .past-projects-module .carousel-control.right {
+    width: 25px;
+    height: 24px;
+    top: 108px;
+  }
+  .past-projects-module .carousel-control.left {
+    left: -36px;
+  }
+  .past-projects-module .carousel-control.right {
+    right: -36px;
+  }
+  .past-projects-module .carousel-control.left .icons, .past-projects-module .carousel-control.right .icons {
+    width: 12px;
+    height: 12px;
+    margin: 0 auto 4px auto;
+  }
+  .past-projects-module .carousel-control.left .icons {
+    background-position: -144px -8px;
+  }
+  .past-projects-module .carousel-control:hover.left .icons {
+    background-position: -168px -8px;
+  }
+  .past-projects-module .carousel-control.right .icons {
+    background-position: -180px -8px;
+  }
+  .past-projects-module .carousel-control:hover.right .icons {
+    background-position: -192px -8px;
+  }
+  /* project details page */
+  .details-active-project-module .banners.min-height455 {
+    min-height: 320px;
+  }
+  .details-active-project-module .banners img {
+    height: 320px;
+  }
+  /* .details-active-project-module .banner-section */
+  .details-active-project-module .banner-section .container {
+    padding: 25px 0 0 0;
+    min-height: 320px;
+  }
+  .details-active-project-module .banner-section .title-active-project {
+    letter-spacing: 6px;
+    padding-left: 10px;
+    width: 189px;
+  }
+  .details-active-project-module .banner-section .title-h1 {
+    font-size: 21px;
+    bottom: 20px;
+  }
+  .details-active-project-module .banner-section .funded-round {
+    width: 86px;
+    height: 86px;
+    padding: 4px;
+    margin: 0 0 0 -43px;
+    bottom: -73px;
+  }
+  .details-active-project-module .banner-section .funded-round .round-depict {
+    font-size: 9.66px;
+    width: 85px;
+    margin: 3px 0 0 -44px;
+  }
+  .details-active-project-module .banner-section .funded-round .status-indicator {
+    margin-top: 2px;
+  }
+  .details-active-project-module .banner-section .funded-round .status-indicator input {
+    font-size: 20.2px !important;
+    margin-top: 16px !important;
+  }
+  .details-active-project-module .banner-section .funded-round .status-indicator input.smaller {
+    font-size: 16.2px !important;
+    -webkit-transition: font-size 0.25s ease;
+    transition: font-size 0.25s ease;
+  }
+  /* .details-active-project-module .info-section */
+  .details-active-project-module .info-section .container {
+    padding: 2px 14px 0 16px;
+  }
+  /* .details-active-project-module .info-main */
+  .details-active-project-module .info-main {
+    padding-bottom: 24px;
+  }
+  .details-active-project-module .info-main .blue-bar, .details-active-project-module .info-main .dark-blue-bar {
+    font-size: 9.66px;
+    height: 23px;
+    line-height: 23px;
+    padding: 0 20px;
+    margin-top: 6px;
+  }
+  /* .details-active-project-module .video-main */
+  .details-active-project-module .video-main {
+    padding: 0 15px 27px 15px;
+  }
+  .details-active-project-module .video-area .video, .details-active-project-module .video-area .video img, .details-active-project-module .video-area .video iframe {
+    height: 201px;
+  }
+  .details-active-project-module .video-area .video img, .details-active-project-module .video-area .video iframe {
+    width: 100%;
+  }
+  .details-active-project-module .video-area .btn-play {
+    width: 65px;
+    height: 65px;
+    margin: -32.5px 0 0 -32.5px;
+  }
+  .details-active-project-module .video-area .btn-play .icons {
+    background-position: 0 -44px;
+    width: 48px;
+    height: 48px;
+    margin: 6px 0 0 0;
+  }
+  .details-active-project-module .video-area .btn-play:hover .icons, .details-active-project-module .video-area .btn-play:focus .icons {
+    background-position: -48px -44px;
+  }
+  .details-active-project-module .mobile-bottom-bar {
+    margin: 15px 0 0 0;
+    padding-bottom: 42px;
+  }
+  .details-active-project-module .mobile-bottom-bar .social-ul li {
+    margin-right: 9px;
+  }
+  .details-active-project-module .mobile-bottom-bar .share-txt {
+    font-size: 8px;
+    padding: 20px 0 0 0;
+    margin-left: -5px;
+  }
+  .details-active-project-module .txt-area .btn-icon-gray {
+    width: 35px;
+  }
+  .details-active-project-module .txt-area .txt-td {
+    line-height: 10px;
+  }
+  .details-active-project-module .txt-area .txt-td .font20 {
+    font-size: 10px;
+    line-height: 18px;
+    padding: 12px 0 16px 0;
+  }
+  .details-active-project-module .txt-area .txt-td .font14 {
+    font-size: 8px;
+    line-height: 16px;
+  }
+  /* .project-updates-module */
+  .project-updates-module .container {
+    padding: 28px 16px 10px 16px;
+  }
+  /* .project-updates-module .main-area */
+  .project-updates-module .main-area .title-project-updates {
+    width: 192px;
+    letter-spacing: 4px;
+    padding-left: 10px;
+    margin: 0 auto 8px auto;
+  }
+  /* .project-updates-module .list-area */
+  .project-updates-module .list-area .row {
+    padding: 20px 0 0 0;
+    border-bottom: 2.5px solid #dcdcdc;
+  }
+  .project-updates-module .list-area .left-date {
+    width: 111px;
+  }
+  .project-updates-module .list-area .left-date .date-txt {
+    padding: 0 25px 0 16px;
+  }
+  .project-updates-module .list-area .left-date .month-txt {
+    padding: 0 25px 0 20px;
+  }
+  .project-updates-module .list-area .left-date .date-txt {
+    font-size: 61.54px;
+    line-height: 55px;
+    margin-top: 2px;
+  }
+  .project-updates-module .list-area .left-date .month-txt {
+    font-size: 12px;
+    letter-spacing: 11px;
+  }
+  .project-updates-module .list-area .main-info {
+    margin-left: 111px;
+  }
+  .project-updates-module .list-area .main-info .title-h4 {
+    line-height: 15px;
+    padding-bottom: 5px;
+  }
+  .project-updates-module .list-area .main-info .title-h4 a {
+    font-size: 9px;
+  }
+  .project-updates-module .list-area .main-info p {
+    font-size: 8px;
+    line-height: 16px;
+    padding-bottom: 23px;
+  }
+  .project-updates-module .list-area .main-info .social-ul {
+    margin-bottom: 17px;
+    top: 78px;
+    left: -105px;
+  }
+  .project-updates-module .list-area .main-info .social-ul li {
+    margin-right: 7px;
+  }
+  .project-updates-module .list-area .main-info .btn-icon-gray {
+    width: 25px;
+    height: 22px;
+    border: 1px solid #fff;
+  }
+  .project-updates-module .list-area .main-info .btn-icon-gray .icons {
+    background-size: 336px auto;
+    width: 12px;
+    height: 12px;
+    margin-top: 4px;
+  }
+  .project-updates-module .list-area .main-info .btn-icon-gray .icon-fb {
+    background-position: -72px -8px;
+  }
+  .project-updates-module .list-area .main-info .btn-icon-gray:hover .icon-fb {
+    background-position: -84px -8px;
+  }
+  .project-updates-module .list-area .main-info .btn-icon-gray .icon-tw {
+    background-position: -96px -8px;
+  }
+  .project-updates-module .list-area .main-info .btn-icon-gray:hover .icon-tw {
+    background-position: -108px -8px;
+  }
+  .project-updates-module .list-area .main-info .btn-icon-gray .icon-gg {
+    background-position: -120px -8px;
+  }
+  .project-updates-module .list-area .main-info .btn-icon-gray:hover .icon-gg {
+    background-position: -132px -8px;
+  }
+  /* .project-updates-module .right-aside */
+  .project-updates-module .right-aside {
+    margin-top: 19px;
+  }
+  .project-updates-module .right-aside .module-box {
+    min-height: 113px;
+    padding: 6px 0 16px 0;
+    margin: 0 16px 10px 16px;
+  }
+  .project-updates-module .right-aside .module-box .type-txt {
+    font-size: 10px;
+    line-height: 15px;
+    padding: 5px 0 6px 0;
+    width: 148px;
+  }
+  .project-updates-module .right-aside .module-box .value-txt {
+    font-size: 36px;
+    line-height: 35px;
+    padding: 0 0 10px 0;
+    width: 148px;
+  }
+  .project-updates-module .right-aside .module-box .title-h5 {
+    font-size: 8px;
+    border-bottom: 1px solid #c3c3c3;
+    height: 16px;
+    line-height: 16px;
+    top: 9px;
+    right: 22px;
+  }
+  .project-updates-module .right-aside .module-box ul {
+    padding: 17px 0 12px 0;
+    width: 44%;
+    top: 17px;
+    right: 22px;
+  }
+  .project-updates-module .right-aside .module-box li {
+    font-size: 7px;
+    line-height: 16px;
+  }
+  .project-updates-module .right-aside .btn-i-want-to-donate {
+    letter-spacing: 2px;
+    padding-left: 6px;
+    width: 111px;
+    height: 22px;
+    line-height: 22px;
+    bottom: 12px;
+    left: 16px;
+  }
+  /* .donors-module */
+  .donors-module .titles.container {
+    min-height: 50px;
+  }
+  .titles.container .title-donors {
+    min-width: 96px;
+    width: 96px;
+    letter-spacing: 4px;
+    padding-left: 6px;
+  }
+  .donors-module .mains-tabs .tab-index .row {
+    margin-top: -1px;
+  }
+  .donors-module .mains-tabs .tab-content {
+    min-height: 354px;
+  }
+  .donors-module .tab-content .row {
+    margin: 2px 9px 50px 2px;
+  }
+  .donors-module .tab-content .row .col-md-6 {
+    padding: 23px 0 0 0;
+  }
+  .donors-module .tab-content .head-img {
+    width: 78px;
+  }
+  .donors-module .tab-content .head-img img {
+    width: 63px;
+    height: 63px;
+  }
+  .donors-module .info-box {
+    margin-left: 78px;
+  }
+  .donors-module .info-box .title-h4 {
+    padding: 0 0 4px 0;
+    margin-top: -2px;
+  }
+  .donors-module .info-box .title-h4 a {
+    font-size: 9px;
+  }
+  .donors-module .info-box p {
+    font-size: 8px;
+    line-height: 17px;
+    padding: 0 22px 0 0;
+  }
+  /* solar ambassador program page */
+  .contents.solar-ambassador-program-contents {
+    min-height: 800px;
+    margin-top: 91px;
+  }
+  /* .article-detail */
+  .solar-contents .article-detail {
+    padding: 26px 15px 12px 32px;
+  }
+  .solar-contents .article-detail .title-blue-border {
+    border-width: 1px;
+  }
+  .solar-contents .article-detail .title-solar {
+    width: auto;
+    font-size: 11px;
+    height: 22px;
+    line-height: 22px;
+    padding-left: 13px;
+    padding-top: 0;
+    padding-right: 8px;
+    letter-spacing: 4px;
+  }
+  .solar-contents .article-detail .detail-left {
+    padding-right: 0px;
+    padding-top: 40px;
+  }
+  .solar-contents .article-detail .detail-left .title-img {
+    margin-bottom: 11px;
+  }
+  .solar-contents .article-detail .detail-left p {
+    margin-top: 5px;
+    padding-left: 3px;
+  }
+  .solar-contents .article-detail .detail-left .title-img {
+    margin-bottom: 11px;
+  }
+  .solar-contents .article-detail .detail-left .btn-group {
+    padding-top: 0;
+    padding-right: 0;
+    margin-top: -5px;
+  }
+  .solar-contents .article-detail .detail-left .btn-group .btn-blue {
+    height: 23px;
+    line-height: 23px;
+    margin-bottom: 14px;
+    margin-left: 1px;
+  }
+  .solar-contents .article-detail .detail-left .btn-group .btn-application {
+    padding-left: 16px;
+    padding-right: 14px;
+    margin-top: 0;
+    margin-right: 18px;
+  }
+  .solar-contents .article-detail .detail-left .btn-group .btn-team {
+    padding-left: 11px;
+    padding-right: 12px;
+    margin-bottom: 11px;
+    margin-right: 0;
+  }
+  .solar-contents .article-detail .detail-left .btn-group .btn-project {
+    padding-left: 21px;
+    padding-right: 22px;
+    margin-right: 0;
+    clear: both;
+  }
+  /* partners page */
+  .contents.partners-contents {
+    min-height: 800px;
+    margin-top: 91px;
+  }
+  /* .partners-contents .container */
+  .partners-contents .container {
+    padding: 26px 0 3px 13px;
+  }
+  .partners-contents .title-blue-border {
+    border-width: 1px;
+  }
+  .partners-contents .title-partners {
+    font-size: 11px;
+    height: 22px;
+    line-height: 22px;
+    padding-left: 18px;
+    padding-right: 15px;
+    margin-right: 15px;
+    margin-bottom: 20px;
+    letter-spacing: 3px;
+  }
+  .partners-contents .titles .title-primary {
+    font-size: 24px;
+    line-height: 26px;
+    margin-bottom: 5px;
+    padding-left: 17px;
+  }
+  .partners-contents .titles .title-sub {
+    font-size: 8px;
+    line-height: 16px;
+    padding-left: 18px;
+  }
+  /* .partners-contents .list */
+  .partners-contents .list-wrap {
+    margin-top: 16px;
+  }
+  .partners-contents .list-wrap .item-wrap {
+    height: auto;
+    min-height: 0;
+    margin-bottom: 0;
+    position: relative;
+  }
+  .partners-contents .list-wrap .item-wrap.large-spacing {
+    margin-bottom: 12px;
+  }
+  .partners-contents .left-img {
+    width: 100px;
+    height: 100px;
+    margin-top: 0;
+    margin-left: 2px;
+  }
+  .partners-contents .content-info {
+    margin-left: 109px;
+    height: auto;
+    overflow: auto;
+    min-height: 0;
+  }
+  .partners-contents .content-info h4 {
+    font-size: 15px;
+    line-height: 18px;
+    margin-bottom: 4px;
+    padding-top: 18px;
+  }
+  .partners-contents .content-info h4 a {
+    font-size: 15px;
+  }
+  .partners-contents .content-info p {
+    font-size: 8px;
+    line-height: 16px;
+    padding-right: 20px;
+    padding-left: 1px;
+  }
+  .partners-contents .btn-wrap {
+    position: absolute;
+    left: -188px;
+    top: 100px;
+  }
+  .partners-contents .btn-wrap .btn-blue {
+    height: 22px;
+    line-height: 22px;
+    padding-left: 24px;
+    padding-right: 25px;
+    letter-spacing: 2px;
+  }
+  /* .partners-contents .pager-info */
+  .partners-contents .pager-info {
+    margin-top: -20px;
+    margin-right: 9px;
+    margin-bottom: 4px;
+    float: right;
+  }
+  .partners-contents .pager-info li {
+    float: left;
+    margin-right: 8px;
+  }
+  .partners-contents .pager-info li a {
+    padding: 0 10px;
+    font-size: 8px;
+    line-height: 20px;
+    height: 20px;
+  }
+  /* .sponsoring-organizations-module */
+  .sponsoring-organizations-module {
+    min-height: 225px;
+  }
+  .sponsoring-organizations-module .container {
+    padding: 25px 12px 0 12px;
+  }
+  .sponsoring-organizations-module .title-sponsoring-organizations {
+    font-size: 9px;
+    width: 248px;
+    letter-spacing: 4px;
+    padding-left: 7px;
+    margin-bottom: 35px;
+  }
+  /* .sponsoring-organizations-module .carousel-main */
+  .sponsoring-organizations-module .carousel-main {
+    margin-right: 37px;
+    margin-left: 37px;
+  }
+  .sponsoring-organizations-module .logo-ul li {
+    height: 100px;
+  }
+  .sponsoring-organizations-module .logo-the-san-francisco {
+    background-size: 83px auto;
+    width: 83px;
+    height: 83px;
+  }
+  .sponsoring-organizations-module .logo-toyota-togethergreen {
+    background-size: 96.5px auto;
+    width: 96.5px;
+    height: 31.5px;
+  }
+  .sponsoring-organizations-module .logo-sun-shot {
+    background-size: 67px auto;
+    width: 67px;
+    height: 20.5px;
+  }
+  .sponsoring-organizations-module .logo-patagonia {
+    background-size: 86px auto;
+    width: 86px;
+    height: 27px;
+  }
+  .sponsoring-organizations-module .carousel-control.left, .sponsoring-organizations-module .carousel-control.right {
+    width: 25px;
+    height: 24px;
+    border: 1px solid #fff;
+    top: 37px;
+  }
+  .sponsoring-organizations-module .carousel-control.left {
+    left: -38px;
+  }
+  .sponsoring-organizations-module .carousel-control.right {
+    right: -38px;
+  }
+  .sponsoring-organizations-module .carousel-control.left .icons, .sponsoring-organizations-module .carousel-control.right .icons {
+    width: 12px;
+    height: 12px;
+    margin: 0 auto 3px auto;
+  }
+  .sponsoring-organizations-module .carousel-control.left .icons {
+    background-position: -144px -8px;
+  }
+  .sponsoring-organizations-module .carousel-control:hover.left .icons {
+    background-position: -168px -8px;
+  }
+  .sponsoring-organizations-module .carousel-control.right .icons {
+    background-position: -180px -8px;
+  }
+  .sponsoring-organizations-module .carousel-control:hover.right .icons {
+    background-position: -192px -8px;
+  }
+  /* blog page */
+  .titles.container .title-blog {
+    margin-right: 11px;
+    min-width: 70px;
+    letter-spacing: 4px;
+    padding-left: 7px;
+    margin-top: -1px;
+  }
+  /* .grid-data */
+  .grid-data.container {
+    padding: 0;
+  }
+  /* .form-area */
+  .form-area {
+    padding: 0 0 6px 15px;
+    min-height: 25px;
+  }
+  .form-area .width167 .btn-default, .form-area .width167.input-search {
+    width: 109px;
+  }
+  /* .input-search */
+  .input-search {
+    padding: 0 22px 0 15px;
+    height: 25px;
+    line-height: 25px;
+  }
+  .input-search input {
+    font-size: 8.335px;
+    letter-spacing: 3px;
+    height: 25px;
+    line-height: 10px;
+  }
+  .input-search .icon-search {
+    background-position: -264px -44px;
+    width: 12px;
+    height: 12px;
+    top: 5px;
+    right: 6px;
+  }
+  .input-search .icon-search:hover {
+    background-position: -276px -44px;
+  }
+  /* .grid-area.row */
+  .grid-area.row {
+    min-height: 50px;
+  }
+  .grid-area.row .img-main, .grid-area.row .video, .grid-area.row .video iframe {
+    height: 194px;
+  }
+  .grid-area.row .btn-play {
+    border: 2px solid #fff;
+    width: 53px;
+    height: 53px;
+    margin: -26px 0 0 -26px;
+  }
+  .grid-area.row .btn-play .icons {
+    background-size: 271px auto;
+    background-position: 0 -35px;
+    width: 39px;
+    height: 39px;
+    margin: 5px 0 0 0;
+  }
+  .grid-area.row .btn-play:hover, .grid-area.row .btn-play:focus {
+    border: 2px solid #1cb0e6;
+  }
+  .grid-area.row .btn-play:hover .icons, .grid-area.row .btn-play:focus .icons {
+    background-position: -39px -35.5px;
+  }
+  .grid-area.row .img-main img {
+    height: 194px;
+  }
+  .grid-area.row .carousel-control.left, .grid-area.row .carousel-control.right {
+    width: 25px;
+    height: 24px;
+    border: 1px solid #fff;
+    margin-top: -12px;
+  }
+  .grid-area.row .carousel-control.left {
+    left: 8px;
+  }
+  .grid-area.row .carousel-control.right {
+    right: 8px;
+  }
+  .grid-area.row .carousel-control.left .icons, .grid-area.row .carousel-control.right .icons {
+    width: 12px;
+    height: 12px;
+    margin-top: 0;
+    margin-bottom: 2px;
+  }
+  .grid-area.row .carousel-control.left .icons {
+    background-position: -144px -8px;
+  }
+  .grid-area.row .carousel-control:hover.left .icons {
+    background-position: -168px -8px;
+  }
+  .grid-area.row .carousel-control.right .icons {
+    background-position: -180px -8px;
+  }
+  .grid-area.row .carousel-control:hover.right .icons {
+    background-position: -192.5px -8px;
+  }
+  .grid-area.row .info-main {
+    padding: 30px 18px 20px 18px;
+  }
+  .grid-area.row .info-main .title-h2 {
+    font-size: 21px;
+    line-height: 24px;
+  }
+  .grid-area.row .info-main .title-h2 a {
+    font-size: 21px;
+  }
+  .grid-area.row .info-main .date-txt {
+    font-size: 9px;
+    line-height: 16px;
+    padding-top: 4px;
+    letter-spacing: 0;
+    padding-bottom: 7px;
+  }
+  .grid-area.row .info-main p {
+    font-size: 8px;
+    line-height: 16px;
+    padding: 4px 12px 9px 0;
+  }
+  .grid-area.row .info-main .bottom-bar {
+    padding: 12px 2px 28px 3px;
+  }
+  .grid-area.row .info-main .bottom-bar .btn-read-more {
+    font-size: 7px;
+    letter-spacing: 2px;
+    width: 76px;
+    height: 33px;
+    padding: 0 0 0 1px;
+    line-height: 33px;
+  }
+  .grid-area.row .info-main .bottom-bar .social-ul {
+    margin: 1.5px 0 0 0;
+  }
+  .grid-area.row .info-main .bottom-bar .social-ul li {
+    margin: 0 4px 0 4.5px;
+  }
+  .grid-area.row .info-main .bottom-bar .btn-icon-gray {
+    width: 40px;
+    height: 33px;
+  }
+  .grid-area.row .info-main .bottom-bar .btn-icon-gray .icons {
+    margin-top: 3.5px;
+  }
+  /* .loading-bar */
+  .loading-bar {
+    padding: 0 0 9px 0;
+    margin-top: -31px;
+  }
+  .loading-bar .loading-img {
+    background-size: 64px auto;
+    width: 64px;
+    height: 21px;
+  }
+  /* .blog-details-data */
+  .blog-details-data.container {
+    min-height: 150px;
+  }
+  /* .blog-details-data .title-bar */
+  .blog-details-data.container .title-bar {
+    padding: 5px 35px 8px 35px;
+  }
+  .blog-details-data.container .title-bar .title-h1 {
+    font-size: 24px;
+    line-height: 30px;
+  }
+  .blog-details-data.container .title-bar .date-txt {
+    font-size: 9px;
+    line-height: 16px;
+  }
+  .blog-details-data.container .title-bar .social-ul {
+    min-height: 30px;
+    padding: 7px 0 0 0;
+    margin-bottom: 11px;
+  }
+  .blog-details-data.container .title-bar .social-ul li {
+    margin-right: 10px;
+  }
+  .blog-details-data.container .title-bar .social-ul li .btn-icon-gray {
+    width: 39px;
+    height: 32px;
+  }
+  .blog-details-data.container .title-bar .social-ul li .btn-icon-gray .icons {
+    margin-top: 3px;
+  }
+  /* .blog-details-data .info-box */
+  .blog-details-data.container .info-box .img-main, .blog-details-data.container .info-box .img-main img {
+    height: 194px;
+  }
+  .blog-details-data.container .info-box .info-main {
+    padding: 18px 0 31px 0;
+    margin: 0 35px;
+  }
+  .blog-details-data.container .info-box .info-main .font20 {
+    font-size: 10px;
+    line-height: 18px;
+  }
+  .blog-details-data.container .info-box .info-main .font14 {
+    font-size: 8px;
+    line-height: 16px;
+  }
+  .blog-details-data.container .info-box .info-main .lefts .font14, .blog-details-data.container .info-box .down25 {
+    padding-bottom: 17px;
+  }
+  /* .related-blog-module */
+  .related-blog-module {
+    padding: 13px 0 3px 0;
+  }
+  .related-blog-module .form-area {
+    min-height: 36px;
+    margin-top: 48px;
+  }
+  .related-blog-module .title-related-blog {
+    font-size: 10.5px;
+    width: 160px;
+    top: 1px;
+    right: 19px;
+  }
+  #mobile-related-example-generic {
+    margin: 0 32px;
+  }
+  #mobile-related-example-generic .grid-area.row .info-main {
+    padding: 11px 92px 11px 0;
+  }
+  #mobile-related-example-generic .grid-area.row .info-main .title-h2 {
+    font-size: 24px;
+  }
+  #mobile-related-example-generic .grid-area.row .info-main .bottom-bar .btn-read-more {
+    top: 17px;
+    width: 79px;
+    height: 27px;
+    line-height: 27px;
+  }
+  .related-blog-module .carousel-control.left, .related-blog-module .carousel-control.right {
+    width: 26px;
+    height: 25px;
+    top: 90px;
+  }
+  .related-blog-module .carousel-control.left {
+    left: -29px;
+  }
+  .related-blog-module .carousel-control.right {
+    right: -29px;
+  }
+  .related-blog-module .carousel-control.left .icons, .related-blog-module .carousel-control.right .icons {
+    width: 12px;
+    height: 12px;
+    margin-top: 0;
+    margin-bottom: 3px;
+  }
+  .related-blog-module .carousel-control.left .icons {
+    background-position: -144px -8px;
+  }
+  .related-blog-module .carousel-control:hover.left .icons {
+    background-position: -168px -8px;
+  }
+  .related-blog-module .carousel-control.right .icons {
+    background-position: -180px -8px;
+  }
+  .related-blog-module .carousel-control:hover.right .icons {
+    background-position: -192px -8px;
+  }
+  .related-blog-module .carousel-inner>.active {
+    min-height: 295px;
+  }
+  /* .comments-module */
+  .comments-module .container {
+    padding: 18px 19px 0 19px;
+  }
+  .comments-module .container .title-comments {
+    width: 111px;
+    letter-spacing: 5px;
+    padding-left: 6px;
+    margin-bottom: 3px;
+  }
+  /* .comments-module .comments-area  .comments-list*/
+  .comments-module .comments-area {
+    min-height: 100px;
+    padding-top: 10px;
+  }
+  .comments-module .comments-area .comments-list {
+    padding: 32px 0 17px 0;
+  }
+  .comments-module .comments-area .spacetop {
+    padding-top: 13px;
+  }
+  .comments-module .comments-area .comments-list .head-img {
+    width: 62px;
+  }
+  .comments-module .comments-area .comments-list .head-img img {
+    width: 50px;
+    height: 50px;
+    margin-left: 2px;
+  }
+  .comments-module .comments-area .comments-list .info-box {
+    margin-left: 62px;
+  }
+  .comments-module .comments-area .comments-list .info-box .title-h4 {
+    padding: 0 0 3px 0;
+    margin-top: -3px;
+  }
+  .comments-module .comments-area .comments-list .info-box .title-h4 a {
+    font-size: 10px;
+  }
+  .comments-module .comments-area .comments-list .info-box p {
+    font-size: 8px;
+    line-height: 16px;
+    padding: 0 14px 15px 0;
+  }
+  .comments-module .comments-area .comments-list .comments-apply {
+    border: 1px solid #fff;
+    width: 78px;
+    height: 21px;
+    line-height: 21px;
+    letter-spacing: 3px;
+  }
+  .comments-module .comments-area .comments-list .comments-apply a {
+    font-size: 7px;
+    padding-left: 2px;
+  }
+  /* .comments-module .comments-area .quick-reply */
+  .comments-module .comments-area .quick-reply {
+    padding: 16px 0 17px 0;
+  }
+  .comments-module .btn-icon-gray {
+    width: 27px;
+    height: 22px;
+  }
+  .comments-module .btn-icon-gray .icons {
+    width: 12px;
+    height: 12px;
+    margin-top: 4px;
+  }
+  .comments-module .btn-icon-gray .icon-fb {
+    background-position: -72px -8px;
+  }
+  .comments-module .btn-icon-gray:hover .icon-fb {
+    background-position: -84px -8px;
+  }
+  .comments-module .btn-icon-gray .icon-tw {
+    background-position: -96px -8px;
+  }
+  .comments-module .btn-icon-gray:hover .icon-tw {
+    background-position: -108px -8px;
+  }
+  .comments-module .btn-icon-gray .icon-gg {
+    background-position: -120px -8px;
+  }
+  .comments-module .btn-icon-gray:hover .icon-gg {
+    background-position: -132px -8px;
+  }
+  .comments-module .comments-area .quick-reply .quick-reply-txt {
+    width: 67px;
+  }
+  .comments-module .comments-area .quick-reply .quick-reply-txt .title-h4 {
+    padding: 9px 0 11px 0;
+    font-size: 10px;
+  }
+  .comments-module .comments-area .quick-reply .quick-reply-txt p {
+    font-size: 8px;
+  }
+  .comments-module .comments-area .quick-reply .quick-reply-txt li {
+    margin-top: 5px;
+    margin-left: 0;
+  }
+  .comments-module .comments-area .quick-reply .quick-reply-txt li:nth-child(2) {
+    margin-left: 6px;
+  }
+  .comments-module .comments-area .quick-reply .textarea-box {
+    margin-right: 2px;
+    margin-left: 67px;
+    height: 126px;
+    padding: 10.5px 14px;
+  }
+  .comments-module .comments-area .quick-reply .textarea-box textarea {
+    font-size: 8px;
+    height: 85px;
+    line-height: 7px;
+    letter-spacing: 3px;
+  }
+  .comments-module .comments-area .quick-reply .comments-post {
+    width: 68.5px;
+    height: 21.5px;
+    line-height: 21.5px;
+    right: 3px;
+    bottom: 18px;
+    letter-spacing: 2px;
+  }
+  .comments-module .comments-area .quick-reply .comments-post a {
+    font-size: 7px;
+    padding: 1px 0 0 1.5px;
+  }
+  /* .footer */
+  .footer .row {
+    padding: 0 21.5px 0 32.5px;
+  }
+  .footer .row .col-info {
+    padding: 17px 0 9px 0;
+  }
+  .footer .row .col-menu dt, .footer .row .col-info dt {
+    line-height: 12.5px;
+    padding: 5px 0;
+  }
+  .footer .row .col-menu dt a, .footer .row .col-info dt a {
+    font-size: 10.5px;
+  }
+  .footer .row .col-menu dd, .footer .row .col-info dd {
+    line-height: 14.5px;
+  }
+  /* .footer .col-menu */
+  .footer .row .col-menu {
+    padding: 26px 0 11px 0;
+  }
+  /* .footer .col-info */
+  .footer .row .col-info:nth-child(5) {
+    padding: 0 0 16px 0;
+  }
+  .footer .row .col-info:nth-child(5) dt a {
+    font-size: 8px;
+  }
+  .footer .row .col-info dt {
+    padding-bottom: 3.5px;
+  }
+  .footer .row .col-info a {
+    font-size: 8px;
+  }
+  .footer .row .col-info p {
+    font-size: 7px;
+    line-height: 12px;
+    padding: 0 8px 0 0;
+  }
+  /* .footer .bottoms */
+  .footer .bottoms {
+    min-height: 112.5px;
+  }
+  .footer .bottoms .logo {
+    background-size: 85px auto;
+    margin: 19px auto 0 auto;
+    width: 85.5px;
+    height: 36px;
+  }
+  .footer .bottoms .social-ul {
+    margin: 19px auto 0 auto;
+    width: 85px;
+    height: 12px;
+  }
+  .footer .bottoms .social-ul li {
+    margin: 0 7px;
+  }
+  .footer .bottoms .social-ul li .icons {
+    background-size: 336px auto;
+    width: 12px;
+    height: 12px;
+  }
+  .footer .bottoms .social-ul li .icon-fb {
+    background-position: 0 -8px;
+  }
+  .footer .bottoms .social-ul li .icon-fb:hover {
+    background-position: -12px -8px;
+  }
+  .footer .bottoms .social-ul li .icon-tw {
+    background-position: -24px -8px;
+  }
+  .footer .bottoms .social-ul li .icon-tw:hover {
+    background-position: -36px -8px;
+  }
+  .footer .bottoms .social-ul li .icon-gg {
+    background-position: -48px -8px;
+  }
+  .footer .bottoms .social-ul li .icon-gg:hover {
+    background-position: -60px -8px;
+  }
+  /* .modal-default */
+  .modal.modal-default .modal-dialog {
+    width: 346px;
+    margin: 102px auto;
+  }
+  /* .modal-default .modal-header */
+  .modal.modal-default .btn-close {
+    background-position: -240px -44px;
+    width: 24px;
+    height: 24px;
+    top: 18.5px;
+    right: 12px;
+  }
+  .modal.modal-default .btn-close:hover {
+    background-position: -240px -68px;
+  }
+  /* .modal-default .modal-body */
+  .modal.modal-default .modal-body {
+    min-height: 50px;
+  }
+  /* #modal-how-it-works */
+  #modal-how-it-works .title-how-it-works {
+    width: 142px;
+    letter-spacing: 4px;
+    padding-left: 6px;
+    margin: 19px auto 0 auto;
+  }
+  #modal-how-it-works .txt-info {
+    font-size: 8px;
+    line-height: 16px;
+    padding: 262px 34px 17px 34px;
+  }
+  /* #modal-how-it-works .info-row */
+  #modal-how-it-works .info-row {
+    padding: 12px 15px 3.5px 15px;
+    top: 10px;
+  }
+  #modal-how-it-works .info-row .video-area .video, #modal-how-it-works .info-row .video-area .video img {
+    width: 315px;
+    height: 224px;
+  }
+  #modal-how-it-works .info-row .video-area .video iframe {
+    width: 315px;
+    height: 224px;
+  }
+  #modal-how-it-works .info-row .video-area .btn-play {
+    border: 2.5px solid #fff;
+    width: 65px;
+    height: 65px;
+    margin: -32.5px 0 0 -32.5px;
+  }
+  #modal-how-it-works .info-row .video-area .btn-play .icons {
+    background-position: 0 -44px;
+    width: 48px;
+    height: 48px;
+    margin: 7px 0 0 0;
+  }
+  #modal-how-it-works .info-row .video-area .btn-play:hover, #modal-how-it-works .info-row .video-area .btn-play:focus {
+    border: 2.5px solid #1cb0e6;
+  }
+  #modal-how-it-works .info-row .video-area .btn-play:hover .icons, #modal-how-it-works .info-row .video-area .btn-play:focus .icons {
+    background-position: -48px -44px;
+  }
 }
-.icons {
-	background: url(../images/mobile/mobile-icon-sprites.png) no-repeat;
-	background-size: 336px auto;
-}
-
-/* btn */
-.btn-blue {
-	font-size: 7px;
-	height: 26.5px;
-	line-height: 26.5px;
-	padding: 0 3px;
-}
-.btn-icon-gray {
-	border: 1px solid #fff;
-	width: 32px;
-	height: 31px;
-}
-	.btn-icon-gray .icons {
-		width: 24px;
-		height: 24px;
-		margin-top: 2.5px;
-	}
-		.btn-icon-gray .icon-fb {
-			background-position: -144px -20px;
-		}
-			.btn-icon-gray:hover .icon-fb {
-				background-position: -168px -20px;
-			}
-		.btn-icon-gray .icon-tw {
-			background-position: -192px -20px;
-		}
-			.btn-icon-gray:hover .icon-tw {
-				background-position: -216px -20px;
-			}
-		.btn-icon-gray .icon-gg {
-			background-position: -240px -20px;
-		}
-			.btn-icon-gray:hover .icon-gg {
-				background-position: -264px -20px;
-			}
-			.title-blue-border {
-				border: 1px solid #14b1e7;
-			}
-			.title-white-border {
-				border: 1px solid #fff;
-			}
-
-
-
-	/* .dropdown-default */
-	.dropdown-default .btn-default {
-		font-size: 8.335px;
-		letter-spacing: 3.5px;
-		padding: 0 16px 0 20px;
-		height: 25px;
-		line-height: 23px;
-	}
-		.dropdown-default .btn-default .icon-arrow-down {
-			background-position: -48px 0;
-			top: 7px;
-			right: 8.5px;
-			width: 8px;
-			height: 8px;
-		}
-			.dropdown-default .btn-default.active .icon-arrow-down,
-			.dropdown-default .btn-default:active .icon-arrow-down,
-			.open.dropdown-default>.dropdown-toggle.btn-default .icon-arrow-down {
-				background-position: -56.5px 0;
-			}
-		.dropdown-default .dropdown-menu {
-			font-size: 8.23px;
-			min-width: 30px;
-			padding: 2.5px 0;
-		}
-			.dropdown-default .dropdown-menu>li>a {
-				padding: 0 12.5px;
-				line-height: 13px;
-			}
-/* title */
-.title-white-border,
-.title-blue-border {
-	font-size: 10.5px;
-	letter-spacing: 3.5px;
-	height: 21.5px;
-	line-height: 21.5px;
-	padding: 0 2.5px;
-}
-
-.container {
-	width: auto;
-}
-
-
-/* .header */
-.header {
-	margin-top: 5px;
-	height: 92.5px;
-}
-		.header .logo {
-			background-repeat: no-repeat;
-			background-size: 129px auto;
-			margin: 18.5px 0 0 16px;
-			width: 129px;
-			height: 51px;
-		}
-		.header .btn-donate {
-			min-width: 66px;
-		}
-		.header .rights {
-			padding: 33px 24px 0 0;
-		}
-			.header .txt {
-				font-size: 8px;
-				padding: 0 10px 3px 0;
-				line-height: 13px;
-			}
-	/* .after-scroll-header */
-	.header.after-scroll-header {
-		border-bottom: 1px solid #c6c6c6;
-	}
-		.header.after-scroll-header .logo {
-			background: url(../images/mobile/mobile-logo.png) no-repeat;
-			background-size: 129px auto;
-			width: 129px;
-			height: 51px;
-			margin: 18.5px 0 0 16px;
-		}
-		.header.after-scroll-header .rights {
-			padding: 33px 24px 0 0;
-		}
-
-
-/* .top-section */
-.top-section {
-	min-height: 92.5px;
-}
-	.top-section .sub-section-bg {
-		background-size: 100% 92.5px;
-	}
-		.top-section.min-height {
-			min-height: 667px;
-		}
-		.top-section .section-video-area iframe,
-		.top-section .section-video-area video,
-		.top-section .section-video-area .mejs-container,
-		.top-section .section-video-area .me-plugin,
-		.top-section .section-video-area embed,
-		.top-section .section-video-area .mejs-overlay-play {
-			height: 667px!important;
-		}
-			.top-section .section-video img {
-				width: 100%;
-				height: 667px;
-			}
-			.top-section .section-video-area iframe,
-			.top-section .section-video-area video,
-			.top-section .section-video-area .mejs-container,
-			.top-section .section-video-area .me-plugin,
-			.top-section .section-video-area embed,
-			.top-section .section-video-area .mejs-overlay-play {
-				width: 100%!important;
-				height: 667px!important;
-				border: none;
-			}
-	/* .top-section .carousel */
-	.top-section .carousel {
-		top: 75px;
-		padding-right: 20px;
-		padding-left: 20px;
-	}
-		/* .top-section .carousel .item */
-		.top-section .carousel .item {
-			padding: 75px 0 0 0;
-			min-height: 507px;
-		}
-			.top-section .carousel .item-info {
-				width: 290px;
-			}
-				.top-section .carousel .item-info .titles {
-					font-size: 24px;
-					line-height: 29px;
-				}
-				.top-section .carousel .item-info p {
-					font-size: 10px;
-					line-height: 18px;
-					width: 240px;
-					padding: 11px 0 22px 0;
-				}
-				.top-section .carousel .item-info .btn-donate-now {
-					letter-spacing: 2px;
-					min-width: 125px;
-					padding-left: 7.5px;
-				}
-		/* .top-section .carousel-indicators */
-		.top-section .carousel-indicators {
-			bottom: 15px;
-		}
-		.top-section .carousel-indicators li {
-			width: 10px;
-			height: 10px;
-			margin: 0 3px 0 2.5px;
-		}
-			.top-section .icon-arrow-down {
-				background-position: -120px -20px;
-				width: 24px;
-				height: 24px;
-				bottom: -23px;
-				margin: 0 0 0 -12px;
-			}
-			.top-section .carousel-control.left,
-			.top-section .carousel-control.right {
-				border: 1px solid #fff;
-				width: 33px;
-				height: 32px;
-				bottom: 21px;
-			}
-				.top-section .carousel-control.left {
-					left: 16px;
-				}
-				.top-section .carousel-control.right {
-					right: 16px;
-				}
-					.top-section .carousel-control.left .icons,
-					.top-section .carousel-control.right .icons {
-						width: 12px;
-						height: 12px;
-						margin-top: 9px;
-					}
-						.top-section .carousel-control.left .icons {
-							background-position: -240px -8px;
-						}
-							.top-section .carousel-control:hover.left .icons {
-								background-position: -252px -8px;
-							}
-						.top-section .carousel-control.right .icons {
-							background-position: -288px -8px;
-						}
-							.top-section .carousel-control:hover.right .icons {
-								background-position: -276px -8px;
-							}
-
-
-
-/* home page */
-
-	/* .active-projects-module */
-	.active-projects-module {
-		padding-bottom: 18px;
-	}
-		.active-projects-module .title-active-projects {
-			letter-spacing: 5px;
-			width: 185px;
-			padding-left: 6px;
-			margin: 25px auto;
-		}
-		.active-projects-module .row {
-			margin: 0 32px;
-		}
-				/* .active-projects-module .module-box */
-				.active-projects-module .module-box {
-					margin: 0 0 26px 0;
-				}
-					/* .active-projects-module .img-main */
-					.active-projects-module .img-main .txt-table {
-						height: 312px;
-					}
-						.active-projects-module .img-main .txt {
-							font-size: 21px;
-							line-height: 31px;
-							padding: 0 65px 23px 65px;
-						}
-						.active-projects-module .img-main .img-link img {
-							height: 312px;
-						}
-						.active-projects-module .img-main .funded-round {
-							width: 120px;
-							height: 125px;
-							padding: 10px;
-							bottom: -50px;
-							margin: 0 0 0 -60px;
-						}
-						    .active-projects-module .img-main .funded-round .round-depict {
-								text-align: center;
-								font-size: 15px;
-								width: 125px;
-								margin: 6px 0 0 -60px;
-							}
-							.active-projects-module .img-main .funded-round .status-indicator input {
-								font-size: 36px !important;
-								margin-top: 3px !important;
-								width: 80px !important;
-								height: 80px !important;
-								margin-left: -92px!important;
-							}
-								.active-projects-module .img-main .funded-round .status-indicator input.smaller {
-									font-size: 32px !important;
-									margin-top: 3px !important;
-									-webkit-transition: font-size 0.25s ease;
-									transition: font-size 0.25s ease;
-								}
-								.active-projects-module.embedded .img-main .funded-round .status-indicator input {
-									margin-top: -102.5px !important;
-									margin-left: 8px !important;
-								}
-									.active-projects-module.embedded .img-main .funded-round .status-indicator input.smaller {
-										margin-top: -102.5px !important;
-										margin-left: 10px !important;
-										font-size: 30px !important;
-									}
-						.mobile-circle {
-							display: block;
-						}
-						.desktop-circle,
-						.small-circle,
-						.tablet-circle {
-							display: none;
-						}
-
-
-
-
-					/* .active-projects-module .info-main */
-					.active-projects-module .info-main {
-						padding: 38px 29px 27px 30px;
-					}
-						.active-projects-module .info-main .blue-bar,
-						.active-projects-module .info-main .dark-blue-bar {
-							font-size: 15px;
-							height: 46px;
-							line-height: 46px;
-							padding: 0 24px 0 24px;
-							margin-top: 12px;
-						}
-
-		/* .our-impacts-module */
-		.our-impacts-module .title-our-impacts {
-			letter-spacing: 5px;
-			padding-left: 15px;
-			width: 156px;
-			margin: 21px auto 14px auto;
-		}
-		.our-impacts-module .row {
-			margin: 0 9px 0 8px;
-			padding: 0 0 1px 0;
-		}
-			.our-impacts-module .module-box {
-				margin-bottom: 24px;
-			}
-					.our-impacts-module .row .col-md-3:nth-child(3) .module-box .titles {
-						letter-spacing: -0.9px;
-						padding-top: 10px;
-						line-height: 20px;
-					}
-					.our-impacts-module .row .col-md-3:nth-child(4) .module-box .titles {
-						padding-top: 2px;
-						line-height: 25px;
-					}
-			.our-impacts-module .module-box .icons {
-				width: 84px;
-				height: 80px;
-			}
-				.our-impacts-module .module-box .icon-people {
-					background-position: 0 -92px;
-				}
-				.our-impacts-module .module-box .icon-home-ok {
-					background-position: -78px -92px;
-				}
-				.our-impacts-module .module-box .icon-tree {
-					background-position: -177px -85px;
-					width: 78px;
-				}
-				.our-impacts-module .module-box .icon-user {
-					background-position: -252px -89px;
-				}
-					.our-impacts-module .module-box .titles {
-						line-height: 33px;
-					}
-						.our-impacts-module .module-box .font20 {
-							font-size: 9px;
-						}
-						.our-impacts-module .module-box .font48 {
-							font-size: 24px;
-						}
-						.our-impacts-module .module-box .font72 {
-							font-size: 36px;
-						}
-					.our-impacts-module .module-box .txt {
-						font-size: 9px;
-						line-height: 11px;
-						padding-right: 10%;
-						padding-left: 10%;
-					}
-					.our-impacts-module .module-box .txt .position {
-						min-width: 4px;
-					}
-						.our-impacts-module .module-box .txt .position .font10 {
-							font-size: 5px;
-							top: -5px;
-							left: 1.5px;
-						}
-
-	/* .how-it-works-module */
-	.how-it-works-module .title-how-it-works {
-		letter-spacing: 5px;
-		padding-left: 8px;
-		width: 156px;
-		margin: 26px auto 0 auto;
-	}
-		/* .how-it-works-module .info-row */
-		.how-it-works-module .info-row {
-			padding: 23px 15px 0 16px;
-		}
-			.how-it-works-module .info-row .video-area .video,
-			.how-it-works-module .info-row .video-area .video img,
-			.how-it-works-module .info-row .video-area .video iframe {
-				height: 262px;
-			}
-				.how-it-works-module .info-row .video-area .btn-play {
-					width: 66px;
-					height: 66px;
-					margin: -33px 0 0 -33px;
-				}
-					.how-it-works-module .info-row .video-area .btn-play .icons {
-						background-position: 0 -44px;
-						width: 48px;
-						height: 48px;
-						margin: 7px 0 0 0;
-					}
-						.how-it-works-module .info-row .video-area .btn-play:hover .icons,
-						.how-it-works-module .info-row .video-area .btn-play:focus .icons {
-							background-position: -48px -44px;
-						}
-			.how-it-works-module .info-row .txt-area {
-				margin: 15px;
-			}
-				.how-it-works-module .info-row .txt-area .txt-td {
-					line-height: 10px;
-				}
-				.how-it-works-module .info-row .txt-area .txt-td p {
-					font-size: 8px;
-					line-height: 16px;
-				}
-		/* .how-it-works-module .step-row */
-		.how-it-works-module .step-row {
-			margin: 38px 16px 0 16px;
-			min-height: 155px;
-		}
-			.how-it-works-module .carousel {
-				min-height: 132px;
-				margin-right: 42px;
-				margin-left: 42px;
-			}
-					.how-it-works-module .row .carousel-control.left,
-					.how-it-works-module .row .carousel-control.right {
-						width: 34px;
-						height: 32px;
-						border: 1px solid #fff;
-						top: 22px;
-					}
-						.how-it-works-module .row .carousel-control.left {
-							left: -42px;
-						}
-						.how-it-works-module .row .carousel-control.right {
-							right: -42px;
-						}
-							.how-it-works-module .row .carousel-control.left .icons,
-							.how-it-works-module .row .carousel-control.right .icons {
-								width: 12px;
-								height: 12px;
-								margin: 8px auto 0 auto;
-							}
-								.how-it-works-module .row .carousel-control.left .icons {
-									background-position: -228px -8px;
-								}
-									.how-it-works-module .row .carousel-control:hover.left .icons {
-										background-position: -252px -8px;
-									}
-								.how-it-works-module .row .carousel-control.right .icons {
-									background-position: -264px -8px;
-								}
-									.how-it-works-module .row .carousel-control:hover.right .icons {
-										background-position: -276px -8px;
-									}
-						.how-it-works-module .carousel-indicators li {
-							width: 9px;
-							height: 9px;
-							margin: 0 2.5px;
-						}
-							.how-it-works-module .carousel-indicators .active {
-								width: 9px;
-								height: 9px;
-							}
-								.how-it-works-module .step-row .module-box {
-									padding: 5px 16px 0 16px;
-									min-height: 85px;
-								}
-									.how-it-works-module .step-row .icon-blue-round {
-										width: 66px;
-										height: 66px;
-									}
-										.how-it-works-module .step-row .icon-blue-round .icons {
-											width: 48px;
-											height: 48px;
-											margin-top: 7px;
-										}
-											.how-it-works-module .step-row .icon-fundraise .icons {
-												background-position: -96px -44px;
-											}
-											.how-it-works-module .step-row .icon-invest .icons {
-												background-position: -144px -44px;
-											}
-											.how-it-works-module .step-row .icon-pay-it-forward .icons {
-												background-position: -192px -44px;
-											}
-									.how-it-works-module .step-row .info-txt {
-										margin: 0 0 0 80px;
-									}
-										.how-it-works-module .step-row .info-txt h4 {
-											font-size: 12px;
-											line-height: 15px;
-											padding-bottom: 1px;
-											margin-top: 12px;
-										}
-										.how-it-works-module .step-row .info-txt p {
-											font-size: 8px;
-											line-height: 16px;
-											letter-spacing: -0.3px;
-										}
-
-	/* .how-it-works-module */
-	.testimonial-module {
-		padding-bottom: 30px;
-	}
-		.testimonial-module .title-testimonial {
-			letter-spacing: 4px;
-			padding-left: 5px;
-			width: 126px;
-			margin: 24px auto 0 auto;
-		}
-			/* .testimonial-module .head-row */
-			.testimonial-module .head-row {
-				padding: 18px 9px 0 9px;
-			}
-				.testimonial-module .head-row li .head-img {
-					margin: 7px;
-				}
-				.testimonial-module .head-row li .head-img.active {
-					border-radius: 5px;
-					margin: 3.5px;
-					padding: 2.5px;
-				}
-					.testimonial-module .head-row li .head-img img {
-						border-radius: 5px;
-					}
-			/* .testimonial-module .info-area */
-			.testimonial-module .info-area {
-				padding: 17px 30px 0 30px;
-			}
-				.testimonial-module .info-area p {
-					font-size: 8px;
-					line-height: 16px;
-					letter-spacing: -0.1px;
-					width: 320px;
-					padding-bottom: 7px;
-				}
-					.testimonial-module .user-group {
-						padding-top: 7px;
-					}
-							.testimonial-module .user-group .link-blue {
-								font-size: 12px;
-							}
-							.testimonial-module .user-group .txt {
-								font-size: 8px;
-								padding: 0 0 12px 0;
-							}
-							.testimonial-module .user-group .btn-blue {
-								font-size: 7px;
-								height: 20px;
-								line-height: 20px;
-								padding-top: 1px;
-								min-width: 146px;
-								letter-spacing: 2px;
-							}
-
-	/* .featured-on-module */
-	.featured-on-module {
-		padding-bottom: 20px;
-	}
-		.featured-on-module .title-featured-on {
-			font-size: 10px;
-			letter-spacing: 5px;
-			padding-left: 10px;
-			width: 150px;
-			margin: 21px auto 21px auto;
-		}
-			/* .featured-on-module .carousel-main */
-			.featured-on-module .carousel-main {
-				min-height: 88px;
-			}
-				/* .featured-on-module .carousel-main */
-				.featured-on-module .carousel-main {
-					min-height: 88px;
-					margin-right: 32px;
-					margin-left: 32px;
-				}
-					.featured-on-module .carousel-main .logo-ul li {
-						height: 85px;
-					}
-						.featured-on-module .logo-fast-mpany {
-							background-size: 77px auto;
-							width: 77px;
-							height: 11.5px;
-						}
-						.featured-on-module .logo-ehe-new-hork-eimes {
-							background-size: 68.5px auto;
-							width: 68.5px;
-							height: 56.5px;
-						}
-						.featured-on-module .logo-shareable {
-							background-size: 72px auto;
-							width: 72px;
-							height: 10.5px;
-						}
-						.featured-on-module .logo-philanthropy {
-							background-size: 76.5px auto;
-							width: 76.5px;
-							height: 14px;
-						}
-						.featured-on-module .logo-clean-technica {
-							background-size: 76.5px auto;
-							width: 76.5px;
-							height: 22px;
-						}
-			.featured-on-module .carousel-control.left,
-			.featured-on-module .carousel-control.right {
-				border: 1px solid #fff;
-				width: 24px;
-				height: 24px;
-				top: 30px;
-			}
-				.featured-on-module .carousel-control.left {
-					left: -34px;
-				}
-				.featured-on-module .carousel-control.right {
-					right: -34px;
-				}
-					.featured-on-module .carousel-control.left .icons,
-					.featured-on-module .carousel-control.right .icons {
-						width: 12px;
-						height: 12px;
-						margin: 0 auto 3px 0;
-					}
-						.featured-on-module .carousel-control.left .icons {
-							background-position: -144px -8px;
-						}
-							.featured-on-module .carousel-control:hover.left .icons {
-								background-position: -168px -8px;
-							}
-						.featured-on-module .carousel-control.right .icons {
-							background-position: -180px -8px;
-						}
-							.featured-on-module .carousel-control:hover.right .icons {
-								background-position: -192px -8px;
-							}
-
-
-
-	/* .newsletter-module */
-	.newsletter-module {
-		height: 224px;
-	}
-	.newsletter-module .img-area img {
-		height: 225px;
-	}
-	.newsletter-module .img-area .mobile-img {
-		min-height: 225px;
-	}
-		.newsletter-module .title-newsletter {
-			letter-spacing: 2.5px;
-			padding-left: 6px;
-			width: 173px;
-			height: 22px;
-			line-height: 22px;
-			margin: 24px auto;
-		}
-				/* .newsletter-module .container */
-				.newsletter-module .group-main p {
-					font-size: 10px;
-					line-height: 12px;
-					padding: 25px 0 19px 0;
-				}
-				.newsletter-module .group-main .group {
-					min-height: 56px;
-					margin: 0 16px;
-					padding: 15px 15px 15px 36px;
-				}
-					.newsletter-module .group-main .group .btn-sign-up {
-						font-size: 7px;
-						letter-spacing: 2px;
-						width: 78px;
-						height: 26px;
-						line-height: 26px;
-                        border: none;
-					}
-					.newsletter-module .group-main .group .inputs {
-						margin-right: 85px;
-						height: 26px;
-					}
-						.newsletter-module .group-main .group .inputs input {
-							font-size: 10px;
-							height: 26px;
-							line-height: 26px;
-						}
-
-
-
-/* .contents */
-.contents {
-	min-height: 92px;
-}
-	.top150 {
-		margin-top: 92px;
-	}
-
-	/* .titles */
-	.titles.container {
-		padding: 26px 0 0 0;
-		min-height: 56.5px;
-	}
-		.titles.container .title-get-involved {
-			margin-right: 15px;
-			min-width: 145px;
-			letter-spacing: 5px;
-			padding-left: 7px;
-		}
-		.title-h1 {
-			font-size: 24px;
-			line-height: 30px;
-		}
-
-
-
-	/* sign in page */
-	.contents.sign-in-contents {
-		min-height: 450px;
-		margin-top: 91px;
-	}
-	.sign-in {
-		padding: 26px 15px 38px 31px;
-	}
-		.sign-in .title-blue-border {
-			border-width: 1px;
-		}
-		.sign-in .title-sign-in {
-			font-size: 11px;
-			height: 22px;
-			line-height: 22px;
-			padding-left: 13px;
-			padding-right: 10px;
-			letter-spacing: 5px;
-		}
-		/* .sign-in .sign-in-left */
-		.sign-in .sign-in-left {
-			float: none;
-			padding-top: 46px;
-		}
-			.sign-in .sign-in-left h2 {
-				font-size: 24px;
-				line-height: 26px;
-				margin-bottom: 7px;
-			}
-			.sign-in .sign-in-left p {
-				font-size: 8px;
-				line-height: 16px;
-				padding-left: 0;
-			}
-			.sign-in .sign-in-left .account {
-				margin-top: 16px;
-			}
-			.sign-in .sign-in-left .account p {
-				line-height: 10px;
-			}
-			.sign-in .sign-in-left .account a {
-				font-size: 8px;
-				line-height: 10px;
-				padding-left: 0;
-			}
-			/* .sign-in .login-area */
-			.sign-in .login-area {
-				padding: 20px 15px 0 0;
-			}
-				.sign-in .login-area .input-wrap {
-					height: 37px;
-					margin-bottom: 7px;
-				}
-					.sign-in .login-area .input-wrap input {
-						font-size: 8px;
-						line-height: 10px;
-						padding-left: 20px;
-						padding-right: 20px;
-						letter-spacing: 5px;
-					}
-				.sign-in .check-wrap {
-					min-height: 35px;
-					padding: 2px 0 14px 0;
-				}
-				.sign-in .login-area .btn-login {
-					padding-left: 11px;
-					padding-right: 5px;
-					height: 23px;
-					line-height: 23px;
-					letter-spacing: 2px;
-					font-size: 7px;
-				}
-
-
-	/* sign up page */
-	.contents.sign-up-contents {
-		margin-top: 91px;
-		min-height: 289px;
-	}
-	.sign-up {
-		padding: 26px 15px 12px 28px;
-	}
-		.sign-up .title-blue-border {
-			border-width: 1px;
-		}
-		.sign-up .title-sign-up {
-			font-size: 11px;
-			height: 22px;
-			line-height: 22px;
-			padding-left: 13px;
-			padding-right: 6px;
-			letter-spacing: 5px;
-		}
-		/* .sign-up .sign-up-left */
-		.sign-up .sign-up-left {
-			float: none;
-			padding-top: 41px;
-			padding-left: 2px;
-		}
-			.sign-up .sign-up-left h2 {
-				font-size: 24px;
-				line-height: 26px;
-				margin-bottom: 6px;
-			}
-			.sign-up .sign-up-left p {
-				font-size: 8px;
-				line-height: 16px;
-				padding-left: 0;
-			}
-			.sign-up .sign-up-left .account {
-				margin-top: 16px;
-			}
-			.sign-up .sign-up-left a {
-				font-size: 8px;
-				line-height: 16px;
-			}
-			/* .sign-up .reg-area */
-			.sign-up .reg-area {
-				padding: 14px 15px 0 3px;
-			}
-				.sign-up .reg-area .input-wrap {
-					height: 37px;
-					margin-bottom: 7px;
-				}
-				.sign-up .reg-area .input-wrap.less-margin {
-					margin-bottom: 6px;
-				}
-				.sign-up .reg-area .input-wrap.high-margin {
-					margin-bottom: 7px;
-				}
-				.sign-up .reg-area .input-wrap.higher-margin {
-					margin-bottom: 12px;
-				}
-					.sign-up .reg-area .input-wrap input {
-						font-size: 8px;
-						line-height: 10px;
-						padding-left: 20px;
-						padding-right: 20px;
-						letter-spacing: 5px;
-					}
-				.sign-up .check-wrap {
-					min-height: 15px;
-					padding: 1px 0 0 0;
-				}
-				.sign-up .reg-area p {
-					font-size: 7px;
-					line-height: 14px;
-					padding-left: 22px;
-					padding-right: 90px;
-					margin-bottom: 11px;
-				}
-				.sign-up .reg-area .btn-signup {
-					padding-left: 15px;
-					padding-right: 13px;
-					height: 24px;
-					line-height: 24px;
-					letter-spacing: 2px;
-				}
-
-
-	/* what do page */
-	.contents.what-we-do-contents {
-		min-height: 500px;
-		margin-top: 91px;
-	}
-		/* .article-detail */
-		.article-detail,
-		.what-we-do-contents .article-detail {
-			padding: 26px 15px 26px 32px;
-		}
-			.article-detail .title-blue-border {
-				border-width: 1px;
-			}
-			.article-detail .title-do {
-				padding-left: 18px;
-				padding-right: 15px;
-				font-size: 11px;
-				height: 22px;
-				line-height: 22px;
-				letter-spacing: 4px;
-				margin-right: 0px;
-			}
-			.article-detail .detail-left {
-				padding-top: 40px;
-			}
-			.article-detail .detail-left .title-img {
-				width: 100%;
-				height: 156px;
-				margin-bottom: 12px;
-			}
-			.article-detail .detail-left h2 {
-				font-size: 24px;
-				line-height: 28px;
-			}
-			.article-detail .detail-left p {
-				font-size: 8px;
-				line-height: 16px;
-				margin-left: -3px;
-				margin-top: 11px;
-				margin-bottom: 16px;
-				padding-right: 31px;
-			}
-			.article-detail .detail-left .btn-group {
-				padding-top: 7px;
-				padding-right: 0;
-			}
-				.article-detail .detail-left .btn-group .btn-blue {
-					font-size: 7px;
-					line-height: 22px;
-					height: 22px;
-					letter-spacing: 2px;
-					margin-right: 8px;
-					margin-bottom: 11px;
-				}
-				.article-detail .detail-left .btn-group .btn-leasing {
-					padding-left: 9px;
-					padding-right: 9px;
-					margin-right: 18px;
-					margin-top: 2px;
-				}
-				.article-detail .detail-left .btn-group .btn-communities {
-					padding-left: 7px;
-					padding-right: 9px;
-					margin-bottom: 14px;
-					margin-right: 0;
-				}
-				.article-detail .detail-left .btn-group .btn-services {
-					padding-left: 19px;
-					padding-right: 17px;
-					clear: both;
-				}
-
-
-	/* about us page */
-	.contents.about-us-contents {
-		margin-top: 91px;
-	}
-	.about-us {
-		padding: 26px 0 36px 30px;
-	}
-		.about-us .title-blue-border {
-			border-width: 1px;
-		}
-		.about-us .title-about-us {
-    		font-size: 11px;
-			height: 22px;
-			line-height: 22px;
-			padding-left: 13px;
-			padding-right: 15px;
-			margin-right: 15px;
-			letter-spacing: 4px;
-		}
-		.about-us .about-us-left {
-			padding-right: 10px;
-			padding-top: 61px;
-		}
-		.about-us .about-us-left h2 {
-			font-size: 21px;
-			line-height: 31px;
-		}
-		.about-us .about-us-left p {
-			font-size: 8px;
-			line-height: 16px;
-			margin-top: 12px;
-			margin-bottom: 24px;
-			padding-right: 135px;
-		}
-		.about-us .about-us-left .btn-works {
-			font-size: 7px;
-			line-height: 27px;
-			height: 27px;
-			letter-spacing: 2px;
-			padding-left: 18px;
-			padding-right: 17px;
-			margin-left: 2px;
-		}
-		/* .mains-tabs */
-		.mains-tabs .container {
-			width: 100%;
-		}
-		.mains-tabs .tab-index .row {
-			padding: 0;
-		}
-		.mains-tabs .tab-index .row .col-lg-3 {
-			width: 50%;
-			float: left;
-		}
-		.mains-tabs .tab-index .row .col-lg-3:nth-child(2n+1) {
-			padding-right: 2px;
-		}
-			.mains-tabs .tab-index .row .col-lg-3 a {
-				font-size: 11px;
-				height: 30px;
-				line-height: 30px;
-				border-width: 2px;
-			}
-			.mains-tabs .tab-index .row .col-lg-3 a:hover {
-				border-width: 2px;
-			}
-			.mains-tabs .tab-index .row .col-lg-3 a.active {
-				border-width: 2px;
-			}
-		.mains-tabs .tab-content {
-			min-height: 450px;
-		}
-		.mains-tabs .tab-content .tab-why,
-		.mains-tabs .tab-content .tab-how,
-		.mains-tabs .tab-content .tab-funded,
-		.mains-tabs .tab-content .tab-involved {
-			padding-left: 16px;
-			padding-right: 15px;
-		}
-			.mains-tabs .tab-content .img-left {
-				float: none;
-				margin-top: 23px;
-				width: 100%;
-				height: 248px;
-			}
-			.mains-tabs .tab-content .content-right {
-				margin-left: 14px;
-			}
-				.mains-tabs .tab-content .content-right p {
-					font-size: 8px;
-					line-height: 17px;
-				}
-				.mains-tabs .tab-content .tab-why .content-right p {
-					padding-top: 21px;
-					padding-right: 28px;
-				}
-				.mains-tabs .tab-content .tab-how p {
-					font-size: 7px;
-					line-height: 14px;
-				}
-				.mains-tabs .tab-content .tab-how .content-right,
-				.mains-tabs .tab-content .tab-funded .content-right  {
-					padding-top: 22px;
-				}
-					.mains-tabs .tab-content .tab-how .content-right p,
-					.mains-tabs .tab-content .tab-funded .content-right p {
-						margin-bottom: 14px;
-						padding-right: 16px;
-					}
-				.mains-tabs .tab-content .tab-funded .content-right  {
-					padding-top: 18px;
-				}
-					.mains-tabs .tab-content .tab-funded .content-right p {
-						padding-right: 19px;
-						padding-top: 2px;
-						margin-bottom: 10px;
-					}
-				.mains-tabs .tab-content .tab-involved .content-right {
-					padding-top: 26px;
-					margin-left: 0;
-				}
-					.mains-tabs .tab-content .tab-involved .btn-blue {
-						margin-right: 0;
-						margin-bottom: 13px;
-						font-size: 7px;
-						line-height: 22px;
-						width: 153px;
-						height: 22px;
-						letter-spacing: 3px;
-					}
-					.mains-tabs .tab-content .tab-involved .btn-blue:nth-child(2n) {
-						float: right;
-					}
-
-
-
-	/* get involved page */
-
-		/* .info-area */
-		.info-area.container {
-			padding: 0 15px 18px 30px;
-		}
-			.info-area.container .title-h1 {
-				padding: 16px 110px 9px 0;
-			}
-			.info-area.container .txt {
-				font-size: 8px;
-				line-height: 16px;
-				padding-right: 35px;
-				padding-bottom: 8px;
-			}
-
-		/* .list-area */
-		.list-area.container {
-			padding: 0 0 20px 0;
-		}
-			/* .list-area .row */
-			.list-area .row {
-				width: 375px;
-			}
-					/* .list-area .img-main */
-					.list-area .mobile-show.txt-table {
-						bottom: 23px;
-					}
-						.list-area .mobile-show.txt-table .txt {
-							font-size: 21px;
-							height: 25px;
-							line-height: 25px;
-						}
-					.list-area .img-main .funded-round {
-						width: 85px;
-						height: 85px;
-						padding: 3px;
-						bottom: -72px;
-						margin: 0 0 0 -42px;
-					}
-						.get-involved-contents .funded-round .status-indicator {
-							margin: 2px 0 0 0;
-							left: -2px;
-						}
-						.get-involved-contents .funded-round .round-depict {
-							font-size: 9px;
-							width: 55px;
-							margin: 3px 0 0 -27px;
-						}
-						.get-involved-contents .funded-round .status-indicator input {
-							font-size: 21px !important;
-							margin-top: 17px !important;
-						}
-						.get-involved-contents .past-projects-module .funded-round .round-depict {
-							margin: 6px 0 0 -27px;
-						}
-						.get-involved-contents .past-projects-module .funded-round .status-indicator input {
-							font-size: 21px !important;
-							margin-top: -65px !important;
-							margin-left: -25px !important;
-						}
-						.get-involved-contents .past-projects-module .funded-round .status-indicator input.smaller {
-                        }
-					/* .list-area .info-main */
-					.list-area .info-main {
-						padding-top: 2px;
-					}
-						.list-area .info-main .blue-bar,
-						.list-area .info-main .dark-blue-bar {
-							font-size: 9px;
-							height: 23px;
-							line-height: 23px;
-							padding: 0 20px;
-							margin-top: 5px;
-							margin-right: 17px;
-							margin-left: 17px;
-						}
-				/* .list-area  .rights */
-				.list-area .row .rights {
-					margin: 0 31px;
-					padding: 46px 0 20px 0;
-				}
-					.list-area .row .rights .btn-icon-gray {
-						width: 35px;
-						height: 30px;
-					}
-					.list-area .row .rights .share-txt {
-						font-size: 8px;
-						top: 51px;
-						left: 128px;
-					}
-					.list-area .row .rights p {
-						font-size: 8px;
-						line-height: 16px;
-						padding-top: 37px;
-						padding-right: 12px;
-						padding-bottom: 22px;
-					}
-					.list-area .row .rights .bottom-bar {
-						padding-bottom: 24px;
-					}
-						.list-area .row .rights .bottom-bar .btn-read-more {
-							font-size: 7px;
-							letter-spacing: 2px;
-							padding-left: 7px;
-							width: 78px;
-							height: 22px;
-							line-height: 22px;
-						}
-						.list-area .row .rights .bottom-bar .social-ul {
-							top: 29px;
-						}
-							.list-area .row .rights .bottom-bar .social-ul li {
-								margin-right: 9px;
-							}
-
-		/* .past-projects-module */
-		  .past-projects-module .title-past-projects {
-			  letter-spacing: 5px;
-			  padding-left: 6px;
-			  width: 174px;
-			  margin: 19px auto 27px auto;
-		  }
-			  /* .past-projects-module .carousel-main */
-			  .past-projects-module .carousel-main {
-				  margin-right: 40px;
-				  margin-left: 40px;
-			  }
-				  /* .past-projects-module .carousel .item */
-				  .past-projects-module .carousel .item {
-					  min-height: 290px;
-				  }
-						  .past-projects-module .carousel .spacing {
-							  padding: 0 9px 0 10px;
-						  }
-							  /* .past-projects-module .carousel .img-main */
-							  .past-projects-module .img-main .img-gradient {
-								  height: 60%;
-								  top: 40%;
-							  }
-							  .past-projects-module .img-main .funded-round {
-								  width: 85px;
-								  height: 85px;
-								  padding: 5px;
-								  right: 3px;
-								  bottom: -89px;
-							  }
-							  /* .past-projects-module .carousel .info-main */
-							  .past-projects-module .info-main {
-								  padding: 14px 0 25px 0;
-							  }
-								  .past-projects-module .info-main h2 {
-									  line-height: 17px;
-								  }
-									  .past-projects-module .info-main h2 a {
-										  font-size: 15px;
-									  }
-								  .past-projects-module .info-main .time {
-									  font-size: 9px;
-									  padding: 6px 0 11px 0;
-								  }
-								  .past-projects-module .info-main .bottom-bar {
-									  padding-right: 17px;
-								  }
-									  .past-projects-module .info-main .bottom-bar .btn-read-more {
-										  font-size: 7px;
-										  letter-spacing: 2px;
-										  padding-left: 6px;
-										  width: 78px;
-										  height: 22px;
-										  line-height: 22px;
-									  }
-							  .past-projects-module .img-main .img-link img {
-								  height: 185px;
-							  }
-							  .past-projects-module .carousel-control.left,
-							  .past-projects-module .carousel-control.right {
-								  width: 25px;
-								  height: 24px;
-								  top: 108px;
-							  }
-								  .past-projects-module .carousel-control.left {
-									  left: -36px;
-								  }
-								  .past-projects-module .carousel-control.right {
-									  right: -36px;
-								  }
-									  .past-projects-module .carousel-control.left .icons,
-									  .past-projects-module .carousel-control.right .icons {
-										  width: 12px;
-										  height: 12px;
-										  margin: 0 auto 4px auto;
-									  }
-										  .past-projects-module .carousel-control.left .icons {
-											  background-position: -144px -8px;
-										  }
-											  .past-projects-module .carousel-control:hover.left .icons {
-												  background-position: -168px -8px;
-											  }
-										  .past-projects-module .carousel-control.right .icons {
-											  background-position: -180px -8px;
-										  }
-											  .past-projects-module .carousel-control:hover.right .icons {
-												  background-position: -192px -8px;
-											  }
-
-
-	/* project details page */
-	.details-active-project-module .banners.min-height455 {
-		min-height: 320px;
-	}
-		.details-active-project-module .banners img {
-			height: 320px;
-		}
-				/* .details-active-project-module .banner-section */
-				.details-active-project-module .banner-section .container {
-					padding: 25px 0 0 0;
-					min-height: 320px;
-				}
-					.details-active-project-module .banner-section .title-active-project {
-						letter-spacing: 6px;
-						padding-left: 10px;
-						width: 189px;
-					}
-					.details-active-project-module .banner-section .title-h1 {
-						font-size: 21px;
-						bottom: 20px;
-					}
-					.details-active-project-module .banner-section .funded-round {
-						width: 86px;
-						height: 86px;
-						padding: 4px;
-						margin: 0 0 0 -43px;
-						bottom: -73px;
-					}
-						.details-active-project-module .banner-section .funded-round .round-depict {
-							font-size: 9.66px;
-							width: 85px;
-							margin: 3px 0 0 -44px;
-						}
-						.details-active-project-module .banner-section .funded-round .status-indicator {
-							margin-top: 2px;
-						}
-						.details-active-project-module .banner-section .funded-round .status-indicator input {
-							font-size: 20.2px !important;
-							margin-top: 16px !important;
-						}
-							.details-active-project-module .banner-section .funded-round .status-indicator input.smaller {
-								font-size: 16.2px !important;
-								-webkit-transition: font-size 0.25s ease;
-								transition: font-size 0.25s ease;
-							}
-				/* .details-active-project-module .info-section */
-				.details-active-project-module .info-section .container {
-					padding: 2px 14px 0 16px;
-				}
-					/* .details-active-project-module .info-main */
-					.details-active-project-module .info-main {
-						padding-bottom: 24px;
-					}
-						.details-active-project-module .info-main .blue-bar,
-						.details-active-project-module .info-main .dark-blue-bar {
-							font-size: 9.66px;
-							height: 23px;
-							line-height: 23px;
-							padding: 0 20px;
-							margin-top: 6px;
-						}
-					/* .details-active-project-module .video-main */
-					.details-active-project-module .video-main {
-						padding: 0 15px 27px 15px;
-					}
-						.details-active-project-module .video-area .video,
-						.details-active-project-module .video-area .video img,
-						.details-active-project-module .video-area .video iframe {
-							height: 201px;
-						}
-						.details-active-project-module .video-area .video img,
-						.details-active-project-module .video-area .video iframe {
-							width: 100%;
-						}
-							.details-active-project-module .video-area .btn-play {
-								width: 65px;
-								height: 65px;
-								margin: -32.5px 0 0 -32.5px;
-							}
-								.details-active-project-module .video-area .btn-play .icons {
-									background-position: 0 -44px;
-									width: 48px;
-									height: 48px;
-									margin: 6px 0 0 0;
-								}
-									.details-active-project-module .video-area .btn-play:hover .icons,
-									.details-active-project-module .video-area .btn-play:focus .icons {
-										background-position: -48px -44px;
-									}
-							.details-active-project-module .mobile-bottom-bar {
-								margin: 15px 0 0 0;
-								padding-bottom: 42px;
-							}
-									.details-active-project-module .mobile-bottom-bar .social-ul li {
-										margin-right: 9px;
-									}
-									.details-active-project-module .mobile-bottom-bar .share-txt {
-										font-size: 8px;
-										padding: 20px 0 0 0;
-										margin-left: -5px;
-									}
-							.details-active-project-module .txt-area .btn-icon-gray {
-								width: 35px;
-							}
-
-							.details-active-project-module .txt-area .txt-td {
-								line-height: 10px;
-
-							}
-								.details-active-project-module .txt-area .txt-td .font20 {
-									font-size: 10px;
-									line-height: 18px;
-									padding: 12px 0 16px 0;
-								}
-								.details-active-project-module .txt-area .txt-td .font14 {
-									font-size: 8px;
-									line-height: 16px;
-								}
-
-			/* .project-updates-module */
-			.project-updates-module .container {
-				padding: 28px 16px 10px 16px;
-			}
-					/* .project-updates-module .main-area */
-					.project-updates-module .main-area .title-project-updates {
-						width: 192px;
-						letter-spacing: 4px;
-						padding-left: 10px;
-						margin: 0 auto 8px auto;
-					}
-					 /* .project-updates-module .list-area */
-					 .project-updates-module .list-area .row {
-						 padding: 20px 0 0 0;
-						 border-bottom: 2.5px solid #dcdcdc;
-					 }
-						.project-updates-module .list-area .left-date {
-							 width: 111px;
-						}
-							 .project-updates-module .list-area .left-date .date-txt {
-								 padding: 0 25px 0 16px;
-							 }
-							 .project-updates-module .list-area .left-date .month-txt {
-								 padding: 0 25px 0 20px;
-							 }
-								 .project-updates-module .list-area .left-date .date-txt {
-									 font-size: 61.54px;
-									 line-height: 55px;
-									 margin-top: 2px;
-								 }
-								 .project-updates-module .list-area .left-date .month-txt {
-									 font-size: 12px;
-									 letter-spacing: 11px;
-								 }
-					     .project-updates-module .list-area .main-info {
-							 margin-left: 111px;
-					     }
-							.project-updates-module .list-area .main-info .title-h4 {
-								 line-height: 15px;
-								 padding-bottom: 5px;
-							}
-								 .project-updates-module .list-area .main-info .title-h4 a {
-									 font-size: 9px;
-								 }
-							.project-updates-module .list-area .main-info p {
-								 font-size: 8px;
-								 line-height: 16px;
-								 padding-bottom: 23px;
-							}
-							.project-updates-module .list-area .main-info .social-ul {
-								 margin-bottom: 17px;
-								 top: 78px;
-								 left: -105px;
-							 }
-								 .project-updates-module .list-area .main-info .social-ul li {
-									 margin-right: 7px;
-								 }
-									.project-updates-module .list-area .main-info .btn-icon-gray {
-										width: 25px;
-										height: 22px;
-										border: 1px solid #fff;
-									}
-										.project-updates-module .list-area .main-info .btn-icon-gray .icons {
-											background-size: 336px auto;
-											width: 12px;
-											height: 12px;
-											margin-top: 4px;
-										}
-											.project-updates-module .list-area .main-info .btn-icon-gray .icon-fb {
-												background-position: -72px -8px;
-											}
-												.project-updates-module .list-area .main-info .btn-icon-gray:hover .icon-fb {
-													background-position: -84px -8px;
-												}
-											.project-updates-module .list-area .main-info .btn-icon-gray .icon-tw {
-												background-position: -96px -8px;
-											}
-												.project-updates-module .list-area .main-info .btn-icon-gray:hover .icon-tw {
-													background-position: -108px -8px;
-												}
-											.project-updates-module .list-area .main-info .btn-icon-gray .icon-gg {
-												background-position: -120px -8px;
-											}
-												.project-updates-module .list-area .main-info .btn-icon-gray:hover .icon-gg {
-													background-position: -132px -8px;
-												}
-
-				/* .project-updates-module .right-aside */
-				.project-updates-module .right-aside {
-					margin-top: 19px;
-				}
-					.project-updates-module .right-aside .module-box {
-						min-height: 113px;
-						padding: 6px 0 16px 0;
-						margin: 0 16px 10px 16px;
-					}
-						.project-updates-module .right-aside .module-box .type-txt {
-							font-size: 10px;
-							line-height: 15px;
-							padding: 5px 0 6px 0;
-							width: 148px;
-						}
-						.project-updates-module .right-aside .module-box .value-txt {
-							font-size: 36px;
-							line-height: 35px;
-							padding: 0 0 10px 0;
-							width: 148px;
-						}
-						.project-updates-module .right-aside .module-box .title-h5 {
-							font-size: 8px;
-							border-bottom: 1px solid #c3c3c3;
-							height: 16px;
-							line-height: 16px;
-							top: 9px;
-							right: 22px;
-						}
-						.project-updates-module .right-aside .module-box ul {
-							padding: 17px 0 12px 0;
-							width: 44%;
-							top: 17px;
-							right: 22px;
-						}
-							.project-updates-module .right-aside .module-box li {
-								font-size: 7px;
-								line-height: 16px;
-							}
-						.project-updates-module .right-aside .btn-i-want-to-donate {
-							letter-spacing: 2px;
-							padding-left: 6px;
-							width: 111px;
-							height: 22px;
-							line-height: 22px;
-							bottom: 12px;
-							left: 16px;
-						}
-
-			/* .donors-module */
-			.donors-module .titles.container {
-				min-height: 50px;
-			}
-				.titles.container .title-donors {
-					min-width: 96px;
-					width: 96px;
-					letter-spacing: 4px;
-					padding-left: 6px;
-				}
-			.donors-module .mains-tabs .tab-index .row {
-				margin-top: -1px;
-			}
-			.donors-module .mains-tabs .tab-content {
-				min-height: 354px;
-			}
-			.donors-module .tab-content .row {
-				margin: 2px 9px 50px 2px;
-			}
-				.donors-module .tab-content .row .col-md-6 {
-					padding: 23px 0 0 0;
-				}
-					.donors-module .tab-content .head-img {
-						width: 78px;
-					}
-						.donors-module .tab-content .head-img img {
-							width: 63px;
-							height: 63px;
-						}
-					.donors-module .info-box {
-						margin-left: 78px;
-					}
-					.donors-module .info-box .title-h4 {
-						padding: 0 0 4px 0;
-						margin-top: -2px;
-					}
-						.donors-module .info-box .title-h4 a {
-							font-size: 9px;
-						}
-					.donors-module .info-box p {
-						font-size: 8px;
-						line-height: 17px;
-						padding: 0 22px 0 0;
-					}
-
-
-	/* solar ambassador program page */
-	.contents.solar-ambassador-program-contents {
-		min-height: 800px;
-		margin-top: 91px;
-	}
-		/* .article-detail */
-		.solar-contents .article-detail {
-			padding: 26px 15px 12px 32px;
-		}
-			.solar-contents .article-detail .title-blue-border {
-				border-width: 1px;
-			}
-			.solar-contents .article-detail .title-solar {
-				width: auto;
-				font-size: 11px;
-				height: 22px;
-				line-height: 22px;
-				padding-left: 13px;
-				padding-top: 0;
-				padding-right: 8px;
-				letter-spacing: 4px;
-			}
-			.solar-contents .article-detail .detail-left {
-				padding-right: 0px;
-				padding-top: 40px;
-			}
-			.solar-contents .article-detail .detail-left .title-img {
-				margin-bottom: 11px;
-			}
-			.solar-contents .article-detail .detail-left p {
-				margin-top: 5px;
-				padding-left: 3px;
-			}
-			.solar-contents .article-detail .detail-left .title-img {
-				margin-bottom: 11px;
-			}
-			.solar-contents .article-detail .detail-left .btn-group {
-				padding-top: 0;
-				padding-right: 0;
-				margin-top: -5px;
-			}
-			.solar-contents .article-detail .detail-left .btn-group .btn-blue {
-				height: 23px;
-				line-height: 23px;
-				margin-bottom: 14px;
-				margin-left: 1px;
-			}
-				.solar-contents .article-detail .detail-left .btn-group .btn-application {
-					padding-left: 16px;
-					padding-right: 14px;
-					margin-top: 0;
-					margin-right: 18px;
-				}
-				.solar-contents .article-detail .detail-left .btn-group .btn-team {
-					padding-left: 11px;
-					padding-right: 12px;
-					margin-bottom: 11px;
-					margin-right: 0;
-				}
-				.solar-contents .article-detail .detail-left .btn-group .btn-project {
-					padding-left: 21px;
-					padding-right: 22px;
-					margin-right: 0;
-					clear: both;
-				}
-
-
-	/* partners page */
-	.contents.partners-contents {
-		min-height: 800px;
-		margin-top: 91px;
-	}
-		/* .partners-contents .container */
-		.partners-contents .container {
-			padding: 26px 0 3px 13px;
-		}
-		.partners-contents .title-blue-border {
-			border-width: 1px;
-		}
-		.partners-contents .title-partners {
-			font-size: 11px;
-			height: 22px;
-			line-height: 22px;
-			padding-left: 18px;
-			padding-right: 15px;
-			margin-right: 15px;
-			margin-bottom: 20px;
-			letter-spacing: 3px;
-		}
-		.partners-contents .titles .title-primary {
-			font-size: 24px;
-			line-height: 26px;
-			margin-bottom: 5px;
-			padding-left: 17px;
-		}
-		.partners-contents .titles .title-sub {
-			font-size: 8px;
-			line-height: 16px;
-			padding-left: 18px;
-		}
-		/* .partners-contents .list */
-		.partners-contents .list-wrap {
-			margin-top: 16px;
-		}
-			.partners-contents .list-wrap .item-wrap {
-				height: auto;
-				min-height: 0;
-				margin-bottom: 0;
-				position: relative;
-			}
-			.partners-contents .list-wrap .item-wrap.large-spacing {
-				margin-bottom: 12px;
-			}
-			.partners-contents .left-img {
-				width: 100px;
-				height: 100px;
-				margin-top: 0;
-				margin-left: 2px;
-			}
-			.partners-contents .content-info {
-				margin-left: 109px;
-				height: auto;
-				overflow: auto;
-				min-height: 0;
-			}
-				.partners-contents .content-info h4 {
-					font-size: 15px;
-					line-height: 18px;
-					margin-bottom: 4px;
-					padding-top: 18px;
-				}
-				.partners-contents .content-info h4 a {
-					font-size: 15px;
-				}
-				.partners-contents .content-info p {
-					font-size: 8px;
-					line-height: 16px;
-					padding-right: 20px;
-					padding-left: 1px;
-				}
-			.partners-contents .btn-wrap {
-				position: absolute;
-				left: -188px;
-				top: 100px;
-			}
-				.partners-contents .btn-wrap .btn-blue {
-					height: 22px;
-					line-height: 22px;
-					padding-left: 24px;
-					padding-right: 25px;
-					letter-spacing: 2px;
-				}
-			/* .partners-contents .pager-info */
-			.partners-contents .pager-info {
-				margin-top: -20px;
-				margin-right: 9px;
-				margin-bottom: 4px;
-				float: right;
-			}
-				.partners-contents .pager-info li {
-					float: left;
-					margin-right: 8px;
-				}
-					.partners-contents .pager-info li a {
-						padding: 0 10px;
-						font-size: 8px;
-						line-height: 20px;
-						height: 20px;
-					}
-
-		/* .sponsoring-organizations-module */
-		.sponsoring-organizations-module {
-			min-height: 225px;
-		}
-		.sponsoring-organizations-module .container {
-			padding: 25px 12px 0 12px;
-		}
-			.sponsoring-organizations-module .title-sponsoring-organizations {
-				font-size: 9px;
-				width: 248px;
-				letter-spacing: 4px;
-				padding-left: 7px;
-				margin-bottom: 35px;
-			}
-				/* .sponsoring-organizations-module .carousel-main */
-				.sponsoring-organizations-module .carousel-main {
-					margin-right: 37px;
-					margin-left: 37px;
-				}
-					.sponsoring-organizations-module .logo-ul li {
-						height: 100px;
-					}
-							.sponsoring-organizations-module .logo-the-san-francisco {
-								background-size: 83px auto;
-								width: 83px;
-								height: 83px;
-							}
-							.sponsoring-organizations-module .logo-toyota-togethergreen {
-								background-size: 96.5px auto;
-								width: 96.5px;
-								height: 31.5px;
-							}
-							.sponsoring-organizations-module .logo-sun-shot {
-								background-size: 67px auto;
-								width: 67px;
-								height: 20.5px;
-							}
-							.sponsoring-organizations-module .logo-patagonia {
-								background-size: 86px auto;
-								width: 86px;
-								height: 27px;
-							}
-				.sponsoring-organizations-module .carousel-control.left,
-				.sponsoring-organizations-module .carousel-control.right {
-					width: 25px;
-					height: 24px;
-					border: 1px solid #fff;
-					top: 37px;
-				}
-					.sponsoring-organizations-module .carousel-control.left {
-						left: -38px;
-					}
-					.sponsoring-organizations-module .carousel-control.right {
-						right: -38px;
-					}
-						.sponsoring-organizations-module .carousel-control.left .icons,
-						.sponsoring-organizations-module .carousel-control.right .icons {
-							width: 12px;
-							height: 12px;
-							margin: 0 auto 3px auto;
-						}
-							.sponsoring-organizations-module .carousel-control.left .icons {
-								background-position: -144px -8px;
-							}
-								.sponsoring-organizations-module .carousel-control:hover.left .icons {
-									background-position: -168px -8px;
-								}
-							.sponsoring-organizations-module .carousel-control.right .icons {
-								background-position: -180px -8px;
-							}
-								.sponsoring-organizations-module .carousel-control:hover.right .icons {
-									background-position: -192px -8px;
-								}
-
-
-
-
-	/* blog page */
-	.titles.container .title-blog {
-		margin-right: 11px;
-		min-width: 70px;
-		letter-spacing: 4px;
-		padding-left: 7px;
-		margin-top: -1px;
-	}
-
-	/* .grid-data */
-	.grid-data.container {
-		padding: 0;
-	}
-		/* .form-area */
-		.form-area {
-			padding: 0 0 6px 15px;
-			min-height: 25px;
-		}
-				.form-area .width167 .btn-default,
-				.form-area .width167.input-search {
-					width: 109px;
-				}
-				/* .input-search */
-				.input-search {
-					padding: 0 22px 0 15px;
-					height: 25px;
-					line-height: 25px;
-				}
-					.input-search input {
-						font-size: 8.335px;
-						letter-spacing: 3px;
-						height: 25px;
-						line-height: 10px;
-					}
-					.input-search .icon-search {
-						background-position: -264px -44px;
-						width: 12px;
-						height: 12px;
-						top: 5px;
-						right: 6px;
-					}
-						.input-search .icon-search:hover {
-							background-position: -276px -44px;
-					}
-			/* .grid-area.row */
-			.grid-area.row {
-				min-height: 50px;
-			}
-				.grid-area.row .img-main,
-				.grid-area.row .video,
-				.grid-area.row .video iframe {
-					height: 194px;
-				}
-						.grid-area.row .btn-play {
-							border: 2px solid #fff;
-							width: 53px;
-							height: 53px;
-							margin: -26px 0 0 -26px;
-						}
-							.grid-area.row .btn-play .icons {
-								background-size: 271px auto;
-								background-position: 0 -35px;
-								width: 39px;
-								height: 39px;
-								margin: 5px 0 0 0;
-							}
-								.grid-area.row .btn-play:hover,
-								.grid-area.row .btn-play:focus {
-									border: 2px solid #1cb0e6;
-								}
-								.grid-area.row .btn-play:hover .icons,
-								.grid-area.row .btn-play:focus .icons {
-									background-position: -39px -35.5px;
-								}
-					.grid-area.row .img-main img {
-						height: 194px;
-					}
-						.grid-area.row .carousel-control.left,
-						.grid-area.row .carousel-control.right {
-							width: 25px;
-							height: 24px;
-							border: 1px solid #fff;
-							margin-top: -12px;
-						}
-							.grid-area.row .carousel-control.left {
-								left: 8px;
-							}
-							.grid-area.row .carousel-control.right {
-								right: 8px;
-							}
-								.grid-area.row .carousel-control.left .icons,
-								.grid-area.row .carousel-control.right .icons {
-									width: 12px;
-									height: 12px;
-									margin-top: 0;
-									margin-bottom: 2px;
-								}
-									.grid-area.row .carousel-control.left .icons {
-										background-position: -144px -8px;
-									}
-										.grid-area.row .carousel-control:hover.left .icons {
-											background-position: -168px -8px;
-										}
-									.grid-area.row .carousel-control.right .icons {
-										background-position: -180px -8px;
-									}
-										.grid-area.row .carousel-control:hover.right .icons {
-											background-position: -192.5px -8px;
-										}
-				.grid-area.row .info-main {
-					padding: 30px 18px 20px 18px;
-				}
-					.grid-area.row .info-main .title-h2 {
-						font-size: 21px;
-						line-height: 24px;
-					}
-						.grid-area.row .info-main .title-h2 a {
-							font-size: 21px;
-						}
-					.grid-area.row .info-main .date-txt {
-						font-size: 9px;
-						line-height: 16px;
-						padding-top: 4px;
-						letter-spacing: 0;
-						padding-bottom: 7px;
-					}
-					.grid-area.row .info-main p {
-						font-size: 8px;
-						line-height: 16px;
-						padding: 4px 12px 9px 0;
-					}
-					.grid-area.row .info-main .bottom-bar {
-						padding: 12px 2px 28px 3px;
-					}
-						.grid-area.row .info-main .bottom-bar .btn-read-more {
-							font-size: 7px;
-							letter-spacing: 2px;
-							width: 76px;
-							height: 33px;
-							padding: 0 0 0 1px;
-							line-height: 33px;
-						}
-						.grid-area.row .info-main .bottom-bar .social-ul {
-							margin: 1.5px 0 0 0;
-						}
-							.grid-area.row .info-main .bottom-bar .social-ul li {
-								margin: 0 4px 0 4.5px;
-							}
-							.grid-area.row .info-main .bottom-bar .btn-icon-gray {
-								width: 40px;
-								height: 33px;
-							}
-							.grid-area.row .info-main .bottom-bar .btn-icon-gray .icons {
-								margin-top: 3.5px;
-							}
-
-
-		/* .loading-bar */
-		.loading-bar {
-			padding: 0 0 9px 0;
-			margin-top: -31px;
-		}
-			.loading-bar .loading-img {
-				background-size: 64px auto;
-				width: 64px;
-				height: 21px;
-			}
-			/* .blog-details-data */
-			.blog-details-data.container {
-				min-height: 150px;
-			}
-				/* .blog-details-data .title-bar */
-				.blog-details-data.container .title-bar {
-					padding: 5px 35px 8px 35px;
-				}
-					.blog-details-data.container .title-bar .title-h1 {
-						font-size: 24px;
-						line-height: 30px;
-					}
-					.blog-details-data.container .title-bar .date-txt {
-						font-size: 9px;
-						line-height: 16px;
-					}
-						.blog-details-data.container .title-bar .social-ul {
-							min-height: 30px;
-							padding: 7px 0 0 0;
-							margin-bottom: 11px;
-						}
-							.blog-details-data.container .title-bar .social-ul li {
-								margin-right: 10px;
-							}
-							.blog-details-data.container .title-bar .social-ul li .btn-icon-gray {
-								width: 39px;
-								height: 32px;
-							}
-								.blog-details-data.container .title-bar .social-ul li .btn-icon-gray .icons {
-									margin-top: 3px;
-								}
-				/* .blog-details-data .info-box */
-				.blog-details-data.container .info-box .img-main,
-				.blog-details-data.container .info-box .img-main img {
-					height: 194px;
-				}
-					.blog-details-data.container .info-box .info-main {
-						padding: 18px 0 31px 0;
-						margin: 0 35px;
-					}
-						.blog-details-data.container .info-box .info-main .font20 {
-							font-size: 10px;
-							line-height: 18px;
-						}
-						.blog-details-data.container .info-box .info-main .font14 {
-							font-size: 8px;
-							line-height: 16px;
-						}
-						.blog-details-data.container .info-box .info-main .lefts .font14,
-						.blog-details-data.container .info-box .down25 {
-							padding-bottom: 17px;
-						}
-
-			/* .related-blog-module */
-			.related-blog-module {
-				padding: 13px 0 3px 0;
-			}
-				.related-blog-module .form-area {
-					min-height: 36px;
-					margin-top: 48px;
-				}
-				.related-blog-module .title-related-blog {
-					font-size: 10.5px;
-					width: 160px;
-					top: 1px;
-					right: 19px;
-				}
-				#mobile-related-example-generic {
-					margin: 0 32px;
-				}
-					#mobile-related-example-generic .grid-area.row .info-main {
-						padding: 11px 92px 11px 0;
-					}
-						#mobile-related-example-generic .grid-area.row .info-main .title-h2 {
-							font-size: 24px;
-						}
-						#mobile-related-example-generic .grid-area.row .info-main .bottom-bar .btn-read-more {
-							top: 17px;
-							width: 79px;
-							height: 27px;
-							line-height: 27px;
-						}
-				.related-blog-module .carousel-control.left,
-				.related-blog-module .carousel-control.right {
-					width: 26px;
-					height: 25px;
-					top: 90px;
-				}
-					.related-blog-module .carousel-control.left {
-						left: -29px;
-					}
-					.related-blog-module .carousel-control.right {
-						right: -29px;
-					}
-						.related-blog-module .carousel-control.left .icons,
-						.related-blog-module .carousel-control.right .icons {
-							width: 12px;
-							height: 12px;
-							margin-top: 0;
-							margin-bottom: 3px;
-						}
-							.related-blog-module .carousel-control.left .icons {
-								background-position: -144px -8px;
-							}
-								.related-blog-module .carousel-control:hover.left .icons {
-									background-position: -168px -8px;
-								}
-							.related-blog-module .carousel-control.right .icons {
-								background-position: -180px -8px;
-							}
-								.related-blog-module .carousel-control:hover.right .icons {
-									background-position: -192px -8px;
-								}
-					.related-blog-module .carousel-inner>.active {
-						min-height: 295px;
-					}
-
-			/* .comments-module */
-			.comments-module .container {
-				padding: 18px 19px 0 19px;
-			}
-				.comments-module .container .title-comments {
-					width: 111px;
-					letter-spacing: 5px;
-					padding-left: 6px;
-					margin-bottom: 3px;
-				}
-				/* .comments-module .comments-area  .comments-list*/
-				.comments-module .comments-area {
-					min-height: 100px;
-					padding-top: 10px;
-				}
-					.comments-module .comments-area .comments-list {
-						padding: 32px 0 17px 0;
-					}
-					.comments-module .comments-area .spacetop {
-						padding-top: 13px;
-					}
-						.comments-module .comments-area .comments-list .head-img {
-							width: 62px;
-						}
-							.comments-module .comments-area .comments-list .head-img img {
-								width: 50px;
-								height: 50px;
-								margin-left: 2px;
-							}
-						.comments-module .comments-area .comments-list .info-box {
-							margin-left: 62px;
-						}
-							.comments-module .comments-area .comments-list .info-box .title-h4 {
-								padding: 0 0 3px 0;
-								margin-top: -3px;
-							}
-								.comments-module .comments-area .comments-list .info-box .title-h4 a {
-								    font-size: 10px;
-								}
-							.comments-module .comments-area .comments-list .info-box p {
-								    font-size: 8px;
-								    line-height: 16px;
-								    padding: 0 14px 15px 0;
-							}
-						.comments-module .comments-area .comments-list .comments-apply {
-							border: 1px solid #fff;
-							width: 78px;
-							height: 21px;
-							line-height: 21px;
-							letter-spacing: 3px;
-						}
-							.comments-module .comments-area .comments-list .comments-apply a {
-								font-size: 7px;
-								padding-left: 2px;
-
-							}
-				/* .comments-module .comments-area .quick-reply */
-				.comments-module .comments-area .quick-reply {
-					padding: 16px 0 17px 0;
-				}
-					.comments-module .btn-icon-gray {
-						width: 27px;
-						height: 22px;
-					}
-						.comments-module .btn-icon-gray .icons {
-							width: 12px;
-							height: 12px;
-							margin-top: 4px;
-						}
-							.comments-module .btn-icon-gray .icon-fb {
-								background-position: -72px -8px;
-							}
-								.comments-module .btn-icon-gray:hover .icon-fb {
-									background-position: -84px -8px;
-								}
-							.comments-module .btn-icon-gray .icon-tw {
-								background-position: -96px -8px;
-							}
-								.comments-module .btn-icon-gray:hover .icon-tw {
-									background-position: -108px -8px;
-								}
-							.comments-module .btn-icon-gray .icon-gg {
-								background-position: -120px -8px;
-							}
-								.comments-module .btn-icon-gray:hover .icon-gg {
-									background-position: -132px -8px;
-								}
-					.comments-module .comments-area .quick-reply .quick-reply-txt {
-						width: 67px;
-					}
-						.comments-module .comments-area .quick-reply .quick-reply-txt .title-h4 {
-							padding: 9px 0 11px 0;
-						    font-size: 10px;
-						}
-						.comments-module .comments-area .quick-reply .quick-reply-txt p {
-							font-size: 8px;
-						}
-							.comments-module .comments-area .quick-reply .quick-reply-txt li {
-								margin-top: 5px;
-								margin-left: 0;
-							}
-							.comments-module .comments-area .quick-reply .quick-reply-txt li:nth-child(2) {
-								margin-left: 6px;
-							}
-					.comments-module .comments-area .quick-reply .textarea-box {
-						margin-right: 2px;
-						margin-left: 67px;
-						height: 126px;
-						padding: 10.5px 14px;
-					}
-						.comments-module .comments-area .quick-reply .textarea-box textarea {
-							font-size: 8px;
-							height: 85px;
-							line-height: 7px;
-							letter-spacing: 3px;
-
-						}
-					.comments-module .comments-area .quick-reply .comments-post {
-						width: 68.5px;
-						height: 21.5px;
-						line-height: 21.5px;
-						right: 3px;
-						bottom: 18px;
-						letter-spacing: 2px;
-					}
-						.comments-module .comments-area .quick-reply .comments-post a {
-							font-size: 7px;
-							padding: 1px 0 0 1.5px;
-
-						}
-
-
-
-
-/* .footer */
-.footer .row {
-	padding: 0 21.5px 0 32.5px;
-}
-	.footer .row .col-info {
-		padding: 17px 0 9px 0;
-	}
-		.footer .row .col-menu dt,
-		.footer .row .col-info dt {
-			line-height: 12.5px;
-			padding: 5px 0;
-		}
-			.footer .row .col-menu dt a,
-			.footer .row .col-info dt a {
-				font-size: 10.5px;
-			}
-		.footer .row .col-menu dd,
-		.footer .row .col-info dd {
-			line-height: 14.5px;
-		}
-	/* .footer .col-menu */
-	.footer .row .col-menu {
-		padding: 26px 0 11px 0;
-	}
-	/* .footer .col-info */
-	.footer .row .col-info:nth-child(5) {
-		padding: 0 0 16px 0;
-	}
-	.footer .row .col-info:nth-child(5) dt a {
-		font-size: 8px;
-	}
-		.footer .row .col-info dt {
-			padding-bottom: 3.5px;
-		}
-			.footer .row .col-info a {
-				font-size: 8px;
-			}
-			.footer .row .col-info p {
-				font-size: 7px;
-				line-height: 12px;
-				padding: 0 8px 0 0;
-			}
-	/* .footer .bottoms */
-	.footer .bottoms {
-		min-height: 112.5px;
-	}
-		.footer .bottoms .logo {
-			background-size: 85px auto;
-			margin: 19px auto 0 auto;
-			width: 85.5px;
-			height: 36px;
-		}
-		.footer .bottoms .social-ul {
-			margin: 19px auto 0 auto;
-			width: 85px;
-			height: 12px;
-		}
-			.footer .bottoms .social-ul li {
-				margin: 0 7px;
-			}
-				.footer .bottoms .social-ul li .icons {
-					background-size: 336px auto;
-					width: 12px;
-					height: 12px;
-				}
-					.footer .bottoms .social-ul li .icon-fb {
-						background-position: 0 -8px;
-					}
-						.footer .bottoms .social-ul li .icon-fb:hover {
-							background-position: -12px -8px;
-						}
-					.footer .bottoms .social-ul li .icon-tw {
-						background-position: -24px -8px;
-					}
-						.footer .bottoms .social-ul li .icon-tw:hover {
-							background-position: -36px -8px;
-						}
-					.footer .bottoms .social-ul li .icon-gg {
-						background-position: -48px -8px;
-					}
-						.footer .bottoms .social-ul li .icon-gg:hover {
-							background-position: -60px -8px;
-						}
-
-
-
-/* .modal-default */
-.modal.modal-default .modal-dialog {
-	width: 346px;
-	margin: 102px auto;
-}
-	/* .modal-default .modal-header */
-	.modal.modal-default .btn-close {
-		background-position: -240px -44px;
-		width: 24px;
-		height: 24px;
-		top: 18.5px;
-		right: 12px;
-	}
-		.modal.modal-default .btn-close:hover {
-			background-position: -240px -68px;
-		}
-	/* .modal-default .modal-body */
-	.modal.modal-default .modal-body {
-		min-height: 50px;
-	}
-
-	/* #modal-how-it-works */
-	#modal-how-it-works .title-how-it-works {
-		width: 142px;
-		letter-spacing: 4px;
-		padding-left: 6px;
-		margin: 19px auto 0 auto;
-	}
-		#modal-how-it-works .txt-info {
-			font-size: 8px;
-			line-height: 16px;
-			padding: 262px 34px 17px 34px;
-		}
-		/* #modal-how-it-works .info-row */
-		#modal-how-it-works .info-row {
-			padding: 12px 15px 3.5px 15px;
-			top: 10px;
-		}
-			#modal-how-it-works .info-row .video-area .video,
-			#modal-how-it-works .info-row .video-area .video img {
-				width: 315px;
-				height: 224px;
-			}
-			#modal-how-it-works .info-row .video-area .video iframe {
-				width: 315px;
-				height: 224px;
-			}
-				#modal-how-it-works .info-row .video-area .btn-play {
-					border: 2.5px solid #fff;
-					width: 65px;
-					height: 65px;
-					margin: -32.5px 0 0 -32.5px;
-				}
-					#modal-how-it-works .info-row .video-area .btn-play .icons {
-						background-position: 0 -44px;
-						width: 48px;
-						height: 48px;
-						margin: 7px 0 0 0;
-					}
-						#modal-how-it-works .info-row .video-area .btn-play:hover,
-						#modal-how-it-works .info-row .video-area .btn-play:focus {
-							border: 2.5px solid #1cb0e6;
-						}
-						#modal-how-it-works .info-row .video-area .btn-play:hover .icons,
-						#modal-how-it-works .info-row .video-area .btn-play:focus .icons {
-							background-position: -48px -44px;
-						}
-}
-
-
-
 
 /* iPads (min-width : 992px) and (max-width : 1024px) */
-@media (min-width : 992px) and (max-width : 1024px) and (-webkit-min-device-pixel-ratio : 1.5){
-	.header .logo,
-	.footer .bottoms .logo {
-		background: url(../images/logo-white@2x.png) no-repeat;
-		background-size: 141px auto;
-	}
-	/* .after-scroll-header */
-	.header.after-scroll-header .logo {
-		background: url(../images/logo@2x.png) no-repeat;
-		background-size: 141px auto;
-	}
-	/* icons */
-	.icons {
-		background: url(../images/icon-sprites@2x.png) no-repeat;
-		background-size: 543px auto;
-	}
-	.mobile-mask {
-		background: #000;
-		display: block;
-		width: 200px;
-		height: 40px;
-		position: absolute;
-		top: 0;
-		right: 0;
-		z-index: 999;
-	}
+
+@media (min-width: 992px) and (max-width: 1024px) and (-webkit-min-device-pixel-ratio: 1.5) {
+  .header .logo, .footer .bottoms .logo {
+    background: url(../images/logo-white@2x.png) no-repeat;
+    background-size: 141px auto;
+  }
+  /* .after-scroll-header */
+  .header.after-scroll-header .logo {
+    background: url(../images/logo@2x.png) no-repeat;
+    background-size: 141px auto;
+  }
+  /* icons */
+  .icons {
+    background: url(../images/icon-sprites@2x.png) no-repeat;
+    background-size: 543px auto;
+  }
+  .mobile-mask {
+    background: #000;
+    display: block;
+    width: 200px;
+    height: 40px;
+    position: absolute;
+    top: 0;
+    right: 0;
+    z-index: 999;
+  }
 }
-
-
-
 
 /* iPads (min-width : 768px) and (max-width : 991px) */
-@media (min-width : 768px) and (max-width : 991px) and (-webkit-min-device-pixel-ratio : 1.5){
-	.header .logo,
-	.footer .bottoms .logo {
-		background: url(../images/tablet/tablet-logo-white@2x.png);
-	}
-	.header .logo {
-		background-size: 257px auto;
-	}
-	.footer .bottoms .logo {
-		background-size: 171px auto;
-		height: 67px;
-	}
-	/* .after-scroll-header */
-	.header.after-scroll-header .logo {
-		background: url(../images/tablet/tablet-logo@2x.png);
-		background-size: 257px auto;
-	}
-	/* icons */
-	.icons {
-		background: url(../images/icon-sprites@2x.png) no-repeat;
-		background-size: 672px auto;
-	}
-	.mobile-mask {
-		background: #000;
-		display: block;
-		width: 200px;
-		height: 50px;
-		position: absolute;
-		top: 0;
-		right: 0;
-		z-index: 999;
-	}
+
+@media (min-width: 768px) and (max-width: 991px) and (-webkit-min-device-pixel-ratio: 1.5) {
+  .header .logo, .footer .bottoms .logo {
+    background: url(../images/tablet/tablet-logo-white@2x.png);
+  }
+  .header .logo {
+    background-size: 257px auto;
+  }
+  .footer .bottoms .logo {
+    background-size: 171px auto;
+    height: 67px;
+  }
+  /* .after-scroll-header */
+  .header.after-scroll-header .logo {
+    background: url(../images/tablet/tablet-logo@2x.png);
+    background-size: 257px auto;
+  }
+  /* icons */
+  .icons {
+    background: url(../images/icon-sprites@2x.png) no-repeat;
+    background-size: 672px auto;
+  }
+  .mobile-mask {
+    background: #000;
+    display: block;
+    width: 200px;
+    height: 50px;
+    position: absolute;
+    top: 0;
+    right: 0;
+    z-index: 999;
+  }
 }
 
-
-
-
 /* iPhone (min-width : 375px) and (max-width : 767px) */
-@media (min-width : 375px) and (max-width : 767px) and (-webkit-min-device-pixel-ratio : 1.5){
-	.header .logo,
-	.footer .bottoms .logo {
-		background: url(../images/mobile/mobile-logo-white@2x.png);
-	}
-	.header .logo {
-		background-size: 129px auto;
-	}
-	.footer .bottoms .logo {
-		background-repeat: no-repeat;
-		background-size: 85px auto;
-		height: 34px;
-	}
-	/* .after-scroll-header */
-	.header.after-scroll-header .logo {
-		background: url(../images/mobile/mobile-logo@2x.png);
-		background-size: 129px auto;
-		height: 50px;
-	}
-	/* icons */
-	.icons {
-		background: url(../images/mobile/mobile-icon-sprites@2x.png) no-repeat;
-		background-size: 336px auto;
-	}
-	.mobile-mask {
-		background: #000;
-		display: block;
-		width: 200px;
-		height: 40px;
-		position: absolute;
-		top: 0;
-		right: 0;
-		z-index: 999;
-	}
+
+@media (min-width: 375px) and (max-width: 767px) and (-webkit-min-device-pixel-ratio: 1.5) {
+  .header .logo, .footer .bottoms .logo {
+    background: url(../images/mobile/mobile-logo-white@2x.png);
+  }
+  .header .logo {
+    background-size: 129px auto;
+  }
+  .footer .bottoms .logo {
+    background-repeat: no-repeat;
+    background-size: 85px auto;
+    height: 34px;
+  }
+  /* .after-scroll-header */
+  .header.after-scroll-header .logo {
+    background: url(../images/mobile/mobile-logo@2x.png);
+    background-size: 129px auto;
+    height: 50px;
+  }
+  /* icons */
+  .icons {
+    background: url(../images/mobile/mobile-icon-sprites@2x.png) no-repeat;
+    background-size: 336px auto;
+  }
+  .mobile-mask {
+    background: #000;
+    display: block;
+    width: 200px;
+    height: 40px;
+    position: absolute;
+    top: 0;
+    right: 0;
+    z-index: 999;
+  }
 }
 
 /* Donate / reinvestment modals */
+
 #donate-form .cc-type-list {
-    margin-top: -10px;
+  margin-top: -10px;
 }
-
 .payment-modal-content .confirm-info-card {
-    margin-bottom: 1em;
+  margin-bottom: 1em;
 }
-
 .payment-modal-content .modal-header {
-    font-weight: bold;
-    font-size: 18px;
+  font-weight: bold;
+  font-size: 18px;
 }
-
 label.checkmark {
   position: relative;
   display: block;
@@ -11122,121 +10695,124 @@ label.checkmark {
   width: 120px;
   border: 5px solid #c7eefb;
   border-radius: 50%;
-  margin: 0 auto 0.9375rem auto; }
-  label.checkmark:after {
-    -moz-transform: scaleX(-1) rotate(135deg);
-    -o-transform: scaleX(-1) rotate(135deg);
-    -ms-transform: scaleX(-1) rotate(135deg);
-    -webkit-transform: scaleX(-1) rotate(135deg);
-    transform: scaleX(-1) rotate(135deg);
-    -moz-transform-origin: left top;
-    -o-transform-origin: left top;
-    -ms-transform-origin: left top;
-    -webkit-transform-origin: left top;
-    transform-origin: left top;
-    border-right: 5px solid #11ade5;
-    border-top: 5px solid #11ade5;
-    content: '';
-    height: 60px;
-    left: 24px;
-    position: absolute;
-    top: 60px;
-    width: 30px;
-    display: none; }
-  label.checkmark.animate:after {
-    display: block;
-    -webkit-animation: check 0.8s;
-    -moz-animation: check 0.8s;
-    -o-animation: check 0.8s;
-    animation: check 0.8s; }
-
+  margin: 0 auto 0.9375rem auto;
+}
+label.checkmark:after {
+  -moz-transform: scaleX(-1) rotate(135deg);
+  -o-transform: scaleX(-1) rotate(135deg);
+  -ms-transform: scaleX(-1) rotate(135deg);
+  -webkit-transform: scaleX(-1) rotate(135deg);
+  transform: scaleX(-1) rotate(135deg);
+  -moz-transform-origin: left top;
+  -o-transform-origin: left top;
+  -ms-transform-origin: left top;
+  -webkit-transform-origin: left top;
+  transform-origin: left top;
+  border-right: 5px solid #11ade5;
+  border-top: 5px solid #11ade5;
+  content: '';
+  height: 60px;
+  left: 24px;
+  position: absolute;
+  top: 60px;
+  width: 30px;
+  display: none;
+}
+label.checkmark.animate:after {
+  display: block;
+  -webkit-animation: check 0.8s;
+  -moz-animation: check 0.8s;
+  -o-animation: check 0.8s;
+  animation: check 0.8s;
+}
 .sharethis-placeholder {
-    font-weight: bold;
-    margin-top: 1em
+  font-weight: bold;
+  margin-top: 1em
 }
 #sharethis-button {
-    margin-top: 0.5em;
-    display: block;
+  margin-top: 0.5em;
+  display: block;
 }
 
 /* Login / sign up area */
-#login_form .placeholder-field-label, .signup .placeholder-field-label {
-    width: 100%;
-}
 
+#login_form .placeholder-field-label, .signup .placeholder-field-label {
+  width: 100%;
+}
 .signup .tos p {
-    font-size: 85%;
+  font-size: 85%;
 }
 
 /* ShareThis widget */
 
+
 /* Hide the sharethis left-size hover widget on small screens, or it will
  * obscure the page */
+
 @media (max-width: 768px) {
-    #sthoverbuttons {
-        display: none;
-    }
+  #sthoverbuttons {
+    display: none;
+  }
 }
 
 /* Dashboard */
-.dashboard .active-projects-module {
-    background-color: #fff;
-}
 
+.dashboard .active-projects-module {
+  background-color: #fff;
+}
 .dashboard .impact {
-    text-align: center;
+  text-align: center;
 }
 .dashboard .impact h2 {
-    color: #2c3691;
-    font-weight: bold;
-	font-family: 'Source Sans Pro', Arial, Helvetica, sans-serif;
-    font-size: 46px;
+  color: #2c3691;
+  font-weight: bold;
+  font-family: 'Source Sans Pro', Arial, Helvetica, sans-serif;
+  font-size: 46px;
 }
 .dashboard .impact h3 {
-    font-weight: 300;
-	font-family: 'Source Sans Pro', Arial, Helvetica, sans-serif;
-    font-size: 41px;
-    color: #2B2B2B;
+  font-weight: 300;
+  font-family: 'Source Sans Pro', Arial, Helvetica, sans-serif;
+  font-size: 41px;
+  color: #2B2B2B;
 }
-
 .dashboard .stats {
-    margin-top: 70px;
-
-    font-family: 'Source Sans Pro', Arial, Helvetica, sans-serif;
+  margin-top: 70px;
+  font-family: 'Source Sans Pro', Arial, Helvetica, sans-serif;
 }
 .dashboard .stats .info {
-    text-transform: uppercase;
-    margin-top: 7px;
-    font-size: 11px;
+  text-transform: uppercase;
+  margin-top: 7px;
+  font-size: 11px;
 }
 .dashboard .stats .info .val {
-    display: block;
-    font-size: 52px;
-    line-height: 38px;
-    margin-bottom: -2px;
-    font-weight: bold;
+  display: block;
+  font-size: 52px;
+  line-height: 38px;
+  margin-bottom: -2px;
+  font-weight: bold;
 }
 .dashboard .stats .info .units {
-    font-weight: bold;
-    font-size: 14px;
-    margin-left: -6px;
+  font-weight: bold;
+  font-size: 14px;
+  margin-left: -6px;
 }
 .dashboard .title-active-projects {
-    margin-top: 3em;
-    margin-bottom: 3em;
+  margin-top: 3em;
+  margin-bottom: 3em;
 }
 
 /* Project draft mode */
+
 .draft-mode-div {
-    position: fixed;
-    z-index: 1020;
-    width: 100%;
-    background-color: #14b1e7;
-    padding: 1em;
-    color: white;
-    font-weight: bold;
-    padding-left: 5em;
-    padding-right: 5em;
-    text-align: center;
-    margin-top: -13px;
+  position: fixed;
+  z-index: 1020;
+  width: 100%;
+  background-color: #14b1e7;
+  padding: 1em;
+  color: white;
+  font-weight: bold;
+  padding-left: 5em;
+  padding-right: 5em;
+  text-align: center;
+  margin-top: -13px;
 }


### PR DESCRIPTION
This changes the indents from tabs to double spaces, and it also changes the line breaks from `\r\n` to just `\n`.

This should make future edits to `screen.css` much more readable. It is the major culprit of bad indents, so that's a big deal.
