### PR TITLE
Moving definition of delayProgress

### DIFF
--- a/revolv/static/js/script.js
+++ b/revolv/static/js/script.js
@@ -316,16 +316,17 @@ $(document).ready(function(){
     var endval = parseInt($elem.attr("data-oldvalue"));
     var m1 = 0;
     var tmr1;
+    
+    function delayProgress(){
+      m1 += 1;
+      $elem.val(m1).trigger('change');
+      if(m1 === endval || m1 === 100) {
+        clearInterval(tmr1);
+      }
+    }
 
     if (m1 < endval) {
       tmr1 = self.setInterval(delayProgress,10);
-      function delayProgress(){
-        m1 += 1;
-        $elem.val(m1).trigger('change');
-        if(m1 === endval || m1 === 100) {
-          clearInterval(tmr1);
-        }
-      }
     }
   }
 


### PR DESCRIPTION
Apparently function definitions are "hoisted" in Chrome but not in Firefox, or something like that. So defining `delayProgress` after it's used worked fine in Chrome but not in Firefox. This moves the function definition up so it'll always be available.
