### PR TITLE
Stripe NaN issue

### DIFF
--- a/revolv/static/css/screen.css
+++ b/revolv/static/css/screen.css
@@ -4914,9 +4914,7 @@ header.edit-project-header > .container > h1 {
   }
   /* .project-updates-module .main-area */
   .project-updates-module .main-area {
-    width: auto;
-    float: none;
-    margin-right: 304px;
+    width: 580px;
   }
   .project-updates-module .main-area .title-project-updates {
     width: 274px;
@@ -4968,9 +4966,6 @@ header.edit-project-header > .container > h1 {
   /* .project-updates-module .right-aside */
   .project-updates-module .right-aside {
     width: 252px;
-    position: absolute;
-    top: 38px;
-    right: 39px;
   }
   .project-updates-module .right-aside .module-box {
     min-height: 120px;

--- a/revolv/static/css/screen.css
+++ b/revolv/static/css/screen.css
@@ -2463,6 +2463,11 @@ header.edit-project-header > .container > h1 {
   background: #14b1e7;
   text-transform: uppercase;
   width: 100%;
+  color: white;
+  border: none;
+}
+.project-updates-module .right-aside .module-box .stripe-button-el:hover {
+  background: #2c3691;
 }
 .project-updates-module .right-aside .module-box .stripe-button-el > span {
   background: transparent;

--- a/revolv/templates/project/project.html
+++ b/revolv/templates/project/project.html
@@ -175,13 +175,6 @@
               {% csrf_token %}
               <input type="hidden" name="amount_cents" value="{{ donation_level.amount }}">
               <input name="metadata" value="1.00" type="hidden">
-              <script
-                src="https://checkout.stripe.com/checkout.js" class="stripe-button"
-                data-key="{{ stripe_publishable_key }}"
-                data-description="Donate ${{ donation_level.amount }}"
-                data-image="{% static "images/revolv-logo.png" %}"
-                data-locale="auto">
-              </script>
             </form>
           </div>
           {% endfor %}
@@ -218,13 +211,17 @@
                 {% csrf_token %}
                 <input type="hidden" name="amount_cents" value="1000">
                 <input name="metadata" value="1.00" type="hidden">
-                <script
+                <!-- <script
                   src="https://checkout.stripe.com/checkout.js" class="stripe-button"
                   data-key="{{ stripe_publishable_key }}"
                   data-description="Donate"
                   data-image="{% static "images/revolv-logo.png" %}"
-                  data-locale="auto">
-                </script>
+                  data-locale="auto"
+                  async>
+                </script> -->
+                <button type="submit" class="stripe-button-el" style="visibility: visible;">
+                  <span style="display: block; min-height: 30px;">Pay with Card</span>
+                </button>
               </form>
             {% else %}
               <a class="btn-blue btn-i-want-to-donate" id="donate-button" href="/signin/?next=/project/{{project.pk}}/&reason=donate#login"><p>DONATE</p></a>
@@ -280,6 +277,53 @@
 {% block javascripts %}
 <script type="text/javascript"
     src="//maps.googleapis.com/maps/api/js?key={{GOOGLEMAPS_API_KEY}}">
+</script>
+
+<script src="https://checkout.stripe.com/checkout.js"></script>
+
+<!-- <script
+  src="https://checkout.stripe.com/checkout.js" class="stripe-button"
+  data-key="{{ stripe_publishable_key }}"
+  data-description="Donate ${{ donation_level.amount }}"
+  data-image="{% static "images/revolv-logo.png" %}"
+  data-locale="auto">
+</script> -->
+
+<script>
+$(function ($) {
+  var handler = StripeCheckout.configure({
+    key: '{{ stripe_publishable_key }}'
+    , image: '{% static "images/revolv-logo.png" %}'
+    , locale: 'auto'
+    , name: 'RE-volv'
+    , token: function (token) {
+      console.log(token);
+    }
+  });
+
+  $('.stripe-button-el').closest('form').on('submit', function (e) {
+    e.preventDefault();
+    var serialized = $(this).serializeArray();
+    var amount, metadata;
+
+    $.each(serialized, function () {
+      if (this.name === 'amount_cents') {
+        amount = this.value;
+      }
+      if (this.name === 'metadata') {
+        metadata = this.value;
+      }
+    });
+
+    if (typeof amount !== 'undefined') {
+      handler.open({
+        description: 'Donate $' + (amount / 100).toFixed(2)
+        , amount: amount
+        , metadata: metadata
+      });
+    }
+  });
+});
 </script>
 
 {% if project.video_url %}

--- a/revolv/templates/project/project.html
+++ b/revolv/templates/project/project.html
@@ -307,7 +307,7 @@ $(function ($) {
 
     if (typeof amount !== 'undefined') {
       handler.open({
-        description: 'Donate $' + (amount / 100).toFixed(2)
+        description: 'Donate $' + parseFloat((amount / 100).toFixed(2)).toLocaleString()
         , amount: amount
         , metadata: metadata
         , token: function (token) {

--- a/revolv/templates/project/project.html
+++ b/revolv/templates/project/project.html
@@ -175,6 +175,9 @@
               {% csrf_token %}
               <input type="hidden" name="amount_cents" value="{{ donation_level.amount }}">
               <input name="metadata" value="1.00" type="hidden">
+              <button type="submit" class="stripe-button-el" style="visibility: visible;">
+                <span style="display: block; min-height: 30px;">Pay with Card</span>
+              </button>
             </form>
           </div>
           {% endfor %}
@@ -211,14 +214,6 @@
                 {% csrf_token %}
                 <input type="hidden" name="amount_cents" value="1000">
                 <input name="metadata" value="1.00" type="hidden">
-                <!-- <script
-                  src="https://checkout.stripe.com/checkout.js" class="stripe-button"
-                  data-key="{{ stripe_publishable_key }}"
-                  data-description="Donate"
-                  data-image="{% static "images/revolv-logo.png" %}"
-                  data-locale="auto"
-                  async>
-                </script> -->
                 <button type="submit" class="stripe-button-el" style="visibility: visible;">
                   <span style="display: block; min-height: 30px;">Pay with Card</span>
                 </button>
@@ -281,14 +276,6 @@
 
 <script src="https://checkout.stripe.com/checkout.js"></script>
 
-<!-- <script
-  src="https://checkout.stripe.com/checkout.js" class="stripe-button"
-  data-key="{{ stripe_publishable_key }}"
-  data-description="Donate ${{ donation_level.amount }}"
-  data-image="{% static "images/revolv-logo.png" %}"
-  data-locale="auto">
-</script> -->
-
 <script>
 $(function ($) {
   var handler = StripeCheckout.configure({
@@ -296,14 +283,17 @@ $(function ($) {
     , image: '{% static "images/revolv-logo.png" %}'
     , locale: 'auto'
     , name: 'RE-volv'
-    , token: function (token) {
-      console.log(token);
-    }
   });
 
-  $('.stripe-button-el').closest('form').on('submit', function (e) {
+  $(window).on('popstate', function () {
+    handler.close();
+  });
+
+  $('.stripe-button-el').on('click', function (e) {
     e.preventDefault();
-    var serialized = $(this).serializeArray();
+    var $form = $(this).closest('form');
+    var serialized = $form.serializeArray();
+    var endpoint = $form.attr('action');
     var amount, metadata;
 
     $.each(serialized, function () {
@@ -320,6 +310,24 @@ $(function ($) {
         description: 'Donate $' + (amount / 100).toFixed(2)
         , amount: amount
         , metadata: metadata
+        , token: function (token) {
+          var id = token.id;
+          var email = token.email;
+
+          var $id = $('<input>')
+            .attr('type', 'hidden')
+            .attr('name', 'stripeToken')
+            .val(id);
+          var $email = $('<input>')
+            .attr('type', 'hidden')
+            .attr('name', 'stripeEmail')
+            .val(email);
+
+          $id.appendTo($form);
+          $email.appendTo($form);
+
+          $form.trigger('submit');
+        }
       });
     }
   });


### PR DESCRIPTION
The mysterious Stripe NaN issue's origins and specific conditions of appearance are still mysterious.

The most reliable way to prevent it from happening is to not rely on the courtesy of the Stripe "simple integration" system and to just do the integration by hand, manually.

This code instantiates `StripeCheckout` and then hijacks the click behavior of every "Pay With Card" button to open a Stripe modal and listen for Stripe to return a `token` object which is then injected into the form and submitted to perform the transaction.

While we're at it, it also fixes a heinous layout problem with the projects page.
