### PR TITLE
Removing Facebook login links

### DIFF
--- a/revolv/templates/base/sign_in.html
+++ b/revolv/templates/base/sign_in.html
@@ -57,20 +57,13 @@
         </form>
 
         <div class="social-login-buttons">
-                <p class="slb-title">Or login with your social account below:</p>
+                <p class="slb-title">Or login with your Google account below:</p>
                 <br/>
             <a href="{% url "social:begin" "google-oauth2" %}?next={% if login_redirect_url %}{{ login_redirect_url }}
                         {% else %}{% url "home" %}{% endif %}" class="slb-btn-google">
                 <button class="row slb_socialButtons slb-google">
                     <i class="fa fa-google-plus visible-xs"></i>
                     <span class="hidden-xs">Google</span>
-                </button>
-            </a>
-            <a href="{% url "social:begin" "facebook" %}?next={% if login_redirect_url %}{{ login_redirect_url }}
-                        {% else %}{% url "home" %}{% endif %}" class="slb-btn-facebook">
-                <button class="row slb_socialButtons slb-facebook">
-                    <i class="fa fa-facebook visible-xs"></i>
-                    <span class="hidden-xs">Facebook</span>
                 </button>
             </a>
         </div>
@@ -87,20 +80,13 @@
         <br/>
         <p>Already have an account? Log in <a class="component-link" data-component="login">here</a>.</p>
         <br/>
-        <p>Or you can login with your social account below</p>
+        <p>Or you can login with your Google account below:</p>
         <div class="social-login-buttons">
                 <a href="{% url "social:begin" "google-oauth2" %}?next={% if login_redirect_url %}{{ login_redirect_url }}
                         {% else %}{% url "home" %}{% endif %}" class="slb-btn-google">
                     <button class="row slb_socialButtons slb-google">
                         <i class="fa fa-google-plus visible-xs"></i>
                         <span class="hidden-xs">Google</span>
-                    </button>
-                </a>
-                <a href="{% url "social:begin" "facebook" %}?next={% if login_redirect_url %}{{ login_redirect_url }}
-                        {% else %}{% url "home" %}{% endif %}" class="slb-btn-facebook">
-                    <button class="row slb_socialButtons slb-facebook">
-                        <i class="fa fa-facebook visible-xs"></i>
-                        <span class="hidden-xs">Facebook</span>
                     </button>
                 </a>
         </div>


### PR DESCRIPTION
There is no time to investigate Facebook-based authentication before launch.

This removes the (non-working) option of using Facebook to log in from the login and signup auth pages.
