### PR TITLE
Require later version of Willow.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,6 +2,7 @@ Django==1.7.1
 psycopg2==2.5.3
 django-facebook==6.0.1
 Pillow==2.9.0
+Willow==0.2.2
 mock==1.0.1
 paypalrestsdk==1.4.1
 pytz==2014.7


### PR DESCRIPTION
Also add command for pulling remote DB and media tree, which
allows for testing that the /cms/images page shows blank on some
pages and this issue is corrected by updating Willow to 0.2.2
