### PR TITLE
Replacing "funded" with funding goal

### DIFF
--- a/revolv/static/css/screen.css
+++ b/revolv/static/css/screen.css
@@ -2130,8 +2130,13 @@ header.edit-project-header > .container > h1 {
   position: absolute;
   top: 50%;
   left: 50%;
-  width: 110px;
-  margin: 6px 0 0 -55px;
+  -webkit-transform: translateX(-50%);
+  transform: translateX(-50%);
+  margin-top: 6px;
+  white-space: nowrap;
+}
+.details-active-project-module .banner-section .funded-round .round-depict > span {
+  font-size: 75%;
 }
 .details-active-project-module .banner-section .funded-round .status-indicator input {
   font-size: 58.26px !important;
@@ -4816,7 +4821,6 @@ header.edit-project-header > .container > h1 {
     font-size: 22.48px;
     text-align: center;
     width: 170px;
-    margin: 6px 0 0 -85px;
   }
   .details-active-project-module .banner-section .funded-round .status-indicator input {
     font-size: 48.17px !important;
@@ -7167,7 +7171,6 @@ header.edit-project-header > .container > h1 {
     font-size: 19.79px;
     text-align: center;
     width: 170px;
-    margin: 6px 0 0 -85px;
   }
   .details-active-project-module .banner-section .funded-round .status-indicator input {
     font-size: 42.4px !important;
@@ -9640,7 +9643,7 @@ header.edit-project-header > .container > h1 {
   .details-active-project-module .banner-section .funded-round .round-depict {
     font-size: 9.66px;
     width: 85px;
-    margin: 3px 0 0 -44px;
+    margin-top: 3px;
   }
   .details-active-project-module .banner-section .funded-round .status-indicator {
     margin-top: 2px;

--- a/revolv/templates/base/home.html
+++ b/revolv/templates/base/home.html
@@ -92,7 +92,7 @@
             <div class="funded-round">
               <div class="status-circular">
                 <span class="status-text">
-                  <span class="round-depict">FUNDED</span>
+                  <span class="round-depict"><span>OF</span> ${{ project.funding_goal|floatformat:0|intcomma }}</span>
                 </span>
                 <!-- end .status-text -->
                 <div class="status-indicator desktop-circle">

--- a/revolv/templates/base/partials/dashboard_project.html
+++ b/revolv/templates/base/partials/dashboard_project.html
@@ -57,7 +57,7 @@
                         <svg class="dashboard-internal-graphics-container"></svg>
                         <div class="text-container">
                             <p class="percentage-text">{{ project.percent_complete }}%</p>
-                            <p class="funded">FUNDED</p>
+                            <p class="funded"><span>OF</span> ${{ project.funding_goal|floatformat:0|intcomma }}</p>
                         </div>
                         <div class="percentage-container hide">{{ project.partial_completeness_as_js }}</div>
                     </div>

--- a/revolv/templates/base/partials/list_projects.html
+++ b/revolv/templates/base/partials/list_projects.html
@@ -19,7 +19,7 @@
             <div class="funded-round">
               <div class="status-circular">
                 <span class="status-text">
-                  <span class="round-depict">FUNDED</span>
+                  <span class="round-depict"><span>OF</span> ${{ project.funding_goal|floatformat:0|intcomma }}</span>
                 </span>
                 <!-- end .status-text -->
                 <div class="status-indicator desktop-circle">

--- a/revolv/templates/project/project.html
+++ b/revolv/templates/project/project.html
@@ -44,7 +44,7 @@
         </h1>
         <div class="funded-round">
           <span class="status-text">
-            <span class="round-depict">FUNDED</span>
+            <span class="round-depict"><span>OF</span> ${{ project.funding_goal|floatformat:0|intcomma }}</span>
           </span>
           <!-- end .status-text -->
             <div class="status-indicator desktop-circle">


### PR DESCRIPTION
We want to indicate what the funding goal is. It's hard to fit that into the existing layout, though.
An easy solution is to simply replace the word "funded" with the goal itself.
