### PR TITLE
.top100 => .after-header

### DIFF
--- a/revolv/static/css/screen.css
+++ b/revolv/static/css/screen.css
@@ -189,6 +189,9 @@ a:hover {
   left: 0;
   z-index: 1019;
 }
+.after-header {
+  margin-top: 102px;
+}
 .header .container {
   height: 100%;
   padding: 0;
@@ -3679,6 +3682,9 @@ header.edit-project-header > .container > h1 {
     margin-top: 30px;
     height: 85px;
   }
+  .after-header {
+    margin-top: 85px;
+  }
   .header .logo {
     background: url(../images/logo-white.png) no-repeat;
     background-size: 141px auto;
@@ -5775,6 +5781,9 @@ header.edit-project-header > .container > h1 {
   .header {
     margin-top: 10px;
     height: 185px;
+  }
+  .after-header {
+    margin-top: 185px;
   }
   .header .logo {
     background: url(../images/tablet/tablet-logo-white.png);
@@ -8415,6 +8424,9 @@ header.edit-project-header > .container > h1 {
   .header {
     margin-top: 5px;
     height: 92.5px;
+  }
+  .after-header {
+    margin-top: 92.5px;
   }
   .header .logo {
     background-repeat: no-repeat;

--- a/revolv/templates/base/dashboard.html
+++ b/revolv/templates/base/dashboard.html
@@ -26,7 +26,7 @@
 {% block body %}
 <div class='main-row dashboard'>
 
-    <div class="container-fluid top100">
+    <div class="container-fluid after-header">
       {% if role == 'ambassador' or role == 'admin' %}
           <div class="dashboard-sidebar col-md-2">
             {% include "base/partials/dashboard_sidebar.html" with user=user %}

--- a/revolv/templates/project/edit_project.html
+++ b/revolv/templates/project/edit_project.html
@@ -21,7 +21,7 @@
 {% endblock %}
 
 {% block body %}
-<div class="contents top100 edit-project">
+<div class="contents after-header edit-project">
   <div class="container">
     <div class="row form-section">
         <div class="large-12 columns">

--- a/revolv/templates/project/project.html
+++ b/revolv/templates/project/project.html
@@ -29,13 +29,13 @@
     </div>
 {% endif %}
 
-<div class="contents project-details-contents top100">
+<div class="contents project-details-contents after-header">
   <div class="details-active-project-module">
     <div class="banners min-height455">
       <img src="{{project.cover_photo.url}}" class="desktop-banner" alt="Banner">
       <img src="{{project.cover_photo.url}}" class="mobile-banner" alt="Banner">
     </div>
-    <!-- end .banner -->  
+    <!-- end .banner -->
     <div class="banner-section">
       <div class="container">
         <div class="title-white-border title-active-project pull-right">{{ project.status_display|upper }}</div>
@@ -44,25 +44,25 @@
         </h1>
         <div class="funded-round">
           <span class="status-text">
-            <span class="round-depict">FUNDED</span>               
+            <span class="round-depict">FUNDED</span>
           </span>
           <!-- end .status-text -->
             <div class="status-indicator desktop-circle">
               <input type="text" value="{{ project.percent_complete }}" data-min="0" data-width="210" data-height="210" data-bgcolor="#fff" data-fgcolor="#14b1e7" data-max="100" data-readonly="true" data-thickness=".12">
-            </div>   
+            </div>
             <div class="status-indicator small-circle">
               <input type="text" value="{{ project.percent_complete }}" data-min="0" data-width="175" data-height="175" data-bgcolor="#fff" data-fgcolor="#14b1e7" data-max="100" data-readonly="true" data-thickness=".13">
-            </div>   
+            </div>
             <div class="status-indicator tablet-circle">
               <input type="text" value="{{ project.percent_complete }}" data-min="0" data-width="152" data-height="152" data-bgcolor="#fff" data-fgcolor="#14b1e7" data-max="100" data-readonly="true" data-thickness=".16">
-            </div>    
+            </div>
             <div class="status-indicator mobile-circle">
               <input type="text" value="{{ project.percent_complete }}" data-min="0" data-width="75" data-height="75" data-bgcolor="#fff" data-fgcolor="#14b1e7" data-max="100" data-readonly="true" data-thickness=".12">
-            </div> 
+            </div>
         </div>
       </div>
     </div>
-    <!-- end .banner-section -->  
+    <!-- end .banner-section -->
     <div class="info-section">
       <div class="container">
         <div class="info-main">
@@ -101,7 +101,7 @@
                   {{ project.tagline }}
                 </p>
                 <p class="font14">
-                  {{ project.description|safe }} 
+                  {{ project.description|safe }}
                 </p>
               </div>
             </div>
@@ -110,10 +110,10 @@
         <!-- end .video-main -->
       </div>
     </div>
-    <!-- end .info-section -->  
+    <!-- end .info-section -->
   </div>
   <!-- end .details-active-project-module -->
-  
+
   <div class="project-updates-module">
     <div class="container">
       <div class="main-area">
@@ -183,18 +183,18 @@
           <!-- end .module-box -->
       </aside>
       <!-- end .list-area -->
-    </div>    
+    </div>
   </div>
   <!-- end .project-updates-module -->
-  
+
   <div class="donors-module">
     <div class="mains-tabs">
       <nav class="tab-index">
-        <div class="container">         
+        <div class="container">
           <div class="row">
             <div class="col-lg-3 col-md-3 col-sm-6"><a href="javascript:;" class="active">DONORS</a></div>
           </div>
-        </div>   
+        </div>
         <!-- end .row -->
       </nav>
       <!-- end .nav -->
@@ -212,13 +212,13 @@
               <!-- end .col-md-6 -->
             </div>
           </div>
-          <!-- end .tab-gold -->      
+          <!-- end .tab-gold -->
         </div>
       </div>
       <!-- end .tab-content -->
     </div>
     <!-- end .tabs -->
-      
+
   </div>
   <!-- end .donors-module -->
 

--- a/revolv/templates/revolv_cms/revolv_custom_page.html
+++ b/revolv/templates/revolv_cms/revolv_custom_page.html
@@ -7,7 +7,7 @@
 {% endblock head %}
 
 {% block body %}
-    <div class="cms-content-row row">
+    <div class="cms-content-row row after-header">
         <div class="small-12 columns">
             <h1>{{ self.title }}</h1>
             {% for block in self.body %}


### PR DESCRIPTION
The `top100` class was apparently meant to create a top margin on elements whose contents would be hidden by the sticky navigation header. It didn't do this job correctly, though, since the header's height is often either more or less than 100px.
This adds a new class, `after-header`, which matches the height of the header at all dimensions. It also replaces references to `top100` with the new class.
The effects of this change are visible on the dashboard and the project page (for example).
