### PR TITLE
Bugfixes

### DIFF
--- a/revolv/static/css/screen.css
+++ b/revolv/static/css/screen.css
@@ -578,10 +578,14 @@ a:hover {
   color: #039;
   display: block;
   position: absolute;
-  top: 50%;
+  top: 47.5%;
   left: 50%;
   width: 110px;
   margin: 2px 0 0 -55px;
+  text-shadow: 0 0 5px rgba(255,255,255,0.75);
+}
+.active-projects-module .img-main .funded-round .round-depict > span {
+  font-size: 75%;
 }
 .active-projects-module .img-main .funded-round .status-indicator input {
   margin-top: 27px !important;

--- a/revolv/templates/base/home.html
+++ b/revolv/templates/base/home.html
@@ -92,7 +92,7 @@
             <div class="funded-round">
               <div class="status-circular">
                 <span class="status-text">
-                  <span class="round-depict"><span>OF</span> ${{ project.funding_goal|floatformat:0|intcomma }}</span>
+                  <span class="round-depict"><span>OF</span> ${{ active_project.funding_goal|floatformat:0|intcomma }}</span>
                 </span>
                 <!-- end .status-text -->
                 <div class="status-indicator desktop-circle">
@@ -118,7 +118,7 @@
             </div>
             <!-- end .blue-bar -->
             <div class="dark-blue-bar">
-              <span class="pull-left actual-energy">{{ active_project.actual_energy }} lbs CO<sub>2</sub> Avoided</span>
+              <span class="pull-left actual-energy">{{ active_project.actual_energy }} lbs CO<sub>2</sub></span>
               <span class="pull-right">{{ active_project.donors.count }} Donors</span>
             </div>
             <!-- end .blue-bar -->

--- a/revolv/templates/base/partials/list_projects.html
+++ b/revolv/templates/base/partials/list_projects.html
@@ -19,7 +19,7 @@
             <div class="funded-round">
               <div class="status-circular">
                 <span class="status-text">
-                  <span class="round-depict"><span>OF</span> ${{ project.funding_goal|floatformat:0|intcomma }}</span>
+                  <span class="round-depict"><span>OF</span> ${{ active_project.funding_goal|floatformat:0|intcomma }}</span>
                 </span>
                 <!-- end .status-text -->
                 <div class="status-indicator desktop-circle">
@@ -45,7 +45,7 @@
             </div>
             <!-- end .blue-bar -->
             <div class="dark-blue-bar">
-              <span class="pull-left actual-energy">{{ active_project.actual_energy }} lbs CO<sub>2</sub> Avoided</span>
+              <span class="pull-left actual-energy">{{ active_project.actual_energy }} lbs CO<sub>2</sub></span>
               <span class="pull-right">{{ active_project.donors.count }} Donors</span>
             </div>
             <!-- end .blue-bar -->


### PR DESCRIPTION
Numerous small bugfixes spotted at the last minute:
- `project` instead of `active_project` was used in a couple of places.
- The styles on the home page's project list need to be adjusted to make the word "of" smaller and to nudge the funding-goal text up a little.
- The word "Avoided" needs to be removed from "card" displays of projects because it breaks the layout really badly.
