### PR TITLE
Add missing migration from REV-16 (pull request 29)

### DIFF
--- a/revolv/project/migrations/0062_auto_20160212_1635.py
+++ b/revolv/project/migrations/0062_auto_20160212_1635.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import imagekit.models.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('project', '0061_auto_20160209_1405'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='project',
+            name='cover_photo',
+            field=imagekit.models.fields.ProcessedImageField(default=None, help_text=b'Choose a beautiful high resolution image to represent this project.', upload_to=b'covers/'),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='project',
+            name='video_url',
+            field=models.URLField(help_text=b'Link to a Youtube video about the project or community.', max_length=255, verbose_name=b'Video URL'),
+            preserve_default=True,
+        ),
+    ]


### PR DESCRIPTION
tested locally with fresh (Feb 12 16:53 EST) copy of production db

video_url and cover_photo both changed blank=True to blank=False; there's no default, all projects on production have both of those set,
