### PR TITLE
REV-54 : lining up impact numbers

### DIFF
--- a/revolv/static/css/screen.css
+++ b/revolv/static/css/screen.css
@@ -672,10 +672,10 @@ a:hover {
   margin-left: -11px;*/
 }
 .our-impacts-module .row .col-md-3:nth-child(2) .module-box .titles {
-  padding-right: 30px;
+  /*padding-right: 30px;*/
 }
 .our-impacts-module .row .col-md-3:nth-child(3) .module-box .icons {
-  margin-left: 8%;
+  /*margin-left: 8%;*/
 }
 .our-impacts-module .row .col-md-3:nth-child(3) .module-box .titles {
   letter-spacing: -1.8px;
@@ -697,20 +697,29 @@ a:hover {
 .our-impacts-module .module-box .icons {
   width: 168px;
   height: 160px;
-  margin: 0 auto;
   display: block;
+  position: relative;
+  left: 50%;
+  -webkit-transform: translateX(-50%);
+  transform: translateX(-50%);
 }
 .our-impacts-module .module-box .icon-people {
   background-position: 0 -184px;
 }
 .our-impacts-module .module-box .icon-home-ok {
   background-position: -168px -184px;
+  -webkit-transform: translateX(-42%);
+  transform: translateX(-42%);
 }
 .our-impacts-module .module-box .icon-tree {
   background-position: -336px -190px;
+  -webkit-transform: translateX(-65%);
+  transform: translateX(-65%);
 }
 .our-impacts-module .module-box .icon-user {
   background-position: -504px -178px;
+  -webkit-transform: translateX(-48%);
+  transform: translateX(-48%);
 }
 .our-impacts-module .module-box .titles {
   font-family: 'Source Sans Pro';
@@ -3945,10 +3954,10 @@ header.edit-project-header > .container > h1 {
     margin-left: -11px;*/
   }
   .our-impacts-module .row .col-md-3:nth-child(2) .module-box .titles {
-    padding-right: 30px;
+    /*padding-right: 30px;*/
   }
   .our-impacts-module .row .col-md-3:nth-child(3) .module-box .icons {
-    margin-left: 5%;
+    /*margin-left: 5%;*/
   }
   .our-impacts-module .row .col-md-3:nth-child(3) .module-box .titles {
     padding-top: 14px;
@@ -6069,13 +6078,13 @@ header.edit-project-header > .container > h1 {
     margin-left: 0;
   }
   .our-impacts-module .row .col-md-3:nth-child(2) .module-box .icons {
-    margin-left: auto;
+    /*margin-left: auto;*/
   }
   .our-impacts-module .row .col-md-3:nth-child(2) .module-box .titles {
     padding-right: 0;
   }
   .our-impacts-module .row .col-md-3:nth-child(3) .module-box .icons {
-    margin-left: auto;
+    /*margin-left: auto;*/
   }
   .our-impacts-module .row .col-md-3:nth-child(3) .module-box .titles {
     letter-spacing: -1.8px;
@@ -8694,7 +8703,7 @@ header.edit-project-header > .container > h1 {
     background-position: 0 -92px;
   }
   .our-impacts-module .module-box .icon-home-ok {
-    background-position: -78px -92px;
+    background-position: -84px -92px;
   }
   .our-impacts-module .module-box .icon-tree {
     background-position: -177px -85px;

--- a/revolv/static/css/screen.css
+++ b/revolv/static/css/screen.css
@@ -668,8 +668,8 @@ a:hover {
 }
 .our-impacts-module .row .col-md-3:nth-child(1) .module-box {
   float: left;
-  width: 170px;
-  margin-left: -11px;
+  /*width: 170px;
+  margin-left: -11px;*/
 }
 .our-impacts-module .row .col-md-3:nth-child(2) .module-box .titles {
   padding-right: 30px;
@@ -684,7 +684,7 @@ a:hover {
 }
 .our-impacts-module .row .col-md-3:nth-child(4) .module-box {
   float: right;
-  width: 194px;
+  /*width: 194px;*/
 }
 .our-impacts-module .row .col-md-3:nth-child(4) .module-box .titles {
   padding-top: 20px;
@@ -692,6 +692,7 @@ a:hover {
 }
 .our-impacts-module .module-box {
   text-align: center;
+  width: 100%;
 }
 .our-impacts-module .module-box .icons {
   width: 168px;
@@ -3940,8 +3941,8 @@ header.edit-project-header > .container > h1 {
     padding: 0 0 30px 0;
   }
   .our-impacts-module .row .col-md-3:nth-child(1) .module-box {
-    width: 140px;
-    margin-left: -11px;
+    /*width: 140px;
+    margin-left: -11px;*/
   }
   .our-impacts-module .row .col-md-3:nth-child(2) .module-box .titles {
     padding-right: 30px;
@@ -3955,7 +3956,7 @@ header.edit-project-header > .container > h1 {
   }
   .our-impacts-module .row .col-md-3:nth-child(4) .module-box {
     float: right;
-    width: 155px;
+    /*width: 155px;*/
   }
   .our-impacts-module .row .col-md-3:nth-child(4) .module-box .titles {
     padding-top: 14px;

--- a/revolv/static/css/screen.css
+++ b/revolv/static/css/screen.css
@@ -10838,6 +10838,9 @@ label.checkmark.animate:after {
   margin-top: 70px;
   font-family: 'Source Sans Pro', Arial, Helvetica, sans-serif;
 }
+.dashboard .stats > * {
+  padding-bottom: 2rem;
+}
 .dashboard .stats .info {
   text-transform: uppercase;
   margin-top: 7px;

--- a/revolv/static/css/screen.css
+++ b/revolv/static/css/screen.css
@@ -10843,11 +10843,24 @@ label.checkmark.animate:after {
   margin-top: 7px;
   font-size: 11px;
 }
+.dashboard .stats .info > div:first-child {
+  height: 36px;
+}
+.dashboard .stats .info > div:last-child {
+  margin-top: 4px;
+}
+.dashboard .stats .info > div:not(.tall):first-child {
+  line-height: 56px;
+}
+.dashboard .stats .info > .tall:first-child {
+  padding-top: 4px;
+}
+.dashboard .stats .stats-img {
+  height: 80px;
+}
 .dashboard .stats .info .val {
-  display: block;
   font-size: 52px;
-  line-height: 38px;
-  margin-bottom: -2px;
+  line-height: 52px;
   font-weight: bold;
 }
 .dashboard .stats .info .units {

--- a/revolv/static/css/screen.css
+++ b/revolv/static/css/screen.css
@@ -668,27 +668,12 @@ a:hover {
 }
 .our-impacts-module .row .col-md-3:nth-child(1) .module-box {
   float: left;
-  /*width: 170px;
-  margin-left: -11px;*/
-}
-.our-impacts-module .row .col-md-3:nth-child(2) .module-box .titles {
-  /*padding-right: 30px;*/
-}
-.our-impacts-module .row .col-md-3:nth-child(3) .module-box .icons {
-  /*margin-left: 8%;*/
 }
 .our-impacts-module .row .col-md-3:nth-child(3) .module-box .titles {
   letter-spacing: -1.8px;
-  padding-top: 20px;
-  line-height: 40px;
 }
 .our-impacts-module .row .col-md-3:nth-child(4) .module-box {
   float: right;
-  /*width: 194px;*/
-}
-.our-impacts-module .row .col-md-3:nth-child(4) .module-box .titles {
-  padding-top: 20px;
-  line-height: 50px;
 }
 .our-impacts-module .module-box {
   text-align: center;
@@ -733,6 +718,7 @@ a:hover {
 }
 .our-impacts-module .module-box .font48 {
   font-size: 48px;
+  height: 66px;
 }
 .our-impacts-module .module-box .font72 {
   font-size: 72px;
@@ -748,6 +734,7 @@ a:hover {
   line-height: 22px;
   display: block;
   position: relative;
+  padding-top: 1rem;
 }
 .our-impacts-module .module-box .txt .position {
   position: relative;
@@ -3949,27 +3936,8 @@ header.edit-project-header > .container > h1 {
     margin: 0 58px 0 80px;
     padding: 0 0 30px 0;
   }
-  .our-impacts-module .row .col-md-3:nth-child(1) .module-box {
-    /*width: 140px;
-    margin-left: -11px;*/
-  }
-  .our-impacts-module .row .col-md-3:nth-child(2) .module-box .titles {
-    /*padding-right: 30px;*/
-  }
-  .our-impacts-module .row .col-md-3:nth-child(3) .module-box .icons {
-    /*margin-left: 5%;*/
-  }
-  .our-impacts-module .row .col-md-3:nth-child(3) .module-box .titles {
-    padding-top: 14px;
-    line-height: 25px;
-  }
   .our-impacts-module .row .col-md-3:nth-child(4) .module-box {
     float: right;
-    /*width: 155px;*/
-  }
-  .our-impacts-module .row .col-md-3:nth-child(4) .module-box .titles {
-    padding-top: 14px;
-    line-height: 35px;
   }
   .our-impacts-module .module-box .icons {
     width: 136px;
@@ -3989,6 +3957,7 @@ header.edit-project-header > .container > h1 {
   }
   .our-impacts-module .module-box .titles {
     line-height: 45px;
+    height: 45px;
   }
   .our-impacts-module .module-box .font20 {
     font-size: 16.53px;
@@ -4002,7 +3971,6 @@ header.edit-project-header > .container > h1 {
   .our-impacts-module .module-box .txt {
     font-size: 14.88px;
     line-height: 17px;
-    padding-top: 6px
   }
   /* .how-it-works-module */
   .how-it-works-module .container {
@@ -6077,27 +6045,15 @@ header.edit-project-header > .container > h1 {
     width: 100%;
     margin-left: 0;
   }
-  .our-impacts-module .row .col-md-3:nth-child(2) .module-box .icons {
-    /*margin-left: auto;*/
-  }
   .our-impacts-module .row .col-md-3:nth-child(2) .module-box .titles {
     padding-right: 0;
   }
-  .our-impacts-module .row .col-md-3:nth-child(3) .module-box .icons {
-    /*margin-left: auto;*/
-  }
   .our-impacts-module .row .col-md-3:nth-child(3) .module-box .titles {
     letter-spacing: -1.8px;
-    padding-top: 20px;
-    line-height: 40px;
   }
   .our-impacts-module .row .col-md-3:nth-child(4) .module-box {
     float: none;
     width: 100%;
-  }
-  .our-impacts-module .row .col-md-3:nth-child(4) .module-box .titles {
-    padding-top: 5px;
-    line-height: 50px;
   }
   .our-impacts-module .module-box .icons {
     width: 168px;
@@ -6117,6 +6073,7 @@ header.edit-project-header > .container > h1 {
   }
   .our-impacts-module .module-box .titles {
     line-height: 66px;
+    height: 66px;
   }
   .our-impacts-module .module-box .font20 {
     font-size: 20.48px;
@@ -8688,12 +8645,6 @@ header.edit-project-header > .container > h1 {
   }
   .our-impacts-module .row .col-md-3:nth-child(3) .module-box .titles {
     letter-spacing: -0.9px;
-    padding-top: 10px;
-    line-height: 20px;
-  }
-  .our-impacts-module .row .col-md-3:nth-child(4) .module-box .titles {
-    padding-top: 2px;
-    line-height: 25px;
   }
   .our-impacts-module .module-box .icons {
     width: 84px;
@@ -8714,6 +8665,7 @@ header.edit-project-header > .container > h1 {
   }
   .our-impacts-module .module-box .titles {
     line-height: 33px;
+    height: 33px;
   }
   .our-impacts-module .module-box .font20 {
     font-size: 9px;

--- a/revolv/static/js/script.js
+++ b/revolv/static/js/script.js
@@ -11,7 +11,9 @@ function increaseCount1(currentValue1,step1,value1){
   {
     return;
   }
-  setTimeout("increaseCount1("+currentValue1+","+step1+","+value1+")",100);
+  setTimeout(function () {
+    increaseCount1(currentValue1, step1, value1);
+  }, 100);
 }
 
 //count for 2nd Number of "OUR IMPACTS" section in Home page
@@ -25,7 +27,9 @@ function increaseCount2(currentValue2,step2,value2){
   {
     return;
   }
-  setTimeout("increaseCount2("+currentValue2+","+step2+","+value2+")",100);
+  setTimeout(function () {
+    increaseCount2(currentValue2, step2, value2);
+  }, 100);
 }
 
 //count for 3rd Number of "OUR IMPACTS" section in Home page
@@ -39,7 +43,9 @@ function increaseCount3(currentValue3,step3,value3){
   {
     return;
   }
-  setTimeout("increaseCount3("+currentValue3+","+step3+","+value3+")",100);
+  setTimeout(function () {
+    increaseCount3(currentValue3, step3, value3);
+  }, 100);
 }
 
 //count for 4th Number of "OUR IMPACTS" section in Home page
@@ -53,7 +59,9 @@ function increaseCount4(currentValue4,step4,value4){
   {
     return;
   }
-  setTimeout("increaseCount4("+currentValue4+","+step4+","+value4+")",100);
+  setTimeout(function () {
+    increaseCount4(currentValue4, step4, value4);
+  }, 100);
 }
 
 //format the Number text
@@ -82,7 +90,6 @@ function format(number){
     }
     number = mag + number.substring(digit);
   }
-  number = number.toString().replace(",",".").replace(",",".");
   return number;
 }
 

--- a/revolv/templates/base/partials/impact_statistics.html
+++ b/revolv/templates/base/partials/impact_statistics.html
@@ -8,39 +8,66 @@
 
   <div class="row stats">
       <div class="col-md-2">
-        <img src="{% static "images/dashboard/solar-panel-desktop.png" %}" />
+        <div class="stats-img">
+          <img src="{% static "images/dashboard/solar-panel-desktop.png" %}" />
+        </div>
         <div class="info">
-            Built <span class="val">{{ statistics.kwh }} <span class="units">kwH</span></span> of solar energy capacity
+            <div>Built</div>
+            <span class="val">{{ statistics.kwh }} </span>
+            <span class="units">kwH</span>
+            <div>of solar energy capacity</div>
         </div>
       </div>
       <div class="col-md-2">
-        <img src="{% static "images/dashboard/cloud-desktop.png" %}" />
+        <div class="stats-img">
+          <img src="{% static "images/dashboard/cloud-desktop.png" %}" />
+        </div>
         <div class="info">
-            Avoided <span class="val">{{ statistics.carbon_dioxide }} <span class="units">lbs</span> </span> of carbon dioxide emissions
+            <div>Avoided</div>
+            <span class="val">{{ statistics.carbon_dioxide }} </span>
+            <span class="units">lbs</span>
+            <div class="tall">of carbon dioxide emissions</div>
         </div>
       </div>
       <div class="col-md-2">
-        <img src="{% static "images/dashboard/trees-desktop.png" %}" />
+        <div class="stats-img">
+          <img src="{% static "images/dashboard/trees-desktop.png" %}" />
+        </div>
         <div class="info">
-            Equivalent to planting <span class="val">{{ statistics.trees }} <span class="units">acres</span></span> of trees
+            <div>Equivalent to planting</div>
+            <span class="val">{{ statistics.trees }} </span>
+            <span class="units">acres</span>
+            <div>of trees</div>
         </div>
       </div>
       <div class="col-md-2">
-        <img src="{% static "images/dashboard/house-desktop.png" %}" />
+        <div class="stats-img">
+          <img src="{% static "images/dashboard/house-desktop.png" %}" />
+        </div>
         <div class="info">
-            Supported <span class="val">{{ statistics.project_count }} </span> community-serving organizations
+            <div>Supported</div>
+            <span class="val">{{ statistics.project_count }} </span>
+            <div class="tall">community-serving organizations</div>
         </div>
       </div>
       <div class="col-md-2">
-        <img src="{% static "images/dashboard/person-desktop.png" %}" />
+        <div class="stats-img">
+          <img src="{% static "images/dashboard/person-desktop.png" %}" />
+        </div>
         <div class="info">
-            Provided solar energy to organizations serving <span class="val">{{ statistics.people_served }} <span class="units">people</span></span> in their community
+            <div class="tall">Provided solar energy to organizations serving</div>
+            <span class="val">{{ statistics.people_served }} </span>
+            <span class="units">people</span>
+            <div>in their community</div>
         </div>
       </div>
       <div class="col-md-2">
-        <img src="{% static "images/dashboard/money-desktop.png" %}" />
+        <div class="stats-img">
+          <img src="{% static "images/dashboard/money-desktop.png" %}" />
+        </div>
         <div class="info">
-            Total amount donated <span class="val">{{ statistics.total_donated }}</span>
+            <div>Total amount donated</div>
+            <span class="val">{{ statistics.total_donated }}</span>
         </div>
       </div>
   </div>

--- a/revolv/templates/base/partials/impact_statistics.html
+++ b/revolv/templates/base/partials/impact_statistics.html
@@ -7,7 +7,7 @@
   <h3>Your impact to date:</h3>
 
   <div class="row stats">
-      <div class="col-md-2">
+      <div class="col-sm-4 col-md-2 col-xs-6">
         <div class="stats-img">
           <img src="{% static "images/dashboard/solar-panel-desktop.png" %}" />
         </div>
@@ -18,7 +18,7 @@
             <div>of solar energy capacity</div>
         </div>
       </div>
-      <div class="col-md-2">
+      <div class="col-sm-4 col-md-2 col-xs-6">
         <div class="stats-img">
           <img src="{% static "images/dashboard/cloud-desktop.png" %}" />
         </div>
@@ -29,7 +29,7 @@
             <div class="tall">of carbon dioxide emissions</div>
         </div>
       </div>
-      <div class="col-md-2">
+      <div class="col-sm-4 col-md-2 col-xs-6">
         <div class="stats-img">
           <img src="{% static "images/dashboard/trees-desktop.png" %}" />
         </div>
@@ -40,7 +40,7 @@
             <div>of trees</div>
         </div>
       </div>
-      <div class="col-md-2">
+      <div class="col-sm-4 col-md-2 col-xs-6">
         <div class="stats-img">
           <img src="{% static "images/dashboard/house-desktop.png" %}" />
         </div>
@@ -50,7 +50,7 @@
             <div class="tall">community-serving organizations</div>
         </div>
       </div>
-      <div class="col-md-2">
+      <div class="col-sm-4 col-md-2 col-xs-6">
         <div class="stats-img">
           <img src="{% static "images/dashboard/person-desktop.png" %}" />
         </div>
@@ -61,7 +61,7 @@
             <div>in their community</div>
         </div>
       </div>
-      <div class="col-md-2">
+      <div class="col-sm-4 col-md-2 col-xs-6">
         <div class="stats-img">
           <img src="{% static "images/dashboard/money-desktop.png" %}" />
         </div>


### PR DESCRIPTION
On the home page and the dashboard, the "impacts" icons and texts are not lined up in a visually appealing way.

Whether or not this patch makes changes that are "appealing" is a matter of taste, but this at least gets elements lined up in a more deliberate-looking fashion.
