### PR TITLE
Fixing project module image proportions

### DIFF
--- a/revolv/static/css/screen.css
+++ b/revolv/static/css/screen.css
@@ -8408,6 +8408,9 @@ header.edit-project-header > .container > h1 {
   .container {
     width: auto;
   }
+  .active-projects-module .container {
+    max-width: 375px;
+  }
   /* .header */
   .header {
     margin-top: 5px;


### PR DESCRIPTION
On "large" screen widths (beneath 768px), the images for projects used to be appearing in a distorted form because their height wasn't accommodating their width—and if it was made to do so, the result would be bad (because the resulting images would be disastrously tall).

This takes a simple way out: setting the projects to use a "mobile"-style width beneath that threshold point. This looks fine on phones, and the result also looks fine on standard tablet widths.
