### PR TITLE
Remove "start your own project" links, add mailto link

### DIFF
--- a/revolv/project/urls.py
+++ b/revolv/project/urls.py
@@ -7,7 +7,7 @@ from revolv.project.views import (CreateProjectView, EditProjectUpdateView,
 
 urlpatterns = patterns(
     '',
-    url(r'^create$', is_logged_in(CreateProjectView.as_view()), name='new'),
+    url(r'^create$', is_ambassador(CreateProjectView.as_view()), name='new'),
     url(r'^(?P<pk>\d+)/edit$', is_ambassador(UpdateProjectView.as_view()), name='edit'),
     url(r'^(?P<pk>\d+)/$', ProjectView.as_view(), name='view'),
     url(r'^(?P<pk>\d+)/reinvest/$', 'revolv.project.views.reinvest', name='reinvest'),

--- a/revolv/static/css/screen.css
+++ b/revolv/static/css/screen.css
@@ -980,6 +980,13 @@ a:hover {
   min-width: 298px;
   letter-spacing: 4px;
 }
+.testimonial-module .user-group > p {
+  text-align: center;
+  font-size: 100%;
+}
+.testimonial-module .user-group > p > emph {
+  font-style: italic;
+}
 
 /* .featured-on-module */
 

--- a/revolv/templates/base/home.html
+++ b/revolv/templates/base/home.html
@@ -365,7 +365,6 @@
       <div class="user-group">
         <span class="block"><a href="javascript:;" class="link-blue">Jhon Doe1</a></span>
         <span class="txt block">First Volunteer</span>
-        <span class="block"><a href="{% url 'project:new' %}" class="btn-blue">START YOUR OWN PROJECT</a></span>
       </div>
     </div>
     <!-- end .info-area -->
@@ -380,7 +379,6 @@
       <div class="user-group">
         <span class="block"><a href="javascript:;" class="link-blue">Jhon Doe2</a></span>
         <span class="txt block">First Volunteer</span>
-        <span class="block"><a href="{% url 'project:new' %}" class="btn-blue">START YOUR OWN PROJECT</a></span>
       </div>
     </div>
     <!-- end .info-area -->
@@ -395,7 +393,6 @@
       <div class="user-group">
         <span class="block"><a href="javascript:;" class="link-blue">Jhon Doe3</a></span>
         <span class="txt block">First Volunteer</span>
-        <span class="block"><a href="{% url 'project:new' %}" class="btn-blue">START YOUR OWN PROJECT</a></span>
       </div>
     </div>
     <!-- end .info-area -->
@@ -410,7 +407,6 @@
       <div class="user-group">
         <span class="block"><a href="javascript:;" class="link-blue">Jhon Doe4</a></span>
         <span class="txt block">First Volunteer</span>
-        <span class="block"><a href="{% url 'project:new' %}" class="btn-blue">START YOUR OWN PROJECT</a></span>
       </div>
     </div>
     <!-- end .info-area -->
@@ -425,7 +421,6 @@
       <div class="user-group">
         <span class="block"><a href="javascript:;" class="link-blue">Jhon Doe5</a></span>
         <span class="txt block">First Volunteer</span>
-        <span class="block"><a href="{% url 'project:new' %}" class="btn-blue">START YOUR OWN PROJECT</a></span>
       </div>
     </div>
     <!-- end .info-area -->
@@ -440,7 +435,6 @@
       <div class="user-group">
         <span class="block"><a href="javascript:;" class="link-blue">Jhon Doe6</a></span>
         <span class="txt block">First Volunteer</span>
-        <span class="block"><a href="{% url 'project:new' %}" class="btn-blue">START YOUR OWN PROJECT</a></span>
       </div>
     </div>
     <!-- end .info-area -->
@@ -455,7 +449,6 @@
       <div class="user-group">
         <span class="block"><a href="javascript:;" class="link-blue">Jhon Doe7</a></span>
         <span class="txt block">First Volunteer</span>
-        <span class="block"><a href="{% url 'project:new' %}" class="btn-blue">START YOUR OWN PROJECT</a></span>
       </div>
     </div>
     <!-- end .info-area -->
@@ -470,7 +463,6 @@
       <div class="user-group">
         <span class="block"><a href="javascript:;" class="link-blue">Jhon Doe8</a></span>
         <span class="txt block">First Volunteer</span>
-        <span class="block"><a href="{% url 'project:new' %}" class="btn-blue">START YOUR OWN PROJECT</a></span>
       </div>
     </div>
     <!-- end .info-area -->
@@ -485,7 +477,6 @@
       <div class="user-group">
         <span class="block"><a href="javascript:;" class="link-blue">Jhon Doe9</a></span>
         <span class="txt block">First Volunteer</span>
-        <span class="block"><a href="{% url 'project:new' %}" class="btn-blue">START YOUR OWN PROJECT</a></span>
       </div>
     </div>
     <!-- end .info-area -->

--- a/revolv/templates/base/home.html
+++ b/revolv/templates/base/home.html
@@ -365,6 +365,9 @@
       <div class="user-group">
         <span class="block"><a href="javascript:;" class="link-blue">Jhon Doe1</a></span>
         <span class="txt block">First Volunteer</span>
+        <p>
+          <emph>Have a project idea? Contact us at <a href="mailto:info@re-volv.org">info@re-volv.org</a>.</emph>
+        </p>
       </div>
     </div>
     <!-- end .info-area -->
@@ -379,6 +382,9 @@
       <div class="user-group">
         <span class="block"><a href="javascript:;" class="link-blue">Jhon Doe2</a></span>
         <span class="txt block">First Volunteer</span>
+        <p>
+          <emph>Have a project idea? Contact us at <a href="mailto:info@re-volv.org">info@re-volv.org</a>.</emph>
+        </p>
       </div>
     </div>
     <!-- end .info-area -->
@@ -393,6 +399,9 @@
       <div class="user-group">
         <span class="block"><a href="javascript:;" class="link-blue">Jhon Doe3</a></span>
         <span class="txt block">First Volunteer</span>
+        <p>
+          <emph>Have a project idea? Contact us at <a href="mailto:info@re-volv.org">info@re-volv.org</a>.</emph>
+        </p>
       </div>
     </div>
     <!-- end .info-area -->
@@ -407,6 +416,9 @@
       <div class="user-group">
         <span class="block"><a href="javascript:;" class="link-blue">Jhon Doe4</a></span>
         <span class="txt block">First Volunteer</span>
+        <p>
+          <emph>Have a project idea? Contact us at <a href="mailto:info@re-volv.org">info@re-volv.org</a>.</emph>
+        </p>
       </div>
     </div>
     <!-- end .info-area -->
@@ -421,6 +433,9 @@
       <div class="user-group">
         <span class="block"><a href="javascript:;" class="link-blue">Jhon Doe5</a></span>
         <span class="txt block">First Volunteer</span>
+        <p>
+          <emph>Have a project idea? Contact us at <a href="mailto:info@re-volv.org">info@re-volv.org</a>.</emph>
+        </p>
       </div>
     </div>
     <!-- end .info-area -->
@@ -435,6 +450,9 @@
       <div class="user-group">
         <span class="block"><a href="javascript:;" class="link-blue">Jhon Doe6</a></span>
         <span class="txt block">First Volunteer</span>
+        <p>
+          <emph>Have a project idea? Contact us at <a href="mailto:info@re-volv.org">info@re-volv.org</a>.</emph>
+        </p>
       </div>
     </div>
     <!-- end .info-area -->
@@ -449,6 +467,9 @@
       <div class="user-group">
         <span class="block"><a href="javascript:;" class="link-blue">Jhon Doe7</a></span>
         <span class="txt block">First Volunteer</span>
+        <p>
+          <emph>Have a project idea? Contact us at <a href="mailto:info@re-volv.org">info@re-volv.org</a>.</emph>
+        </p>
       </div>
     </div>
     <!-- end .info-area -->
@@ -463,6 +484,9 @@
       <div class="user-group">
         <span class="block"><a href="javascript:;" class="link-blue">Jhon Doe8</a></span>
         <span class="txt block">First Volunteer</span>
+        <p>
+          <emph>Have a project idea? Contact us at <a href="mailto:info@re-volv.org">info@re-volv.org</a>.</emph>
+        </p>
       </div>
     </div>
     <!-- end .info-area -->
@@ -477,6 +501,9 @@
       <div class="user-group">
         <span class="block"><a href="javascript:;" class="link-blue">Jhon Doe9</a></span>
         <span class="txt block">First Volunteer</span>
+        <p>
+          <emph>Have a project idea? Contact us at <a href="mailto:info@re-volv.org">info@re-volv.org</a>.</emph>
+        </p>
       </div>
     </div>
     <!-- end .info-area -->


### PR DESCRIPTION
Users cannot create projects! They should not see a link to the project creation page, nor should they be able to use it if they infer it.

They can however email _info@re-volv.org_ to inquire about starting one.
