### PR TITLE
Adding Toastr CSS link

### DIFF
--- a/revolv/templates/base/base.html
+++ b/revolv/templates/base/base.html
@@ -26,6 +26,9 @@
     <link href="{% static 'css/animate.css' %}" rel="stylesheet" />
     <link href="{% static 'css/screen.css' %}" rel="stylesheet" />
 
+    <!-- Toastr CSS -->
+    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/css/toastr.min.css" />
+
     <!-- jQuery library -->
     <script src="{% static 'js/jquery-2.1.4.min.js' %}"></script>
     <script src="{% static 'js/jquery.waypoints.min.js' %}"></script>
@@ -35,7 +38,7 @@
     <script src="{% static 'js/jquery.hammer.js' %}"></script>
     <script src="{% static 'js/jquery.jqtransform.js' %}"></script>
     <script src="{% static 'lib/bootstrap/js/bootstrap.min.js' %}"></script>
-    
+
     <!-- Main JS -->
     <script src="{% static 'js/script.js' %}"></script>
 


### PR DESCRIPTION
The CDN link for the Toastr library's styles was never added to the project. The predictable bad result was the weird, bad stuff the Toastr plugin did when actually trying to display messages.

Why was the CSS not linked in? Probably this is one of those situations where the Toastr code was partway through being incorporated when the project passed over to new developers' hands.

The styles are not particularly consistent with the rest of the site's styling. _But this is a small problem compared to there being no styles at all_, so this patch is an improvement.
