### PR TITLE
Remove Cling.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,7 +11,6 @@ django-storages==1.1.7
 django-imagekit==3.0
 django-widget-tweaks==1.3
 dj-database-url==0.3.0
-dj-static==0.0.6
 gunicorn==19.1.1
 boto==2.34.0
 celery==3.1.17

--- a/revolv/wsgi.py
+++ b/revolv/wsgi.py
@@ -9,10 +9,9 @@ https://docs.djangoproject.com/en/1.7/howto/deployment/wsgi/
 
 import os
 
-from dj_static import Cling
 from django.core.wsgi import get_wsgi_application
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "revolv.settings")
 
 
-application = Cling(get_wsgi_application())
+application = get_wsgi_application()

--- a/revolv/wsgi.py
+++ b/revolv/wsgi.py
@@ -11,7 +11,10 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "revolv.settings")
+from . import load_env
 
+
+load_env.load_env()
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "revolv.settings")
 
 application = get_wsgi_application()


### PR DESCRIPTION
Cling is a Heroku need, not needed for the current AWS deployment.
